### PR TITLE
[Feature] Image Calibration Screen

### DIFF
--- a/src/common/rendering/gl/gl_postprocess.cpp
+++ b/src/common/rendering/gl/gl_postprocess.cpp
@@ -202,6 +202,8 @@ void FGLRenderer::DrawPresentTexture(const IntRect &box, bool applyGamma)
 		mPresentShader->Uniforms->Contrast = 1.0f;
 		mPresentShader->Uniforms->Brightness = 0.0f;
 		mPresentShader->Uniforms->Saturation = 1.0f;
+		mPresentShader->Uniforms->BlackPoint = 0.0f;
+		mPresentShader->Uniforms->WhitePoint = 1.0f;
 	}
 	else
 	{
@@ -209,6 +211,8 @@ void FGLRenderer::DrawPresentTexture(const IntRect &box, bool applyGamma)
 		mPresentShader->Uniforms->Contrast = clamp<float>(vid_contrast, 0.1f, 3.f);
 		mPresentShader->Uniforms->Brightness = clamp<float>(vid_brightness, -0.8f, 0.8f);
 		mPresentShader->Uniforms->Saturation = clamp<float>(vid_saturation, -15.0f, 15.f);
+		mPresentShader->Uniforms->BlackPoint = clamp<float>(vid_blackpoint, 0.f, 1.f);
+		mPresentShader->Uniforms->WhitePoint = clamp<float>(vid_whitepoint, 0.f, 1.f);
 		mPresentShader->Uniforms->GrayFormula = static_cast<int>(gl_satformula);
 	}
 	if (vid_hdr_active && framebuffer->IsFullscreen())

--- a/src/common/rendering/gl/gl_stereo3d.cpp
+++ b/src/common/rendering/gl/gl_stereo3d.cpp
@@ -48,6 +48,8 @@
 
 
 EXTERN_CVAR(Int, vr_mode)
+EXTERN_CVAR(Float, vid_whitepoint)
+EXTERN_CVAR(Float, vid_blackpoint)
 EXTERN_CVAR(Float, vid_saturation)
 EXTERN_CVAR(Float, vid_brightness)
 EXTERN_CVAR(Float, vid_contrast)
@@ -231,6 +233,8 @@ void FGLRenderer::prepareInterleavedPresent(FPresentShaderBase& shader)
 		shader.Uniforms->Contrast = 1.0f;
 		shader.Uniforms->Brightness = 0.0f;
 		shader.Uniforms->Saturation = 1.0f;
+		shader.Uniforms->BlackPoint = 0.0f;
+		shader.Uniforms->WhitePoint = 1.0f;
 	}
 	else
 	{
@@ -238,6 +242,8 @@ void FGLRenderer::prepareInterleavedPresent(FPresentShaderBase& shader)
 		shader.Uniforms->Contrast = clamp<float>(vid_contrast, 0.1f, 3.f);
 		shader.Uniforms->Brightness = clamp<float>(vid_brightness, -0.8f, 0.8f);
 		shader.Uniforms->Saturation = clamp<float>(vid_saturation, -15.0f, 15.0f);
+		shader.Uniforms->BlackPoint = clamp<float>(vid_blackpoint, 0.f, 1.f);
+		shader.Uniforms->WhitePoint = clamp<float>(vid_whitepoint, 0.f, 1.f);
 		shader.Uniforms->GrayFormula = static_cast<int>(gl_satformula);
 	}
 	shader.Uniforms->HdrMode = 0;

--- a/src/common/rendering/gles/gles_postprocess.cpp
+++ b/src/common/rendering/gles/gles_postprocess.cpp
@@ -133,6 +133,8 @@ void FGLRenderer::DrawPresentTexture(const IntRect &box, bool applyGamma)
 		mPresentShader->Uniforms->Contrast = 1.0f;
 		mPresentShader->Uniforms->Brightness = 0.0f;
 		mPresentShader->Uniforms->Saturation = 1.0f;
+		mPresentShader->Uniforms->BlackPoint = 0.0f;
+		mPresentShader->Uniforms->WhitePoint = 1.0f;
 	}
 	else
 	{
@@ -140,6 +142,8 @@ void FGLRenderer::DrawPresentTexture(const IntRect &box, bool applyGamma)
 		mPresentShader->Uniforms->Contrast = clamp<float>(vid_contrast, 0.1f, 3.f);
 		mPresentShader->Uniforms->Brightness = clamp<float>(vid_brightness, -0.8f, 0.8f);
 		mPresentShader->Uniforms->Saturation = clamp<float>(vid_saturation, -15.0f, 15.f);
+		mPresentShader->Uniforms->BlackPoint = clamp<float>(vid_blackpoint, 0.f, 1.f);
+		mPresentShader->Uniforms->WhitePoint = clamp<float>(vid_whitepoint, 0.f, 1.f);
 		mPresentShader->Uniforms->GrayFormula = static_cast<int>(gl_satformula);
 	}
 	if (vid_hdr_active && framebuffer->IsFullscreen())

--- a/src/common/rendering/hwrenderer/data/hw_cvars.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.cpp
@@ -93,6 +93,18 @@ CUSTOM_CVARD(Float, vid_saturation, 1.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "adju
 	else if (self > 3) self = 3;
 }
 
+CUSTOM_CVARD(Float, vid_blackpoint, 0.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "adjusts what the engine outputs as black")
+{
+	if (self < 0) self = 0;
+	if (self > 1) self = 1;
+}
+
+CUSTOM_CVARD(Float, vid_whitepoint, 1.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "adjusts what the engine outputs as white")
+{
+	if (self < 0) self = 0;
+	if (self > 1) self = 1;
+}
+
 CCMD (bumpgamma)
 {
 	// [RH] Gamma correction tables are now generated on the fly for *any* gamma level

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
@@ -728,6 +728,8 @@ struct PresentUniforms
 	float Contrast;
 	float Brightness;
 	float Saturation;
+	float BlackPoint;
+	float WhitePoint;
 	int GrayFormula;
 	int WindowPositionParity; // top-of-window might not be top-of-screen
 	FVector2 Scale;
@@ -743,6 +745,8 @@ struct PresentUniforms
 			{ "Contrast", UniformType::Float, offsetof(PresentUniforms, Contrast) },
 			{ "Brightness", UniformType::Float, offsetof(PresentUniforms, Brightness) },
 			{ "Saturation", UniformType::Float, offsetof(PresentUniforms, Saturation) },
+			{ "BlackPoint", UniformType::Float, offsetof(PresentUniforms, BlackPoint) },
+			{ "WhitePoint", UniformType::Float, offsetof(PresentUniforms, WhitePoint) },
 			{ "GrayFormula", UniformType::Int, offsetof(PresentUniforms, GrayFormula) },
 			{ "WindowPositionParity", UniformType::Int, offsetof(PresentUniforms, WindowPositionParity) },
 			{ "UVScale", UniformType::Vec2, offsetof(PresentUniforms, Scale) },

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess_cvars.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess_cvars.h
@@ -50,5 +50,7 @@ EXTERN_CVAR(Float, gl_menu_blur)
 EXTERN_CVAR(Float, vid_brightness)
 EXTERN_CVAR(Float, vid_contrast)
 EXTERN_CVAR(Float, vid_saturation)
+EXTERN_CVAR(Float, vid_blackpoint)
+EXTERN_CVAR(Float, vid_whitepoint)
 EXTERN_CVAR(Int, gl_satformula)
 

--- a/src/common/rendering/r_videoscale.cpp
+++ b/src/common/rendering/r_videoscale.cpp
@@ -41,6 +41,8 @@
 #include "i_interface.h"
 #include "printf.h"
 #include "version.h"
+#include "menustate.h"
+#include "menu.h"
 
 #define NUMSCALEMODES countof(vScaleTable)
 extern bool setsizeneeded;
@@ -195,8 +197,19 @@ CUSTOM_CVAR(Bool, vid_cropaspect, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	setsizeneeded = true;
 }
 
+static bool IsVideoMenuActive()
+{
+	if (menuactive != MENU_Off)
+		return CurrentMenu->IsKindOf("VideoOptions");
+	else
+		return false;
+}
+
 bool ViewportLinearScale()
 {
+	if (IsVideoMenuActive())
+		return false;
+
 	if (isOutOfBounds(vid_scalemode))
 		vid_scalemode = 0;
 	// always use linear if supersampling
@@ -212,6 +225,9 @@ bool ViewportLinearScale()
 
 int ViewportScaledWidth(int width, int height)
 {
+	if (IsVideoMenuActive())
+		return width;
+
 	if (isOutOfBounds(vid_scalemode))
 		vid_scalemode = 0;
 	refresh_minimums();
@@ -225,6 +241,9 @@ int ViewportScaledWidth(int width, int height)
 
 int ViewportScaledHeight(int width, int height)
 {
+	if (IsVideoMenuActive())
+		return height;
+
 	if (isOutOfBounds(vid_scalemode))
 		vid_scalemode = 0;
 	if (vid_cropaspect && height > 0)
@@ -237,6 +256,9 @@ int ViewportScaledHeight(int width, int height)
 
 float ViewportPixelAspect()
 {
+	if (IsVideoMenuActive())
+		return 1.0;
+
 	if (isOutOfBounds(vid_scalemode))
 		vid_scalemode = 0;
 	// hack - use custom scaling if in "custom" mode

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
@@ -259,6 +259,8 @@ void VkPostprocess::DrawPresentTexture(const IntRect &box, bool applyGamma, bool
 		uniforms.Contrast = 1.0f;
 		uniforms.Brightness = 0.0f;
 		uniforms.Saturation = 1.0f;
+		uniforms.BlackPoint = 0.0f;
+		uniforms.WhitePoint = 1.0f;
 	}
 	else
 	{
@@ -266,6 +268,8 @@ void VkPostprocess::DrawPresentTexture(const IntRect &box, bool applyGamma, bool
 		uniforms.Contrast = clamp<float>(vid_contrast, 0.1f, 3.f);
 		uniforms.Brightness = clamp<float>(vid_brightness, -0.8f, 0.8f);
 		uniforms.Saturation = clamp<float>(vid_saturation, -15.0f, 15.f);
+		uniforms.BlackPoint = clamp<float>(vid_blackpoint, 0.f, 1.f);
+		uniforms.WhitePoint = clamp<float>(vid_whitepoint, 0.f, 1.f);
 		uniforms.GrayFormula = static_cast<int>(gl_satformula);
 	}
 	uniforms.ColorScale = (gl_dither_bpc == -1) ? 255.0f : (float)((1 << gl_dither_bpc) - 1);

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -393,14 +393,12 @@ void FGameConfigFile::DoGlobalSetup ()
 		const char *lastver = GetValueForKey ("Version");
 		if (lastver != NULL)
 		{
+			FBaseCVar *var;
 			double last = atof (lastver);
 			if (last < 207)
 			{ // Now that snd_midiprecache works again, you probably don't want it on.
-				FBaseCVar *precache = FindCVar ("snd_midiprecache", NULL);
-				if (precache != NULL)
-				{
-					precache->ResetToDefault();
-				}
+				var = FindCVar ("snd_midiprecache", NULL);
+				if (var != NULL) var->ResetToDefault();
 			}
 			if (last < 208)
 			{ // Weapon sections are no longer used, so tidy up the config by deleting them.
@@ -427,11 +425,8 @@ void FGameConfigFile::DoGlobalSetup ()
 			if (last < 209)
 			{
 				// menu dimming is now a gameinfo option so switch user override off
-				FBaseCVar *dim = FindCVar ("dimamount", NULL);
-				if (dim != NULL)
-				{
-					dim->ResetToDefault ();
-				}
+				var = FindCVar ("dimamount", NULL);
+				if (var != NULL) var->ResetToDefault ();
 			}
 			if (last < 210)
 			{
@@ -444,7 +439,7 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 213)
 			{
-				auto var = FindCVar("snd_channels", NULL);
+				var = FindCVar("snd_channels", NULL);
 				if (var != NULL)
 				{
 					// old settings were default 32, minimum 8, new settings are default 128, minimum 64.
@@ -454,7 +449,7 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 214)
 			{
-				FBaseCVar *var = FindCVar("hud_scale", NULL);
+				var = FindCVar("hud_scale", NULL);
 				if (var != NULL) var->ResetToDefault();
 				var = FindCVar("st_scale", NULL);
 				if (var != NULL) var->ResetToDefault();
@@ -470,12 +465,12 @@ void FGameConfigFile::DoGlobalSetup ()
 			if (last < 215)
 			{
 				// Previously a true/false boolean. Now an on/off/auto tri-state with auto as the default.
-				FBaseCVar *var = FindCVar("snd_hrtf", NULL);
+				var = FindCVar("snd_hrtf", NULL);
 				if (var != NULL) var->ResetToDefault();
 			}
 			if (last < 216)
 			{
-				FBaseCVar *var = FindCVar("gl_texture_hqresize", NULL);
+				var = FindCVar("gl_texture_hqresize", NULL);
 				if (var != NULL)
 				{
 					auto v = var->GetGenericRep(CVAR_Int);
@@ -562,11 +557,10 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 217)
 			{
-				auto var = FindCVar("vid_scalemode", NULL);
-				UCVarValue newvalue;
+				var = FindCVar("vid_scalemode", NULL);
 				if (var != NULL)
 				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int);
+					UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
 					if (v.Int == 3) // 640x400
 					{
 						newvalue.Int = 2;
@@ -583,7 +577,7 @@ void FGameConfigFile::DoGlobalSetup ()
 			{
 				// 2019-12-06 - polybackend merge
 				// migrate vid_enablevulkan to vid_preferbackend
-				auto var = FindCVar("vid_enablevulkan", NULL);
+				var = FindCVar("vid_enablevulkan", NULL);
 				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Int);
@@ -600,10 +594,9 @@ void FGameConfigFile::DoGlobalSetup ()
 						vid_scale_custompixelaspect = 1.0f;
 				}
 				var = FindCVar("vid_scalemode", NULL);
-				UCVarValue newvalue;
 				if (var != NULL)
 				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int);
+					UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
 					switch (v.Int)
 					{
 					case 1:
@@ -622,7 +615,7 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 220)
 			{
-				auto var = FindCVar("Gamma", NULL);
+				var = FindCVar("Gamma", NULL);
 				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Float);
@@ -643,7 +636,7 @@ void FGameConfigFile::DoGlobalSetup ()
 #else
 				double xfact = in_mouse == 1? 1.5 : 4, yfact = 1;
 #endif
-				auto var = FindCVar("m_noprescale", NULL);
+				var = FindCVar("m_noprescale", NULL);
 				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Bool);
@@ -675,7 +668,7 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 222)
 			{
-				auto var = FindCVar("mod_dumb_mastervolume", NULL);
+				var = FindCVar("mod_dumb_mastervolume", NULL);
 				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Float);
@@ -690,7 +683,8 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 224)
 			{
-				if (const auto var = FindCVar("m_sensitivity_x", NULL))
+				var = FindCVar("m_sensitivity_x", NULL);
+				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Float);
 					v.Float *= 0.5f;
@@ -699,7 +693,8 @@ void FGameConfigFile::DoGlobalSetup ()
 			}
 			if (last < 225)
 			{
-				if (const auto var = FindCVar("gl_lightmode", NULL))
+				var = FindCVar("gl_lightmode", NULL);
+				if (var != NULL)
 				{
 					UCVarValue v = var->GetGenericRep(CVAR_Int);
 					v.Int = v.Int == 16 ? 2 : v.Int == 8 ? 1 : 0;
@@ -713,6 +708,11 @@ void FGameConfigFile::DoGlobalSetup ()
 				// the files aren't fully loaded. Just queue
 				// up a flag to do this later.
 				b226ResetGamepad = true;
+			}
+			if (last < 229) // UZDoom 5.0
+			{
+				// Reset brightness related settings, as the values all mean something different now
+				AddCommandString("vid_reset2defaults");
 			}
 		}
 	}

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -61,6 +61,7 @@
 #include "teaminfo.h"
 #include "texturemanager.h"
 #include "v_draw.h"
+#include "v_video.h"
 #include "vm.h"
 
 EXTERN_CVAR(Int, cl_gfxlocalization)
@@ -70,6 +71,15 @@ EXTERN_CVAR(Bool, quicksaverotation)
 EXTERN_CVAR(Bool, show_messages)
 EXTERN_CVAR(Bool, haptics_do_menus)
 EXTERN_CVAR(Float, hud_scalefactor)
+
+EXTERN_CVAR(Float, vid_gamma)
+EXTERN_CVAR(Float, vid_contrast)
+EXTERN_CVAR(Float, vid_brightness)
+EXTERN_CVAR(Float, vid_saturation)
+EXTERN_CVAR(Float, vid_fixgamma)
+EXTERN_CVAR(Float, vid_blackpoint)
+EXTERN_CVAR(Float, vid_whitepoint)
+EXTERN_CVAR(Int, gl_satformula)
 
 CVAR(Bool, m_simpleoptions, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 CVAR(Bool, m_simpleoptions_view, true, 0);
@@ -610,6 +620,17 @@ CCMD (sizeup)
 	}
 
 	S_Sound(CHAN_VOICE, CHANF_UI|(haptics_do_menus?CHANF_RUMBLE:CHANF_NORUMBLE), "menu/change", snd_menuvolume, ATTN_NONE);
+}
+
+CCMD(vid_reset2defaults)
+{
+	vid_contrast->ResetToDefault();
+	vid_brightness->ResetToDefault();
+	vid_saturation->ResetToDefault();
+	vid_fixgamma->ResetToDefault();
+	vid_blackpoint->ResetToDefault();
+	vid_whitepoint->ResetToDefault();
+	gl_satformula->ResetToDefault();
 }
 
 CCMD(reset2defaults)

--- a/wadsrc/static/gldefs.txt
+++ b/wadsrc/static/gldefs.txt
@@ -1,5 +1,12 @@
-material GAMMA1
+HardwareShader PostProcess Screen
 {
-	Shader "shaders/glsl/gammatest.fp"
-	// define DITHERTRANS // As a test
+	Name "GammaTestPattern"
+	Shader "shaders/glsl/gammatest.fp" 330
+	Uniform float uInvGamma
+	Uniform float uWhitePoint
+	Uniform float uBlackPoint
+	Uniform int uXmin
+	Uniform int uXmax
+	Uniform int uYmin
+	Uniform int uYmax
 }

--- a/wadsrc/static/gldefs.txt
+++ b/wadsrc/static/gldefs.txt
@@ -1,0 +1,5 @@
+material GAMMA1
+{
+	Shader "shaders/glsl/gammatest.fp"
+	// define DITHERTRANS // As a test
+}

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1046,6 +1046,8 @@ OptionMenu "ImageAdjustMenu" protected
 	Tooltip "Adjusts perceived difference between similar colours. Controls how sharp/washed out the images looks. Adjust to personal taste."
 	Slider "$DSPLYMNU_SATURATION",	"vid_saturation",	-1.0,	2.0,	0.01,	2
 	Tooltip "Adjusts the intensity of colors, making the image look more vivid or muted. Adjust to personal taste."
+	StaticText ""
+	StaticText "Adjust until this looks like a uniform Gray color.", "Cyan"
 }
 
 //-------------------------------------------------------------------------------------------

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1000,6 +1000,9 @@ OptionMenu "VideoOptions" protected
 	Slider "$DSPLYMNU_SCREENSIZE",				"screenblocks", 				3.0, 12.0, 1.0, 0
 
 	Slider "$DSPLYMNU_GAMMA",					"vid_gamma",					0.75, 3.0, 0.05, 2
+	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 1.0, 0.01, 2
+	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.0, 1.0, 0.01, 2
+	StaticText " "
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -993,19 +993,13 @@ OptionMenu "VideoOptions" protected
 
 	Submenu "$DSPLYMNU_GLOPT", 			"OpenGLOptions"
 	Submenu "$DSPLYMNU_SWOPT", 			"SWROptions"
+	Submenu "Image Calibration",		"ImageAdjustMenu"
+	StaticText " "
 	Submenu "$DSPLYMNU_VKOPT",			"VKOptions"
 	Submenu "$GLMNU_TEXOPT", 			"GLTextureGLOptions"
 	Submenu "$GLMNU_DYNLIGHT",			"GLLightOptions"
 	StaticText " "
 	Slider "$DSPLYMNU_SCREENSIZE",				"screenblocks", 				3.0, 12.0, 1.0, 0
-	StaticText " "
-	Slider "$DSPLYMNU_GAMMA",					"vid_fixgamma",					-0.5, 1.0, 0.05, 2
-	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 0.25, 0.01, 2
-	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.75, 1.0, 0.01, 2
-	StaticText " "
-	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
-	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
-	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
 	StaticText " "
 	Slider "$DSPLYMNU_FOV",						"fov",							75.0, 120.0, 0.1, 1
 	StaticText " "
@@ -1028,7 +1022,30 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_TELEZOOM",				"telezoom", "OnOff"
 	Slider "$DSPLYMNU_QUAKEINTENSITY",			"r_quakeintensity", 0.0, 1.0, 0.05, 2
 	Option "$DSPLYMNU_NOMONSTERINTERPOLATION",	"nomonsterinterpolation", "NoYes"
+}
+
+OptionMenu "ImageAdjustMenu" protected
+{
+	Title "Image Calibration Options"
 	Class "VideoOptions"
+
+	StaticText "From a normal viewing distance, adjust these sliders.", "Cyan"
+	StaticText "Upscaling/Supersampling may result in incorrect output.", "Cyan"
+	StaticText "Please disable them before adjusting.", "Cyan"
+	StaticText ""
+	Slider "$DSPLYMNU_GAMMA",		"vid_fixgamma",		-1.0,	1.0,	0.01,	2
+	Tooltip "Compensates for your monitor's limitations. Adjust until vertical grey blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
+	Slider "Blackpoint",			"vid_blackpoint",	0.0,	0.25,	0.01,	2
+	Tooltip "Compensates for monitors that fail to display dark pixels correctly. Adjust until diagonal white blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
+	Slider "Whitepoint",			"vid_whitepoint",	0.75,	1.0,	0.01,	2
+	Tooltip "Compensates for monitors that fail to display bright pixels correctly. Adjust until diagonal black blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
+	StaticText ""
+	Slider "$DSPLYMNU_BRIGHTNESS",	"vid_brightness",	-0.25,	0.25,	0.01,	2
+	Tooltip "Applies linear brightness adjustment. Adjust to personal taste, or to see in the dark."
+	Slider "$DSPLYMNU_CONTRAST",	"vid_contrast",		0.5,	2.0,	0.01,	2
+	Tooltip "Adjusts perceived difference between similar colours. Controls how sharp/washed out the images looks. Adjust to personal taste."
+	Slider "$DSPLYMNU_SATURATION",	"vid_saturation",	-1.0,	2.0,	0.01,	2
+	Tooltip "Adjusts the intensity of colors, making the image look more vivid or muted. Adjust to personal taste."
 }
 
 //-------------------------------------------------------------------------------------------

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1025,6 +1025,7 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_TELEZOOM",				"telezoom", "OnOff"
 	Slider "$DSPLYMNU_QUAKEINTENSITY",			"r_quakeintensity", 0.0, 1.0, 0.05, 2
 	Option "$DSPLYMNU_NOMONSTERINTERPOLATION",	"nomonsterinterpolation", "NoYes"
+	Class "VideoOptions"
 }
 
 //-------------------------------------------------------------------------------------------

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1039,7 +1039,7 @@ OptionMenu "ImageAdjustMenu" protected
 	Tooltip "Compensates for monitors that fail to display dark pixels correctly. Adjust until diagonal white blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
 	Slider "Whitepoint",			"vid_whitepoint",	0.75,	1.0,	0.01,	2
 	Tooltip "Compensates for monitors that fail to display bright pixels correctly. Adjust until diagonal black blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
-	StaticText ""
+	Command "Reset All",			"vid_reset2defaults"
 	Slider "$DSPLYMNU_BRIGHTNESS",	"vid_brightness",	-0.25,	0.25,	0.01,	2
 	Tooltip "Applies linear brightness adjustment. Adjust to personal taste, or to see in the dark."
 	Slider "$DSPLYMNU_CONTRAST",	"vid_contrast",		0.5,	2.0,	0.01,	2

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -998,10 +998,10 @@ OptionMenu "VideoOptions" protected
 	Submenu "$GLMNU_DYNLIGHT",			"GLLightOptions"
 	StaticText " "
 	Slider "$DSPLYMNU_SCREENSIZE",				"screenblocks", 				3.0, 12.0, 1.0, 0
-
-	Slider "$DSPLYMNU_GAMMA",					"vid_gamma",					0.75, 3.0, 0.05, 2
-	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 1.0, 0.01, 2
-	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.0, 1.0, 0.01, 2
+	StaticText " "
+	Slider "$DSPLYMNU_GAMMA",					"vid_fixgamma",					-0.5, 1.0, 0.05, 2
+	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 0.25, 0.01, 2
+	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.75, 1.0, 0.01, 2
 	StaticText " "
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -993,7 +993,7 @@ OptionMenu "VideoOptions" protected
 
 	Submenu "$DSPLYMNU_GLOPT", 			"OpenGLOptions"
 	Submenu "$DSPLYMNU_SWOPT", 			"SWROptions"
-	Submenu "Image Calibration",		"ImageAdjustMenu"
+	Submenu "$DSPLYMNU_IMAGEADJUST",	"ImageAdjustMenu"
 	StaticText " "
 	Submenu "$DSPLYMNU_VKOPT",			"VKOptions"
 	Submenu "$GLMNU_TEXOPT", 			"GLTextureGLOptions"
@@ -1026,28 +1026,29 @@ OptionMenu "VideoOptions" protected
 
 OptionMenu "ImageAdjustMenu" protected
 {
-	Title "Image Calibration Options"
+	Title "$DSPLYMNU_IMAGEADJUST"
 	Class "VideoOptions"
 
-	StaticText "From a normal viewing distance, adjust these sliders.", "Cyan"
-	StaticText "Upscaling/Supersampling may result in incorrect output.", "Cyan"
-	StaticText "Please disable them before adjusting.", "Cyan"
+	StaticText "$DSPLYMNU_IMAGEADJUST_TOP1", "Cyan"
+	StaticText "$DSPLYMNU_IMAGEADJUST_TOP2", "Cyan"
+	StaticText "$DSPLYMNU_IMAGEADJUST_TOP3", "Cyan"
 	StaticText ""
 	Slider "$DSPLYMNU_GAMMA",		"vid_fixgamma",		-1.0,	1.0,	0.01,	2
-	Tooltip "Compensates for your monitor's limitations. Adjust until vertical grey blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
-	Slider "Blackpoint",			"vid_blackpoint",	0.0,	0.25,	0.01,	2
-	Tooltip "Compensates for monitors that fail to display dark pixels correctly. Adjust until diagonal white blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
-	Slider "Whitepoint",			"vid_whitepoint",	0.75,	1.0,	0.01,	2
-	Tooltip "Compensates for monitors that fail to display bright pixels correctly. Adjust until diagonal black blocks fade. Do not use this to make the game brighter, only to ensure the image is calibrated for your setup."
-	Command "Reset All",			"vid_reset2defaults"
+	Tooltip "$DSPLYMNU_TOOLTIP_GAMMA"
+	Slider "$DSPLYMNU_BLACKPOINT",	"vid_blackpoint",	0.0,	0.25,	0.01,	2
+	Tooltip "$DSPLYMNU_TOOLTIP_BLACKPOINT"
+	Slider "$DSPLYMNU_WHITEPOINT",	"vid_whitepoint",	0.75,	1.0,	0.01,	2
+	Tooltip "$DSPLYMNU_TOOLTIP_WHITEPOINT"
+	Command "$OPTMNU_RESETALL",		"vid_reset2defaults"
+	Tooltip "$DSPLYMNU_TOOLTIP_IMAGEADJUST_RESET"
 	Slider "$DSPLYMNU_BRIGHTNESS",	"vid_brightness",	-0.25,	0.25,	0.01,	2
-	Tooltip "Applies linear brightness adjustment. Adjust to personal taste, or to see in the dark."
+	Tooltip "$DSPLYMNU_TOOLTIP_BRIGHTNESS"
 	Slider "$DSPLYMNU_CONTRAST",	"vid_contrast",		0.5,	2.0,	0.01,	2
-	Tooltip "Adjusts perceived difference between similar colours. Controls how sharp/washed out the images looks. Adjust to personal taste."
+	Tooltip "$DSPLYMNU_TOOLTIP_CONTRAST"
 	Slider "$DSPLYMNU_SATURATION",	"vid_saturation",	-1.0,	2.0,	0.01,	2
-	Tooltip "Adjusts the intensity of colors, making the image look more vivid or muted. Adjust to personal taste."
+	Tooltip "$DSPLYMNU_TOOLTIP_SATURATION"
 	StaticText ""
-	StaticText "Adjust until this looks like a uniform Gray color.", "Cyan"
+	StaticText "$DSPLYMNU_IMAGEADJUST_BOTTOM", "Cyan"
 }
 
 //-------------------------------------------------------------------------------------------

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -80,6 +80,7 @@ OptionMenu VideoOptionsSimple protected
 	// the "full" menu doesn't have some of the options that are in this one.
 	//StaticText " "
 	//Submenu "$OPTMNU_FULLOPTIONS", "VideoModeMenu"
+	Class "VideoOptionsSimple"
 }
 
 OptionMenu ScalingOptionsSimple protected

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -70,9 +70,9 @@ OptionMenu VideoOptionsSimple protected
 	Option "$DSPLYMNU_VSYNC",					"vid_vsync", "OnOff"
 	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1
 	StaticText " "
-	Slider "$DSPLYMNU_GAMMA",					"vid_gamma",					0.75, 3.0, 0.05, 2
-	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 1.0, 0.01, 2
-	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.0, 1.0, 0.01, 2
+	Slider "$DSPLYMNU_GAMMA",					"vid_fixgamma",					-0.5, 1.0, 0.05, 2
+	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 0.25, 0.01, 2
+	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.75, 1.0, 0.01, 2
 	StaticText " "
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -71,6 +71,9 @@ OptionMenu VideoOptionsSimple protected
 	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1
 	StaticText " "
 	Slider "$DSPLYMNU_GAMMA",					"vid_gamma",					0.75, 3.0, 0.05, 2
+	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 1.0, 0.01, 2
+	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.0, 1.0, 0.01, 2
+	StaticText " "
 	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
 	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
 	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -54,6 +54,7 @@ OptionMenu VideoOptionsSimple protected
 		Option "$VIDMNU_RENDERMODE",		"vid_rendermode", "RenderMode"
 	}
 	Option "$VIDMNU_FULLSCREEN",		"vid_fullscreen", "YesNo"
+	Submenu "Image Calibration",	"ImageAdjustMenu"
 	IfOption(Mac)
 	{
 		Option "$VIDMNU_HIDPI",			"vid_hidpi", "YesNo"
@@ -70,20 +71,11 @@ OptionMenu VideoOptionsSimple protected
 	Option "$DSPLYMNU_VSYNC",					"vid_vsync", "OnOff"
 	Slider "$VIDMNU_MAXFPS",					"vid_maxfps", 35, 500, 1
 	StaticText " "
-	Slider "$DSPLYMNU_GAMMA",					"vid_fixgamma",					-0.5, 1.0, 0.05, 2
-	Slider "$DSPLYMNU_BLACKPOINT",				"vid_blackpoint",				0.0, 0.25, 0.01, 2
-	Slider "$DSPLYMNU_WHITEPOINT",				"vid_whitepoint",				0.75, 1.0, 0.01, 2
-	StaticText " "
-	Slider "$DSPLYMNU_BRIGHTNESS",				"vid_brightness",				-0.8,0.8, 0.05,2
-	Slider "$DSPLYMNU_CONTRAST",				"vid_contrast",	   				0.1, 3.0, 0.1
-	Slider "$DSPLYMNU_SATURATION",				"vid_saturation",  				-3.0, 3.0, 0.25, 2
-	StaticText " "
 	Slider "$DSPLYMNU_FOV",						"fov",							75.0, 120.0, 0.1, 1
 	// commenting this out for now, this menu is so general purpose I am not sure it makes sense, but I'm leaving it here just in case
 	// the "full" menu doesn't have some of the options that are in this one.
 	//StaticText " "
 	//Submenu "$OPTMNU_FULLOPTIONS", "VideoModeMenu"
-	Class "VideoOptionsSimple"
 }
 
 OptionMenu ScalingOptionsSimple protected

--- a/wadsrc/static/menudef.zsimple
+++ b/wadsrc/static/menudef.zsimple
@@ -54,7 +54,7 @@ OptionMenu VideoOptionsSimple protected
 		Option "$VIDMNU_RENDERMODE",		"vid_rendermode", "RenderMode"
 	}
 	Option "$VIDMNU_FULLSCREEN",		"vid_fullscreen", "YesNo"
-	Submenu "Image Calibration",	"ImageAdjustMenu"
+	Submenu "$DSPLYMNU_IMAGEADJUST",	"ImageAdjustMenu"
 	IfOption(Mac)
 	{
 		Option "$VIDMNU_HIDPI",			"vid_hidpi", "YesNo"

--- a/wadsrc/static/shaders/glsl/gammatest.fp
+++ b/wadsrc/static/shaders/glsl/gammatest.fp
@@ -1,0 +1,44 @@
+vec4 Process(vec4 color)
+{
+	float u_gamma = 1.0;
+	float u_black_point = 0.0;
+	float u_white_point = 1.0;
+
+	float checker_size = 32.0;
+	vec2 checker_coord = floor(gl_FragCoord.xy / checker_size);
+	vec3 base_color;
+
+	float col = floor(mod(checker_coord.x, 4.0));
+	float row = floor(mod(checker_coord.y, 4.0));
+	float dither_pattern = mod(gl_FragCoord.x + gl_FragCoord.y, 2.0);
+
+	vec3 colorA = vec3(0.5);
+	vec3 colorB = mix(vec3(0.0), vec3(1.0), dither_pattern);
+	vec3 colorC = mix(vec3(u_black_point), vec3(1.0), dither_pattern);
+	vec3 colorD = mix(vec3(0.0), vec3(u_white_point), dither_pattern);
+
+	if (row < 1.0) { // Row 0: A B C D
+		if (col < 1.0) { base_color = colorA; }
+		else if (col < 2.0) { base_color = colorB; }
+		else if (col < 3.0) { base_color = colorC; }
+		else { base_color = colorD; }
+	} else if (row < 2.0) { // Row 1: A B D C
+		if (col < 1.0) { base_color = colorA; }
+		else if (col < 2.0) { base_color = colorB; }
+		else if (col < 3.0) { base_color = colorD; }
+		else { base_color = colorC; }
+	} else if (row < 3.0) { // Row 2: C D A B
+		if (col < 1.0) { base_color = colorC; }
+		else if (col < 2.0) { base_color = colorD; }
+		else if (col < 3.0) { base_color = colorA; }
+		else { base_color = colorB; }
+	} else { // Row 3: D C A B
+		if (col < 1.0) { base_color = colorD; }
+		else if (col < 2.0) { base_color = colorC; }
+		else if (col < 3.0) { base_color = colorA; }
+		else { base_color = colorB; }
+	}
+
+	vec3 final_color = pow(base_color, vec3(1.0/u_gamma)); //InvGamma is not defined in material hardware shaders
+	return vec4(clamp(final_color, 0.0, 1.0), 1.0);
+}

--- a/wadsrc/static/shaders/glsl/gammatest.fp
+++ b/wadsrc/static/shaders/glsl/gammatest.fp
@@ -39,6 +39,6 @@ vec4 Process(vec4 color)
 		else { base_color = colorB; }
 	}
 
-	vec3 final_color = pow(base_color, vec3(1.0/u_gamma)); //InvGamma is not defined in material hardware shaders
+	vec3 final_color = pow(base_color, vec3(1.0/2.2));
 	return vec4(clamp(final_color, 0.0, 1.0), 1.0);
 }

--- a/wadsrc/static/shaders/glsl/gammatest.fp
+++ b/wadsrc/static/shaders/glsl/gammatest.fp
@@ -1,44 +1,53 @@
-vec4 Process(vec4 color)
+void main()
 {
-	float u_gamma = 1.0;
-	float u_black_point = 0.0;
-	float u_white_point = 1.0;
+	vec3 colour = texture(InputTexture, TexCoord).rgb;
+	if (gl_FragCoord.x > uXmin && gl_FragCoord.x < uXmax && gl_FragCoord.y > uYmin && gl_FragCoord.y < uYmax)
+	{
+		float u_gamma = 1.0;
+		float u_black_point = 0.0;
+		float u_white_point = 1.0;
 
-	float checker_size = 32.0;
-	vec2 checker_coord = floor(gl_FragCoord.xy / checker_size);
-	vec3 base_color;
+		float checker_size = 32.0;
+		vec2 checker_coord = floor(gl_FragCoord.xy / checker_size);
+		vec3 base_color;
 
-	float col = floor(mod(checker_coord.x, 4.0));
-	float row = floor(mod(checker_coord.y, 4.0));
-	float dither_pattern = mod(gl_FragCoord.x + gl_FragCoord.y, 2.0);
+		float col = floor(mod(checker_coord.x, 4.0));
+		float row = floor(mod(checker_coord.y, 4.0));
+		float dither_pattern = mod(gl_FragCoord.x + gl_FragCoord.y, 2.0);
 
-	vec3 colorA = vec3(0.5);
-	vec3 colorB = mix(vec3(0.0), vec3(1.0), dither_pattern);
-	vec3 colorC = mix(vec3(u_black_point), vec3(1.0), dither_pattern);
-	vec3 colorD = mix(vec3(0.0), vec3(u_white_point), dither_pattern);
+		vec3 colorA = vec3(0.5);
+		vec3 colorB = mix(vec3(0.0), vec3(1.0), dither_pattern);
+		vec3 colorC = mix(vec3(uBlackPoint), vec3(1.0), dither_pattern);
+		vec3 colorD = mix(vec3(0.0), vec3(uWhitePoint), dither_pattern);
 
-	if (row < 1.0) { // Row 0: A B C D
-		if (col < 1.0) { base_color = colorA; }
-		else if (col < 2.0) { base_color = colorB; }
-		else if (col < 3.0) { base_color = colorC; }
-		else { base_color = colorD; }
-	} else if (row < 2.0) { // Row 1: A B D C
-		if (col < 1.0) { base_color = colorA; }
-		else if (col < 2.0) { base_color = colorB; }
-		else if (col < 3.0) { base_color = colorD; }
-		else { base_color = colorC; }
-	} else if (row < 3.0) { // Row 2: C D A B
-		if (col < 1.0) { base_color = colorC; }
-		else if (col < 2.0) { base_color = colorD; }
-		else if (col < 3.0) { base_color = colorA; }
-		else { base_color = colorB; }
-	} else { // Row 3: D C A B
-		if (col < 1.0) { base_color = colorD; }
-		else if (col < 2.0) { base_color = colorC; }
-		else if (col < 3.0) { base_color = colorA; }
-		else { base_color = colorB; }
+		if (row < 1.0) { // Row 0: A B C D
+			if (col < 1.0) { base_color = colorA; }
+			else if (col < 2.0) { base_color = colorB; }
+			else if (col < 3.0) { base_color = colorC; }
+			else { base_color = colorD; }
+		} else if (row < 2.0) { // Row 1: A B D C
+			if (col < 1.0) { base_color = colorA; }
+			else if (col < 2.0) { base_color = colorB; }
+			else if (col < 3.0) { base_color = colorD; }
+			else { base_color = colorC; }
+		} else if (row < 3.0) { // Row 2: C D A B
+			if (col < 1.0) { base_color = colorC; }
+			else if (col < 2.0) { base_color = colorD; }
+			else if (col < 3.0) { base_color = colorA; }
+			else { base_color = colorB; }
+		} else { // Row 3: D C A B
+			if (col < 1.0) { base_color = colorD; }
+			else if (col < 2.0) { base_color = colorC; }
+			else if (col < 3.0) { base_color = colorA; }
+			else { base_color = colorB; }
+		}
+
+		// Need to precompensate for ApplyGamma() here, if we can't disable it.
+		vec3 final_color = pow(base_color, vec3(uInvGamma));
+		FragColor = vec4(clamp(final_color, 0.0, 1.0), 1.0);
 	}
-
-	vec3 final_color = pow(base_color, vec3(1.0/2.2));
-	return vec4(clamp(final_color, 0.0, 1.0), 1.0);
+	else
+	{
+		FragColor = vec4(colour, 1.0);
+	}
 }

--- a/wadsrc/static/shaders/pp/gamma.fp
+++ b/wadsrc/static/shaders/pp/gamma.fp
@@ -1,0 +1,23 @@
+const vec3 rec709Weights = vec3(0.2126, 0.7152, 0.0722);
+const vec3 averageWeights = vec3(1.0 / 3.0);
+const vec3 oldWeights = vec3(0.3, 0.56, 0.14);
+
+vec4 ApplyGamma(vec4 c)
+{
+	c.rgb = min(c.rgb, vec3(2.0)); // for HDR mode - prevents stacked translucent sprites (such as plasma) producing way too bright light
+
+	vec3 val = pow(c.rgb, vec3(2.2));
+
+	vec3 weights = (GrayFormula == 2) ? rec709Weights
+	             : (GrayFormula == 1) ? oldWeights
+	                                  : averageWeights;
+	float lum = dot(val, weights);
+	val = mix(vec3(lum), val, Saturation);
+
+	val = val * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
+	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
+	return vec4(val, c.a);
+}

--- a/wadsrc/static/shaders/pp/present.fp
+++ b/wadsrc/static/shaders/pp/present.fp
@@ -1,3 +1,4 @@
+// #include "shaders/pp/gamma.fp"
 
 layout(location=0) in vec2 TexCoord;
 layout(location=0) out vec4 FragColor;
@@ -5,35 +6,43 @@ layout(location=0) out vec4 FragColor;
 layout(binding=0) uniform sampler2D InputTexture;
 layout(binding=1) uniform sampler2D DitherTexture;
 
+// START `gamma.fp`
+
+const vec3 rec709Weights = vec3(0.2126, 0.7152, 0.0722);
+const vec3 averageWeights = vec3(1.0 / 3.0);
+const vec3 oldWeights = vec3(0.3, 0.56, 0.14);
+
 vec4 ApplyGamma(vec4 c)
 {
 	c.rgb = min(c.rgb, vec3(2.0)); // for HDR mode - prevents stacked translucent sprites (such as plasma) producing way too bright light
 
-	vec3 valgray;
-	if (GrayFormula == 0)
-		valgray = vec3(c.r + c.g + c.b) * (1 - Saturation) / 3 + c.rgb * Saturation;
-	else if (GrayFormula == 2)	// new formula
-		valgray = mix(vec3(pow(dot(pow(vec3(c), vec3(2.2)), vec3(0.2126, 0.7152, 0.0722)), 1.0/2.2)), c.rgb, Saturation);
-	else
-		valgray = mix(vec3(dot(c.rgb, vec3(0.3,0.56,0.14))), c.rgb, Saturation);
-	vec3 val = valgray * Contrast - (Contrast - 1.0) * 0.5;
-	val += Brightness * 0.5;
+	vec3 val = pow(c.rgb, vec3(2.2));
+
+	vec3 weights = (GrayFormula == 2) ? rec709Weights
+	             : (GrayFormula == 1) ? oldWeights
+	                                  : averageWeights;
+	float lum = dot(val, weights);
+	val = mix(vec3(lum), val, Saturation);
+
+	val = val * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
 	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
 	return vec4(val, c.a);
 }
+
+// END `gamma.fp`
 
 vec4 Dither(vec4 c)
 {
 	if (ColorScale == 0.0)
 		return c;
+
 	vec2 texSize = vec2(textureSize(DitherTexture, 0));
 	float threshold = texture(DitherTexture, gl_FragCoord.xy / texSize).r;
-	return vec4(floor(c.rgb * ColorScale + threshold) / ColorScale, c.a);
-}
 
-vec3 sRGBtoLinear(vec3 c)
-{
-	return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), step(vec3(0.04045), c));
+	return vec4(floor(c.rgb * ColorScale + threshold) / ColorScale, c.a);
 }
 
 vec3 sRGBtoscRGBLinear(vec3 c)
@@ -45,11 +54,17 @@ vec4 ApplyHdrMode(vec4 c)
 {
 	if (HdrMode == 0)
 		return c;
-	else
-		return vec4(sRGBtoscRGBLinear(c.rgb), c.a);
+
+	return vec4(sRGBtoscRGBLinear(c.rgb), c.a);
 }
 
 void main()
 {
-	FragColor = Dither(ApplyHdrMode(ApplyGamma(texture(InputTexture, UVOffset + TexCoord * UVScale))));
+	vec4 color;
+	color = texture(InputTexture, UVOffset + TexCoord * UVScale);
+	color = ApplyGamma(color);
+	color = ApplyHdrMode(color);
+	color = Dither(color);
+	FragColor = color;
 }
+

--- a/wadsrc/static/shaders/pp/present_checker3d.fp
+++ b/wadsrc/static/shaders/pp/present_checker3d.fp
@@ -1,3 +1,4 @@
+// #include "shaders/pp/gamma.fp"
 
 layout(location=0) in vec2 TexCoord;
 layout(location=0) out vec4 FragColor;
@@ -5,13 +6,33 @@ layout(location=0) out vec4 FragColor;
 layout(binding=0) uniform sampler2D LeftEyeTexture;
 layout(binding=1) uniform sampler2D RightEyeTexture;
 
+// START `gamma.fp`
+
+const vec3 rec709Weights = vec3(0.2126, 0.7152, 0.0722);
+const vec3 averageWeights = vec3(1.0 / 3.0);
+const vec3 oldWeights = vec3(0.3, 0.56, 0.14);
+
 vec4 ApplyGamma(vec4 c)
 {
-	vec3 val = c.rgb * Contrast - (Contrast - 1.0) * 0.5;
-	val += Brightness * 0.5;
+	c.rgb = min(c.rgb, vec3(2.0)); // for HDR mode - prevents stacked translucent sprites (such as plasma) producing way too bright light
+
+	vec3 val = pow(c.rgb, vec3(2.2));
+
+	vec3 weights = (GrayFormula == 2) ? rec709Weights
+	             : (GrayFormula == 1) ? oldWeights
+	                                  : averageWeights;
+	float lum = dot(val, weights);
+	val = mix(vec3(lum), val, Saturation);
+
+	val = val * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
 	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
 	return vec4(val, c.a);
 }
+
+// END `gamma.fp`
 
 void main()
 {

--- a/wadsrc/static/shaders/pp/present_column3d.fp
+++ b/wadsrc/static/shaders/pp/present_column3d.fp
@@ -1,3 +1,4 @@
+// #include "shaders/pp/gamma.fp"
 
 layout(location=0) in vec2 TexCoord;
 layout(location=0) out vec4 FragColor;
@@ -5,13 +6,33 @@ layout(location=0) out vec4 FragColor;
 layout(binding=0) uniform sampler2D LeftEyeTexture;
 layout(binding=1) uniform sampler2D RightEyeTexture;
 
+// START `gamma.fp`
+
+const vec3 rec709Weights = vec3(0.2126, 0.7152, 0.0722);
+const vec3 averageWeights = vec3(1.0 / 3.0);
+const vec3 oldWeights = vec3(0.3, 0.56, 0.14);
+
 vec4 ApplyGamma(vec4 c)
 {
-	vec3 val = c.rgb * Contrast - (Contrast - 1.0) * 0.5;
-	val += Brightness * 0.5;
+	c.rgb = min(c.rgb, vec3(2.0)); // for HDR mode - prevents stacked translucent sprites (such as plasma) producing way too bright light
+
+	vec3 val = pow(c.rgb, vec3(2.2));
+
+	vec3 weights = (GrayFormula == 2) ? rec709Weights
+	             : (GrayFormula == 1) ? oldWeights
+	                                  : averageWeights;
+	float lum = dot(val, weights);
+	val = mix(vec3(lum), val, Saturation);
+
+	val = val * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
 	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
 	return vec4(val, c.a);
 }
+
+// END `gamma.fp`
 
 void main()
 {

--- a/wadsrc/static/shaders/pp/present_row3d.fp
+++ b/wadsrc/static/shaders/pp/present_row3d.fp
@@ -1,3 +1,4 @@
+// #include "shaders/pp/gamma.fp"
 
 layout(location=0) in vec2 TexCoord;
 layout(location=0) out vec4 FragColor;
@@ -5,13 +6,33 @@ layout(location=0) out vec4 FragColor;
 layout(binding=0) uniform sampler2D LeftEyeTexture;
 layout(binding=1) uniform sampler2D RightEyeTexture;
 
+// START `gamma.fp`
+
+const vec3 rec709Weights = vec3(0.2126, 0.7152, 0.0722);
+const vec3 averageWeights = vec3(1.0 / 3.0);
+const vec3 oldWeights = vec3(0.3, 0.56, 0.14);
+
 vec4 ApplyGamma(vec4 c)
 {
-	vec3 val = c.rgb * Contrast - (Contrast - 1.0) * 0.5;
-	val += Brightness * 0.5;
+	c.rgb = min(c.rgb, vec3(2.0)); // for HDR mode - prevents stacked translucent sprites (such as plasma) producing way too bright light
+
+	vec3 val = pow(c.rgb, vec3(2.2));
+
+	vec3 weights = (GrayFormula == 2) ? rec709Weights
+	             : (GrayFormula == 1) ? oldWeights
+	                                  : averageWeights;
+	float lum = dot(val, weights);
+	val = mix(vec3(lum), val, Saturation);
+
+	val = val * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
 	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
 	return vec4(val, c.a);
 }
+
+// END `gamma.fp`
 
 void main()
 {

--- a/wadsrc/static/shaders_gles/pp/present.fp
+++ b/wadsrc/static/shaders_gles/pp/present.fp
@@ -1,4 +1,3 @@
-
 varying vec2 TexCoord;
 
 uniform sampler2D InputTexture;
@@ -6,25 +5,19 @@ uniform sampler2D DitherTexture;
 
 vec4 ApplyGamma(vec4 c)
 {
-	vec3 valgray;
+	vec3 valgray, val;
 
-	valgray = mix(vec3(dot(c.rgb, vec3(0.3,0.56,0.14))), c.rgb, Saturation);
+	valgray = vec3(dot(c.rgb, vec3(0.3,0.56,0.14)));
+	valgray = mix(valgray, c.rgb, Saturation);
+	valgray = pow(valgray, vec3(2.2));
 
-	vec3 val = valgray * Contrast - (Contrast - 1.0) * 0.5;
-	val += Brightness * 0.5;
+	val = valgray * Contrast - (Contrast - 1.0) * 0.5;
+
+	val = (val + Brightness * 0.5) * (WhitePoint - BlackPoint) + BlackPoint;
 	val = pow(max(val, vec3(0.0)), vec3(InvGamma));
+
 	return vec4(val, c.a);
 }
-
-//vec4 Dither(vec4 c)
-//{
-//	if (ColorScale == 0.0)
-//		return c;
-//	vec2 texSize = vec2(textureSize(DitherTexture, 0));
-//	float threshold = texture2D(DitherTexture, gl_FragCoord.xy / texSize).r;
-//	return vec4(floor(c.rgb * ColorScale + threshold) / ColorScale, c.a);
-//}
-
 
 void main()
 {

--- a/wadsrc/static/textures.txt
+++ b/wadsrc/static/textures.txt
@@ -77,3 +77,8 @@ Graphic optional STBAR, 320, 32
    Graphic "STMBARL", 0, 0
    Graphic "STMBARR", 104, 0
 }
+
+texture GAMMA1, 256, 512
+{
+  Patch "-NOFLAT-", 0, 0
+}

--- a/wadsrc/static/textures.txt
+++ b/wadsrc/static/textures.txt
@@ -77,8 +77,3 @@ Graphic optional STBAR, 320, 32
    Graphic "STMBARL", 0, 0
    Graphic "STMBARR", 104, 0
 }
-
-texture GAMMA1, 256, 512
-{
-  Patch "-NOFLAT-", 0, 0
-}

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -295,6 +295,7 @@ version "4.15.1"
 #include "zscript/ui/menu/playerdisplay.zs"
 #include "zscript/ui/menu/playermenu.zs"
 #include "zscript/ui/menu/readthis.zs"
+#include "zscript/ui/menu/videooptionsmenu.zs"
 
 #include "zscript/ui/statscreen/statscreen.zs"
 #include "zscript/ui/statscreen/statscreen_coop.zs"

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -978,7 +978,7 @@ class OptionMenu : Menu
 				}
 			}
 
-			y += rowheight;
+			y += fontheight;
 		}
 
 		lastVisible = LastVisibleItem();

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -41,7 +41,7 @@
 class VideoOptions : OptionMenu
 {
 	const MARGIN = 20;
-	OptionMenuItem mylist[4];
+	OptionMenuItem mylist[3];
 	TextureID sampletex;
 	bool once;
 
@@ -57,16 +57,15 @@ class VideoOptions : OptionMenu
 		{
 			once = true; // Is there any other virtual that we can move this to?
 			mylist[0] = GetItem('vid_gamma');
-			mylist[1] = GetItem('vid_brightness');
-			mylist[2] = GetItem('vid_contrast');
-			mylist[3] = GetItem('vid_saturation');
+			mylist[1] = GetItem('vid_blackpoint');
+			mylist[2] = GetItem('vid_whitepoint');
 			sampletex = TexMan.CheckForTexture("GAMMA1"); // Replace with whatever texture lump from gzdoom.pk3
 		}
 
 		if (sampletex && mDesc.mSelectedItem >= 0)
 		{
 			OptionMenuItem li = mDesc.mItems[mDesc.mSelectedItem];
-			if (li && (li == mylist[0] || li == mylist[1] || li == mylist[2] || li == mylist[3]))
+			if (li && (li == mylist[0] || li == mylist[1] || li == mylist[2]))
 			{
 				int x = MARGIN;
 				int y = MARGIN + screen.GetHeight()/4;

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -55,7 +55,7 @@ class VideoOptions : OptionMenu
 		if (!once)
 		{
 			once = true; // Is there any other virtual that we can move this to?
-			mylist[0] = GetItem('vid_gamma');
+			mylist[0] = GetItem('vid_fixgamma');
 			mylist[1] = GetItem('vid_blackpoint');
 			mylist[2] = GetItem('vid_whitepoint');
 		}

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -42,7 +42,6 @@ class VideoOptions : OptionMenu
 {
 	const MARGIN = 20;
 	OptionMenuItem mylist[3];
-	TextureID sampletex;
 	bool once;
 
 	//=============================================================================
@@ -59,20 +58,26 @@ class VideoOptions : OptionMenu
 			mylist[0] = GetItem('vid_gamma');
 			mylist[1] = GetItem('vid_blackpoint');
 			mylist[2] = GetItem('vid_whitepoint');
-			sampletex = TexMan.CheckForTexture("GAMMA1"); // Replace with whatever texture lump from gzdoom.pk3
 		}
 
-		if (sampletex && mDesc.mSelectedItem >= 0)
+		if (mDesc.mSelectedItem >= 0)
 		{
 			OptionMenuItem li = mDesc.mItems[mDesc.mSelectedItem];
 			if (li && (li == mylist[0] || li == mylist[1] || li == mylist[2]))
 			{
 				int x = MARGIN;
-				int y = MARGIN + screen.GetHeight()/4;
-				int xsize, ysize;
-				[xsize, ysize] = TexMan.GetSize(sampletex);
-				screen.DrawTexture(sampletex, false, x, y, DTA_DestWidth, screen.GetWidth()/4,
-								   DTA_DestHeight, screen.GetWidth()*ysize/4/xsize);
+				int y = MARGIN + screen.GetHeight()/4 - 7 * NewSmallFont.GetHeight();
+				PPShader.SetUniform1i("GammaTestPattern", "uXmin", MARGIN);
+				PPShader.SetUniform1i("GammaTestPattern", "uXmax", Screen.GetWidth()/4 + MARGIN);
+				PPShader.SetUniform1i("GammaTestPattern", "uYmin", MARGIN + Screen.GetHeight()/2);
+				PPShader.SetUniform1i("GammaTestPattern", "uYmax", MARGIN + 3*Screen.GetHeight()/4);
+				PPShader.SetUniform1f("GammaTestPattern", "uInvGamma", 1.0/vid_gamma);
+				PPShader.SetUniform1f("GammaTestPattern", "uWhitePoint", vid_whitepoint);
+				PPShader.SetUniform1f("GammaTestPattern", "uBlackPoint", vid_blackpoint);
+				PPShader.SetEnabled("GammaTestPattern", true);
+				Screen.DrawText(NewSmallFont, Font.CR_CYAN, x, y,
+								"Adjust until this looks like\n a uniform Gray color.",
+								DTA_CleanNoMove_1, true);
 				DontDim = true;
 				DontBlur = true;
 			}
@@ -80,9 +85,25 @@ class VideoOptions : OptionMenu
 			{
 				DontDim = mDesc.mDontDim;
 				DontBlur = mDesc.mDontBlur;
+				PPShader.SetEnabled("GammaTestPattern", false);
 			}
 		}
 		Super.Drawer();
+	}
+
+	//=============================================================================
+	//
+	//
+	//
+	//=============================================================================
+
+	override bool MenuEvent(int mkey, bool fromcontroller)
+	{
+		if (mkey == MKEY_Back)
+		{
+			PPShader.SetEnabled("GammaTestPattern", false);
+		}
+		return Super.MenuEvent(mkey, fromcontroller);
 	}
 }
 

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -41,8 +41,6 @@
 class VideoOptions : OptionMenu
 {
 	const MARGIN = 20;
-	OptionMenuItem mylist[3];
-	bool once;
 
 	//=============================================================================
 	//
@@ -52,42 +50,22 @@ class VideoOptions : OptionMenu
 
 	override void Drawer()
 	{
-		if (!once)
-		{
-			once = true; // Is there any other virtual that we can move this to?
-			mylist[0] = GetItem('vid_fixgamma');
-			mylist[1] = GetItem('vid_blackpoint');
-			mylist[2] = GetItem('vid_whitepoint');
-		}
+		int x = MARGIN;
+		int y = MARGIN + screen.GetHeight()/4 - 7 * NewSmallFont.GetHeight();
+		PPShader.SetUniform1i("GammaTestPattern", "uXmin", MARGIN);
+		PPShader.SetUniform1i("GammaTestPattern", "uXmax", Screen.GetWidth()/4 + MARGIN);
+		PPShader.SetUniform1i("GammaTestPattern", "uYmin", Screen.GetHeight()/4 - MARGIN);
+		PPShader.SetUniform1i("GammaTestPattern", "uYmax", 3*Screen.GetHeight()/4 + MARGIN);
+		PPShader.SetUniform1f("GammaTestPattern", "uInvGamma", 1.0/vid_gamma);
+		PPShader.SetUniform1f("GammaTestPattern", "uWhitePoint", vid_whitepoint);
+		PPShader.SetUniform1f("GammaTestPattern", "uBlackPoint", vid_blackpoint);
+		PPShader.SetEnabled("GammaTestPattern", true);
+		Screen.DrawText(NewSmallFont, Font.CR_CYAN, x, y,
+						"Adjust until this looks like\na uniform Gray color.",
+						DTA_CleanNoMove_1, true);
+		DontDim = true;
+		DontBlur = true;
 
-		if (mDesc.mSelectedItem >= 0)
-		{
-			OptionMenuItem li = mDesc.mItems[mDesc.mSelectedItem];
-			if (li && (li == mylist[0] || li == mylist[1] || li == mylist[2]))
-			{
-				int x = MARGIN;
-				int y = MARGIN + screen.GetHeight()/4 - 7 * NewSmallFont.GetHeight();
-				PPShader.SetUniform1i("GammaTestPattern", "uXmin", MARGIN);
-				PPShader.SetUniform1i("GammaTestPattern", "uXmax", Screen.GetWidth()/4 + MARGIN);
-				PPShader.SetUniform1i("GammaTestPattern", "uYmin", MARGIN + Screen.GetHeight()/2);
-				PPShader.SetUniform1i("GammaTestPattern", "uYmax", MARGIN + 3*Screen.GetHeight()/4);
-				PPShader.SetUniform1f("GammaTestPattern", "uInvGamma", 1.0/vid_gamma);
-				PPShader.SetUniform1f("GammaTestPattern", "uWhitePoint", vid_whitepoint);
-				PPShader.SetUniform1f("GammaTestPattern", "uBlackPoint", vid_blackpoint);
-				PPShader.SetEnabled("GammaTestPattern", true);
-				Screen.DrawText(NewSmallFont, Font.CR_CYAN, x, y,
-								"Adjust until this looks like\n a uniform Gray color.",
-								DTA_CleanNoMove_1, true);
-				DontDim = true;
-				DontBlur = true;
-			}
-			else
-			{
-				DontDim = mDesc.mDontDim;
-				DontBlur = mDesc.mDontBlur;
-				PPShader.SetEnabled("GammaTestPattern", false);
-			}
-		}
 		Super.Drawer();
 	}
 
@@ -105,14 +83,4 @@ class VideoOptions : OptionMenu
 		}
 		return Super.MenuEvent(mkey, fromcontroller);
 	}
-}
-
-//=============================================================================
-//
-//
-//
-//=============================================================================
-
-class VideoOptionsSimple : VideoOptions
-{
 }

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -1,0 +1,98 @@
+/*
+** The Video Options menu
+**
+**---------------------------------------------------------------------------
+** Copyright 2001-2010 Randy Heit
+** Copyright 2010-2017 Christoph Oelckers
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions
+** are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+** 2. Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in the
+**    documentation and/or other materials provided with the distribution.
+** 3. The name of the author may not be used to endorse or promote products
+**    derived from this software without specific prior written permission.
+**
+** THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+** IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+** OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+** IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+** INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+** NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+** THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**---------------------------------------------------------------------------
+**
+*/
+
+//=============================================================================
+//
+//
+//
+//=============================================================================
+
+class VideoOptions : OptionMenu
+{
+	const MARGIN = 20;
+	OptionMenuItem mylist[4];
+	TextureID sampletex;
+	bool once;
+
+	//=============================================================================
+	//
+	//
+	//
+	//=============================================================================
+
+	override void Drawer()
+	{
+		if (!once)
+		{
+			once = true; // Is there any other virtual that we can move this to?
+			mylist[0] = GetItem('vid_gamma');
+			mylist[1] = GetItem('vid_brightness');
+			mylist[2] = GetItem('vid_contrast');
+			mylist[3] = GetItem('vid_saturation');
+			sampletex = TexMan.CheckForTexture("GAMMA1"); // Replace with whatever texture lump from gzdoom.pk3
+		}
+
+		if (sampletex && mDesc.mSelectedItem >= 0)
+		{
+			OptionMenuItem li = mDesc.mItems[mDesc.mSelectedItem];
+			if (li && (li == mylist[0] || li == mylist[1] || li == mylist[2] || li == mylist[3]))
+			{
+				int x = MARGIN;
+				int y = MARGIN + screen.GetHeight()/4;
+				int xsize, ysize;
+				[xsize, ysize] = TexMan.GetSize(sampletex);
+				screen.DrawTexture(sampletex, false, x, y, DTA_DestWidth, screen.GetWidth()/4,
+								   DTA_DestHeight, screen.GetWidth()*ysize/4/xsize);
+				DontDim = true;
+				DontBlur = true;
+			}
+			else
+			{
+				DontDim = mDesc.mDontDim;
+				DontBlur = mDesc.mDontBlur;
+			}
+		}
+		Super.Drawer();
+	}
+}
+
+//=============================================================================
+//
+//
+//
+//=============================================================================
+
+class VideoOptionsSimple : VideoOptions
+{
+}

--- a/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
+++ b/wadsrc/static/zscript/ui/menu/videooptionsmenu.zs
@@ -50,21 +50,118 @@ class VideoOptions : OptionMenu
 
 	override void Drawer()
 	{
-		int x = MARGIN;
-		int y = MARGIN + screen.GetHeight()/4 - 7 * NewSmallFont.GetHeight();
-		PPShader.SetUniform1i("GammaTestPattern", "uXmin", MARGIN);
-		PPShader.SetUniform1i("GammaTestPattern", "uXmax", Screen.GetWidth()/4 + MARGIN);
-		PPShader.SetUniform1i("GammaTestPattern", "uYmin", Screen.GetHeight()/4 - MARGIN);
-		PPShader.SetUniform1i("GammaTestPattern", "uYmax", 3*Screen.GetHeight()/4 + MARGIN);
+		DontDim = true;
+		DontBlur = true;
+
+		// Dim the background
+		int x = 0;
+		int y = 0;
+		int h = mDesc.mPosition;
+		int w = 0;
+		if (h <= 0)
+		{
+			let font = menuDelegate.PickFont(mDesc.mFont);
+			if (font && mDesc.mTitle.Length() > 0)
+			{
+				w = font.StringWidth(mDesc.mTitle) * CleanXfac_1;
+				h = (-h + font.GetHeight()) * CleanYfac_1;
+			}
+			else
+			{
+				w = h = 0;
+			}
+		}
+
+		int fw = screen.GetWidth();
+		int fh = screen.GetHeight();
+
+		ScreenArea box;
+		GetTooltipArea(box);
+		if (!DrawTooltips)
+			box.y = fh;
+		int lastrow = box.y - OptionHeight() * CleanYfac_1;
+		int fontheight = OptionMenuSettings.mLinespacing * CleanYfac_1;
+
+		int count = 0;
+		int slider = -1;
+		int sliderBound = 0;
+		for (int i = 0; i < mDesc.mItems.Size() && h <= lastrow; i++)
+		{
+			if (i == mDesc.mScrollTop)
+			{
+				i += mDesc.mScrollPos;
+				if (i >= mDesc.mItems.Size()) break;
+				if (i < 0) i = 0;
+			}
+
+			if (!mDesc.mItems[i].Visible())
+			{
+				continue;
+			}
+
+			int t = Menu.OptionWidth(mDesc.mItems[i].mLabel) + mDesc.mItems[i].getIndent();
+
+			if (mDesc.mItems[i] is "OptionMenuSliderBase")
+			{
+				int digits = OptionMenuSliderBase(mDesc.mItems[i]).mShowValue;
+
+				slider = max(slider, digits);
+
+				if (digits > 0)
+				{
+					float upper = OptionMenuSliderBase(mDesc.mItems[i]).mMax;
+					float lower = OptionMenuSliderBase(mDesc.mItems[i]).mMin;
+
+					String fmt = String.format("%%.%df", digits);
+					String fmtLower = String.format(fmt, lower);
+					String fmtUpper = String.format(fmt, upper);
+
+					int widthLower = Menu.OptionWidth(fmtLower);
+					int widthUpper = Menu.OptionWidth(fmtUpper);
+					int width = max(widthLower, widthUpper);
+
+					sliderBound = max(sliderBound, width);
+				}
+			}
+
+			w = max(w, t*CleanXfac_1);
+			h += fontheight;
+		}
+
+		// account for sliders popping out the side
+		if (slider >= 0)
+		{
+			int extra = sliderBound + 2; // text + gap
+
+			slider = (13*16) - w/(CleanXfac_1*2) + extra;
+			slider *= CleanXfac_1;
+
+			if (slider < 0) slider = 0;
+		}
+		if (slider < 0) slider = 0;
+
+		w += fontheight + slider*2;
+		h += fontheight;
+		x = max(0, fw - w) / 2;
+		y = 0;
+		Screen.Dim(0u, 1, x, y, w, h);
+
+		// positioning
+		w = min(fw, max(fw*3/4, w));
+		y = fh - h;
+		h = fh - box.y;
+		if (y-h > w) h = y - w;
+		x = (fw - w)/2;
+		w = x + w;
+
+		PPShader.SetUniform1i("GammaTestPattern", "uXmin", x);
+		PPShader.SetUniform1i("GammaTestPattern", "uXmax", w);
+		PPShader.SetUniform1i("GammaTestPattern", "uYmin", h);
+		PPShader.SetUniform1i("GammaTestPattern", "uYmax", y);
 		PPShader.SetUniform1f("GammaTestPattern", "uInvGamma", 1.0/vid_gamma);
 		PPShader.SetUniform1f("GammaTestPattern", "uWhitePoint", vid_whitepoint);
 		PPShader.SetUniform1f("GammaTestPattern", "uBlackPoint", vid_blackpoint);
 		PPShader.SetEnabled("GammaTestPattern", true);
-		Screen.DrawText(NewSmallFont, Font.CR_CYAN, x, y,
-						"Adjust until this looks like\na uniform Gray color.",
-						DTA_CleanNoMove_1, true);
-		DontDim = true;
-		DontBlur = true;
 
 		Super.Drawer();
 	}


### PR DESCRIPTION
TODO (for this PR):

- [x] Reset relevant settings upon update from older version
- [x] Fix gles
- [x] Verify 3d outputs
- [x] Verify GrayFormula=0/2 pipelines
- [x] Look into HDR
- [x] Add translation strings to language files (#797)
- [x] Verify mac gamma on an apple panel (2.2 is correct. 1.8 was used on old macs aparently)

TODO (for future PR):

- ~~Nicer menu?~~ It's pretty decent now

---

After a lot of discussion in the discord, it has become clear that a proper image calibration screen would be very useful.

Right now, gzdoom's gamma correction is very "Vibes Based", where the user sets the gamma based on what they feel looks nice. In most other applications, gamma correction is used to calibrate the image to the output device, in order to display things as the author intended.

WIP Video Demo (play video in a new tab at its native scale for the test pattern to look correct):

[Screencast_20251214_175556.webm](https://github.com/user-attachments/assets/2b759955-9349-4a75-9dfa-3efdc89c080f)

<details><summary>Proposal / Old mockups</summary>

I propose adding a "Image calibration screen" instead of the gamma slider we currently have. The screen would take control of the renderer directly to display a test pattern (and maybe a demo render), allowing the user to adjust the output parameters accordingly.

The screen would have 3 sliders: Gamma, Black Point, White Point
- Gamma controls the gamma correction. (default 2.2)
- Black point adjust what the engine considers the darkest black. This is to fix the image on monitors with bad black levels.  (default 0)
- White point does the same for as black point, but for the brightest white. (default 1)

Here is a quick-and-dirty demo of how I think the params should work. 
[Demo](https://phinet.ca/projects/gamma/)
[Source](https://github.com/the-phinet/Image-Calibration-Toy/)

Here is an image of how I think the screen should kinda look:

<img width="829" height="1553" alt="Image" src="https://github.com/user-attachments/assets/47ce0406-6731-4264-865f-ae5f23f7e414" />

(if you see a pattern in this mock-screenshot, github probably resized the image. try opening it in a new tab)

Often games give you one slider and three images. "Adjust until you cant see the dark logo". I've always disliked how this is implemented, as it A: hides what it is actually doing (is it setting the black point? adjusting gamma? just boosting brightness?); B: is extremely imprecise. I think the method proposed above is robust and gameplay agnostic (dark maps vs light maps).

Imported from https://github.com/ZDoom/gzdoom/pull/3332

</details>