### PR TITLE
[Fix] Steamdeck Support (Part 1)

### DIFF
--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -54,7 +54,16 @@
 bool GUICapture;
 static bool NativeMouse = true;
 
-CVAR (Bool,  use_mouse,				true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR (Bool, use_mouse, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CUSTOM_CVARD (Int, joykey_stop_conflict, -1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG,
+	"Detect joypad/keyboard conflicts, dropping events as needed. "
+	"Useful for handheld PCs such as the SteamDeck. "
+	"-1: auto-detect, 0: disabled, 1: detected, 2: forced"
+)
+{
+	if (self < -1) self = -1;
+	else if (self > 2) self = 2;
+}
 
 extern int WaitingForKey;
 
@@ -262,6 +271,9 @@ static void MouseRead ()
 	}
 
 	SDL_GetRelativeMouseState (&x, &y);
+
+	if (joykey_stop_conflict > 0) return;
+
 	PostMouseMove (x, y);
 }
 
@@ -272,7 +284,7 @@ static void I_CheckNativeMouse ()
 	bool captureModeInGame = sysCallbacks.CaptureModeInGame && sysCallbacks.CaptureModeInGame();
 	bool wantNative = !focus || (!use_mouse || GUICapture || !captureModeInGame);
 
-	if (!wantNative && sysCallbacks.WantNativeMouse && sysCallbacks.WantNativeMouse())
+	if (!wantNative && sysCallbacks.WantNativeMouse && sysCallbacks.WantNativeMouse() && joykey_stop_conflict <= 0)
 		wantNative = true;
 
 	if (wantNative != NativeMouse)
@@ -288,11 +300,59 @@ static void I_CheckNativeMouse ()
 	}
 }
 
+
 void MessagePump (const SDL_Event &sev)
 {
 	static int lastx = 0, lasty = 0;
 	int x, y;
 	event_t event = { 0,0,0,0,0,0,0 };
+
+	if (joykey_stop_conflict == -1 || joykey_stop_conflict == 1)
+	{
+		const int threshold = 1;
+
+		static unsigned eventTimestamp;
+		static bool seenKeyEvent;
+		static bool seenJoyEvent;
+		static int duplicateEvents;
+
+		if (eventTimestamp == 0)
+		{
+			eventTimestamp = duplicateEvents= 0;
+			seenKeyEvent = seenJoyEvent = false;
+
+			if (joykey_stop_conflict == 1)
+				joykey_stop_conflict = -1;
+		}
+
+		if (joykey_stop_conflict == -1)
+		{
+			if (eventTimestamp != sev.common.timestamp)
+			{
+				if (seenKeyEvent != seenJoyEvent)
+					duplicateEvents = 0;
+				eventTimestamp = sev.common.timestamp;
+				seenKeyEvent = seenJoyEvent = false;
+			}
+
+			switch (sev.type)
+			{
+				case SDL_KEYDOWN:
+					seenKeyEvent = true;
+					break;
+				case SDL_JOYBUTTONDOWN:
+				case SDL_CONTROLLERBUTTONDOWN:
+					seenJoyEvent = true;
+					break;
+			}
+
+			if (seenJoyEvent && seenKeyEvent && ++duplicateEvents >= threshold)
+			{
+				// TODO: notify the user that we did this
+				joykey_stop_conflict = 1;
+			}
+		}
+	}
 
 	switch (sev.type)
 	{
@@ -306,6 +366,7 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_MOUSEBUTTONDOWN:
 	case SDL_MOUSEBUTTONUP:
+		if (joykey_stop_conflict > 0 && sev.type == SDL_MOUSEBUTTONDOWN) break;
 		if (!GUICapture)
 		{
 			event.type = sev.type == SDL_MOUSEBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
@@ -375,6 +436,7 @@ void MessagePump (const SDL_Event &sev)
 		break;
 
 	case SDL_MOUSEMOTION:
+		if (joykey_stop_conflict > 0) break;
 		if (GUICapture)
 		{
 			event.data1 = sev.motion.x;
@@ -395,6 +457,7 @@ void MessagePump (const SDL_Event &sev)
 		break;
 
 	case SDL_MOUSEWHEEL:
+		if (joykey_stop_conflict > 0) break;
 		if (GUICapture)
 		{
 			event.type = EV_GUI_Event;
@@ -428,6 +491,7 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_KEYDOWN:
 	case SDL_KEYUP:
+		if (joykey_stop_conflict > 0 && sev.type == SDL_KEYDOWN) break;
 		if (!GUICapture)
 		{
 			if (sev.key.repeat)
@@ -514,6 +578,7 @@ void MessagePump (const SDL_Event &sev)
 		break;
 
 	case SDL_TEXTINPUT:
+		if (joykey_stop_conflict > 0 && sev.type == SDL_TEXTINPUT) break;
 		if (GUICapture)
 		{
 			int size;

--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -50,6 +50,7 @@
 #include "m_joy.h"
 #include "utf8.h"
 #include "v_video.h"
+#include "version.h"
 
 bool GUICapture;
 static bool NativeMouse = true;
@@ -311,14 +312,14 @@ void MessagePump (const SDL_Event &sev)
 	{
 		const int threshold = 1;
 
+		static SDL_Window *window;
 		static unsigned eventTimestamp;
-		static bool seenKeyEvent;
-		static bool seenJoyEvent;
+		static bool seenKeyEvent, seenJoyEvent;
 		static int duplicateEvents;
 
 		if (eventTimestamp == 0)
 		{
-			eventTimestamp = duplicateEvents= 0;
+			eventTimestamp = duplicateEvents = 0;
 			seenKeyEvent = seenJoyEvent = false;
 
 			if (joykey_stop_conflict == 1)
@@ -339,6 +340,7 @@ void MessagePump (const SDL_Event &sev)
 			{
 				case SDL_KEYDOWN:
 					seenKeyEvent = true;
+					if (!window) window = SDL_GetWindowFromID(sev.key.windowID);
 					break;
 				case SDL_JOYBUTTONDOWN:
 				case SDL_CONTROLLERBUTTONDOWN:
@@ -348,8 +350,23 @@ void MessagePump (const SDL_Event &sev)
 
 			if (seenJoyEvent && seenKeyEvent && ++duplicateEvents >= threshold)
 			{
-				// TODO: notify the user that we did this
 				joykey_stop_conflict = 1;
+
+				// TODO: use CustomMessageBox https://github.com/ZDoom/gzdoom/pull/1821
+				if (window) SDL_HideWindow(window);
+				SDL_ShowSimpleMessageBox(
+					SDL_MESSAGEBOX_INFORMATION,
+					GAMENAME,
+					"Simultaneous input from a gamepad and keyboard detected!\n"
+					"All keyboard/mouse input has been temporarily disabled.\n"
+					"\n"
+					"If using a handheld PC, try switching from DESKTOP to GAMEPAD bindings.\n"
+					"This can generally be done by holding down START.\n"
+					"\n"
+					"To disable this detection, set joykey_stop_conflict to 0.",
+					window
+				);
+				if (window) SDL_ShowWindow(window);
 			}
 		}
 	}

--- a/tools/AppImageBuilder.yml
+++ b/tools/AppImageBuilder.yml
@@ -17,9 +17,18 @@ AppDir:
 
   files:
     include:
-    - /lib64/ld-linux-x86-64.so.2
     - /lib64/libbz2.so.1
+    - /lib64/libwayland-client++.so.1
+    - /lib64/libwayland-client-extra++.so.1
+    - /lib64/libwayland-client-unstable++.so.1
+    - /lib64/libwayland-cursor++.so.1
+    - /lib64/libomp.so
     exclude:
+    - lib64/libm.so.6
+    - lib64/libc.so.6
+    - lib64/libgcc_s.so.1
+    - lib64/ld-linux-x86-64.so.2
+    - lib64/libstdc++.so.6
     - usr/share/man
     - usr/share/doc/*/README.*
     - usr/share/doc/*/changelog.*

--- a/wadsrc/static/engine/commonbinds.txt
+++ b/wadsrc/static/engine/commonbinds.txt
@@ -50,20 +50,7 @@ pgdn +lookup
 del +lookdown
 end centerview
 
-// Xbox 360 / PS2 controllers
-pad_a +use
-pad_y +jump
-rtrigger +attack
-ltrigger +altattack
-lshoulder weapprev
-rshoulder weapnext
-dpadleft invprev
-dpadright invnext
-dpaddown invuse
-dpadup togglemap
-pad_start menu_main
-pad_back pause
-lthumb crouch
+// Gamepads
 lstickleft +moveleft
 lstickright +moveright
 lstickup +forward
@@ -72,6 +59,27 @@ rstickleft +left
 rstickright +right
 rstickup +lookup
 rstickdown +lookdown
+pad_a +use
+pad_b crouch
+pad_x +reload
+pad_y +jump
+rtrigger +attack
+ltrigger +altattack
+lshoulder weapprev
+rshoulder weapnext
+pad_start menu_main
+pad_back togglemap
+pad_touchpad togglemap
+rthumb +zoom
+guide pause
+dpadleft invprev
+dpadright invnext
+dpaddown invuse
+dpadup "slot 1"
+paddle_1 "slot 2"
+paddle_2 "slot 3"
+paddle_3 "slot 4"
+paddle_4 "slot 5"
 
 /* Default automap bindings */
 mapbind f am_togglefollow

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -828,6 +828,7 @@ OptionMenu "JoystickOptionsDefaults" protected
 	StaticText ""
 	Slider "$JOYMNU_TURNSPEED",			"cl_analog_sensitivity_yaw", 0, 2.5, 0.1
 	Slider "$JOYMNU_LOOKSPEED",			"cl_analog_sensitivity_pitch", 0, 2.5, 0.1
+	Option "$JOYMNU_ANALOGRUN",			"cl_analog_run", "OnOff"
 	Option "$JOYMNU_ANALOGSTRAFERUN",	"cl_analog_straferun", "OnOff"
 	StaticText ""
 	StaticTextSwitchable "$JOYMNU_NOCON", "$JOYMNU_CONFIG", "ConfigureMessage"


### PR DESCRIPTION
Fixes the last couple known issues with supporting the steamdeck.

Testing build: [GZDoom-g4.15pre-595-ga84177e3-x86_64.zip](https://github.com/user-attachments/files/22711685/GZDoom-g4.15pre-595-ga84177e3-x86_64.zip)

Fixes:
- Inability to complete Doom2 map02 without rebinding controls.
- Updated controls to be more useful / familiar to modern games.
- Fix desktop mode double input
- Fix appimage bundle generation for steamos
- Add SDL gamepad support for launcher

<details><summary>Double input fix explanation</summary>
When in desktop mode the steamdec will simultaneously send gamepad and mouse/keyboard inputs. 

- Left stick: left stick + WASD
- Right stick: right stick + mouse move
- dpad: dpad + arrow keys
- Triggers: triggers + mouse clicks
- etc

This results in every menu input being fired twice, and looking around being twice as fast as intended. The game is extremely difficult to control due to this. It is easily fixed by enabling gamepad binds in the steamdeck (hold start), but this is not the default. 

To circumvent this, the game will now detect these double inputs, disable mouse/keyboard (for the session), and notify the user what it did and how they can actually fix it.

Added cvar joykey_stop_conflict:
- -1: auto-detect conflicts (default)
- 0: do nothing
- 1: temporarily disable input from mouse/keyboard until next run
- 2: same as 1, but does not reset

If set to 1 or 2, the game will drop all inputs from keyboard and mouse. 

If set to -1, the game will detect double inputs, notfiy the user, and set the cvar to 1

On boot, if the cvar is set to 1, it is reset to -1

The notification that we detected double inputs:
<img width="602" height="249" alt="Screenshot_20251006_151808" src="https://github.com/user-attachments/assets/2655dba0-f857-4207-8205-a1072ab05106" />
</details>

Analogue movement has been given the option to run when fully tilted. This is enabled by default. In order to support old joysticks, previous behaviour can be enabled by disabling `cl_analog_run`

Binds changed:
- **up**
  - Weapon slot 1
  - This gives player a stable point to build muscle memory from, instead of being forced to scroll through weapons
- **R3**
  - zoom
  - This is where most games have zoom
- **B**
  - crouch
  - Moved from r3. This is a common bind
- **X**
  - reload
  - This is a common bind 
- **select**
  - map
  - Moved from up. This is a common bind 
- **guide**
  - pause
  - Moved from select. In order to pause in case steam decides to open
- **paddles**
  - weapon slots
  - For quick access

Fixes https://github.com/ZDoom/gzdoom/issues/2628

Imported from https://github.com/ZDoom/gzdoom/pull/3320