### PR TITLE
[Feat] Better documentation and -help commandline flag

### DIFF
--- a/src/common/audio/sound/i_sound.cpp
+++ b/src/common/audio/sound/i_sound.cpp
@@ -64,9 +64,12 @@ CUSTOM_CVAR(Int, snd_samplerate, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, snd_buffersize, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, snd_hrtf, -1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
-FARG(nomusic, "", "", "", "");
-FARG(nosound, "", "", "", "");
-FARG(nosfx, "", "", "", "");
+FARG(nomusic, "Configuration", "Turns off in-game music playback.", "",
+	"Prevents the playback of music.");
+FARG(nosound, "Configuration", "Turns off all in-game sound/music.", "",
+	"Disables both music and sound effects.");
+FARG(nosfx, "Configuration", "Turns off in-game sound effects.", "",
+	"Prevents the playback of sound effects.");
 
 #if !defined(NO_OPENAL)	
 #define DEF_BACKEND "openal"

--- a/src/common/audio/sound/i_sound.cpp
+++ b/src/common/audio/sound/i_sound.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -61,6 +63,10 @@ CUSTOM_CVAR(Int, snd_samplerate, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 }
 CVAR(Int, snd_buffersize, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, snd_hrtf, -1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+
+FARG(nomusic, "", "", "", "");
+FARG(nosound, "", "", "", "");
+FARG(nosfx, "", "", "", "");
 
 #if !defined(NO_OPENAL)	
 #define DEF_BACKEND "openal"
@@ -250,8 +256,8 @@ void I_InitSound ()
 {
 	FModule_SetProgDir(progdir.GetChars());
 	/* Get command line options: */
-	nosound = !!Args->CheckParm ("-nosound");
-	nosfx = !!Args->CheckParm ("-nosfx");
+	nosound = !!Args->CheckParm (FArg_nosound);
+	nosfx = !!Args->CheckParm (FArg_nosfx);
 
 	GSnd = NULL;
 	if (nosound)

--- a/src/common/audio/sound/i_sound.h
+++ b/src/common/audio/sound/i_sound.h
@@ -3,6 +3,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -38,6 +40,7 @@
 #include <chrono>
 #include <vector>
 #include "i_soundinternal.h"
+#include "m_argv.h"
 #include "zstring.h"
 #include <zmusic.h>
 #include "files.h"
@@ -59,6 +62,9 @@ enum ECodecType
 	CODEC_Vorbis,
 };
 
+EXTERN_FARG(nomusic);
+EXTERN_FARG(nosound);
+EXTERN_FARG(nosfx);
 
 class SoundStream
 {

--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -1,3 +1,29 @@
+/*
+** i_interface.cpp
+**
+**---------------------------------------------------------------------------
+**
+** Copyright 2020 Christoph Oelckers
+** Copyright 2020-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see http://www.gnu.org/licenses/
+**
+**---------------------------------------------------------------------------
+**
+*/
+
 #include "i_interface.h"
 #include "st_start.h"
 #include "gamestate.h"
@@ -166,9 +192,9 @@ int FStartupSelectionInfo::SaveInfo()
 		}
 
 		if (!DefaultNetArgs.IsEmpty())
-			Args->AppendArgsString(DefaultNetArgs);
+			Args->AppendRawArgsString(DefaultNetArgs);
 		if (!AdditionalNetArgs.IsEmpty())
-			Args->AppendArgsString(AdditionalNetArgs);
+			Args->AppendRawArgsString(AdditionalNetArgs);
 
 		return DefaultNetIWAD;
 	}
@@ -178,7 +204,7 @@ int FStartupSelectionInfo::SaveInfo()
 	defaultargs = saveargs ? DefaultArgs.GetChars() : "";
 
 	if (!DefaultArgs.IsEmpty())
-		Args->AppendArgsString(DefaultArgs);
+		Args->AppendRawArgsString(DefaultArgs);
 
 	return DefaultIWAD;
 }

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -82,6 +82,7 @@
 #include "c_cvars.h"
 #include "i_net.h"
 #include "m_random.h"
+#include "version.h"
 
 /* [Petteri] Get more portable: */
 #ifndef __WIN32__
@@ -108,12 +109,24 @@ const char* neterror(void);
 #define neterror() strerror(errno)
 #endif
 
-FARG(host, "", "", "", "");
-FARG(join, "", "", "", "");
-FARG(dup, "", "", "", "");
-FARG(port, "", "", "", "");
-FARG(netmode, "", "", "", "");
-FARG(password, "", "", "", "");
+FARG(host, "Multiplayer", "Designates the machine as the host for a multiplayer game.", "x",
+	"This machine will function as a host for a multiplayer game with x players (including this"
+	" machine). It will wait for other machines to connect using the -join. parameter and then"
+	" start the game when everyone is connected.");
+FARG(join, "Multiplayer", "Connects to a multiplayer host.", "host's IP address[:host's port]",
+	 "Connect to a host for a multiplayer game.");
+FARG(dup, "Multiplayer", "Send less player movement commands over the network.", "x",
+	"Causes " GAMENAME " to transmit fewer player movement commands across the network. Valid"
+	" values range from 1–9. For example, -dup 2 would cause " GAMENAME " to send half as many"
+	" movements as normal.");
+FARG(port, "Multiplayer", "Specifies an alternative IP port for a network game.", "x",
+	"Specifies an alternate IP port for this machine to use during a network game. By default,"
+	" port 5029 is used.");
+FARG(netmode, "Multiplayer", "Changes the network mode", "0|1",
+	"Changes the network mode the game uses (Peer-to-Peer or Packet Server). More information on"
+	" each mode can be found on the Multiplayer page.");
+FARG(password, "", "", "",
+	"");
 
 // As per http://support.microsoft.com/kb/q192599/ the standard
 // size for network buffers is 8k.

--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -3,7 +3,11 @@
 //
 // $Id: i_net.c,v 1.2 1997/12/29 19:50:54 pekangas Exp $
 //
-// Copyright (C) 1993-1996 by id Software, Inc.
+// Copyright 1993-1996 by id Software, Inc.
+// Copyright 1999-2016 Randy Heit
+// Copyright 2002-2016 Christoph Oelckers
+// Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -103,6 +107,13 @@ const char* neterror(void);
 #else
 #define neterror() strerror(errno)
 #endif
+
+FARG(host, "", "", "", "");
+FARG(join, "", "", "", "");
+FARG(dup, "", "", "", "");
+FARG(port, "", "", "", "");
+FARG(netmode, "", "", "", "");
+FARG(password, "", "", "", "");
 
 // As per http://support.microsoft.com/kb/q192599/ the standard
 // size for network buffers is 8k.
@@ -1275,33 +1286,33 @@ static bool JoinGame(int arg)
 bool I_InitNetwork()
 {
 	// set up for network
-	const char* v = Args->CheckValue("-dup");
+	const char* v = Args->CheckValue(FArg_dup);
 	if (v != nullptr)
 		TicDup = clamp<int>(atoi(v), 1, MAXTICDUP);
 
-	v = Args->CheckValue("-port");
+	v = Args->CheckValue(FArg_port);
 	if (v != nullptr)
 	{
 		GamePort = atoi(v);
 		Printf("Using alternate port %d\n", GamePort);
 	}
 
-	v = Args->CheckValue("-netmode");
+	v = Args->CheckValue(FArg_netmode);
 	if (v != nullptr)
 		NetMode = atoi(v) ? NET_PacketServer : NET_PeerToPeer;
 
-	net_password = Args->CheckValue("-password");
+	net_password = Args->CheckValue(FArg_password);
 
 	// parse network game options,
 	//		player 1: -host <numplayers>
 	//		player x: -join <player 1's address>
 	int arg = -1;
-	if ((arg = Args->CheckParm("-host")))
+	if ((arg = Args->CheckParm(FArg_host)))
 	{
 		if (!HostGame(arg + 1, v != nullptr))
 			return false;
 	}
-	else if ((arg = Args->CheckParm("-join")))
+	else if ((arg = Args->CheckParm(FArg_join)))
 	{
 		if (!JoinGame(arg + 1))
 			return false;

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -2,9 +2,13 @@
 #define __I_NET_H__
 
 #include <stdint.h>
+#include "m_argv.h"
 #include "tarray.h"
 
 inline constexpr size_t MAXPLAYERS = 64u;
+
+EXTERN_FARG(host);
+EXTERN_FARG(join);
 
 enum ENetConstants
 {

--- a/src/common/engine/m_joy.cpp
+++ b/src/common/engine/m_joy.cpp
@@ -99,7 +99,11 @@ CUSTOM_CVARD(Bool, use_joystick, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINI
 #endif
 }
 
-FARG(nojoy, "", "", "", "");
+FARG(nojoy, "Configuration", "Disables joystick support.", "",
+	"Disables joystick support. If you have an old-fashioned gameport (non-USB) device attached,"
+	" it can slow down the game even if you do not intend to use it. Use -nojoy to avoid the"
+	" slowdown that comes from polling it for input. Only the Windows version supports a"
+	" joystick.");
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 

--- a/src/common/engine/m_joy.cpp
+++ b/src/common/engine/m_joy.cpp
@@ -7,6 +7,7 @@
 **
 ** Copyright 2005-2016 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -97,6 +98,8 @@ CUSTOM_CVARD(Bool, use_joystick, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG|CVAR_NOINI
 	joy_xinput->Callback();
 #endif
 }
+
+FARG(nojoy, "", "", "", "");
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
 

--- a/src/common/engine/m_joy.h
+++ b/src/common/engine/m_joy.h
@@ -3,6 +3,7 @@
 
 #include "c_cvars.h"
 #include "keydef.h"
+#include "m_argv.h"
 #include "tarray.h"
 
 union CubicBezier {
@@ -94,6 +95,7 @@ struct IJoystickConfig
 };
 
 EXTERN_CVAR(Bool, use_joystick);
+EXTERN_FARG(nojoy);
 
 bool M_LoadJoystickConfig(IJoystickConfig *joy);
 void M_SaveJoystickConfig(IJoystickConfig *joy);

--- a/src/common/menu/menudef.cpp
+++ b/src/common/menu/menudef.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 2010 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -1618,6 +1620,8 @@ static void ParseImageScroller(FScanner& sc)
 //
 //=============================================================================
 
+FARG(nocustommenu, "", "", "", "");
+
 void M_ParseMenuDefs()
 {
 	int lump, lastlump = 0;
@@ -1693,7 +1697,7 @@ void M_ParseMenuDefs()
 				sc.ScriptError("Unknown keyword '%s'", sc.String);
 			}
 		}
-		if (Args->CheckParm("-nocustommenu")) break;
+		if (Args->CheckParm(FArg_nocustommenu)) break;
 	}
 	DefaultListMenuClass = DefaultListMenuSettings->mClass;
 	DefaultListMenuSettings = nullptr;

--- a/src/common/menu/menudef.cpp
+++ b/src/common/menu/menudef.cpp
@@ -55,6 +55,9 @@
 
 
 
+FARG(nocustommenu, "", "", "",
+	"");
+
 bool CheckSkipGameOptionBlock(FScanner& sc);
 
 MenuDescriptorList MenuDescriptors;
@@ -1620,8 +1623,6 @@ static void ParseImageScroller(FScanner& sc)
 //
 //=============================================================================
 
-FARG(nocustommenu, "", "", "", "");
-
 void M_ParseMenuDefs()
 {
 	int lump, lastlump = 0;
@@ -1795,5 +1796,3 @@ void M_CreateMenus()
 		I_BuildALResamplersList(*opt);
 	}
 }
-
-

--- a/src/common/menu/savegamemanager.cpp
+++ b/src/common/menu/savegamemanager.cpp
@@ -5,6 +5,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 2001-2010 Randy Heit
 ** Copyright 2010-2020 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -53,6 +55,8 @@
 CVAR(String, save_dir, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_SYSTEM_ONLY);
 FString SavegameFolder;
 CVAR(Int, save_sort_order, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+
+EXTERN_FARG(savedir);
 
 extern bool netgame;
 
@@ -641,7 +645,7 @@ FString G_GetSavegamesFolder()
 		name = M_GetSavegamesPath();
 		usefilter = true;
 	}
-	else if (const char* const dir = Args->CheckValue("-savedir"))
+	else if (const char* const dir = Args->CheckValue(FArg_savedir))
 	{
 		name = dir;
 		usefilter = false; //-savedir specifies an absolute save directory path.

--- a/src/common/platform/posix/cocoa/i_joystick.cpp
+++ b/src/common/platform/posix/cocoa/i_joystick.cpp
@@ -5,6 +5,7 @@
 **
 ** Copyright 2012-2015 Alexey Lysiuk
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -49,6 +50,7 @@
 
 EXTERN_CVAR(Bool, joy_axespolling)
 EXTERN_CVAR(Bool, use_joystick)
+EXTERN_FARG(nojoy);
 
 namespace
 {
@@ -1322,7 +1324,7 @@ void I_GetJoysticks(TArray<IJoystickConfig*>& sticks)
 	// As M_LoadDefaults() was already called at this moment,
 	// the order of atterm's functions will be correct
 
-	if (NULL == s_joystickManager && !Args->CheckParm("-nojoy"))
+	if (NULL == s_joystickManager && !Args->CheckParm(FArg_nojoy))
 	{
 		s_joystickManager = new IOKitJoystickManager;
 	}

--- a/src/common/platform/posix/cocoa/i_main.mm
+++ b/src/common/platform/posix/cocoa/i_main.mm
@@ -4,6 +4,7 @@
  **---------------------------------------------------------------------------
  ** Copyright 2012-2018 Alexey Lysiuk
  ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+ ** Copyright 2025 UZDoom Maintainers and Contributors
  ** All rights reserved.
  **
  ** Redistribution and use in source and binary forms, with or without
@@ -52,6 +53,8 @@
 #include "zstring.h"
 
 #define ZD_UNUSED(VARIABLE) ((void)(VARIABLE))
+
+extern const char * const BACKEND = "Cocoa";
 
 // ---------------------------------------------------------------------------
 
@@ -132,7 +135,7 @@ static bool ReadSystemVersionFromPlist(NSOperatingSystemVersion& version)
 }
 
 FString sys_ostype;
-void I_DetectOS()
+FString I_DetectOS()
 {
 	NSOperatingSystemVersion version = {};
 
@@ -185,11 +188,13 @@ void I_DetectOS()
 		"Unknown";
 #endif
 
-	Printf("%s running macOS %s %d.%d.%d (%s) %s\n", model, name,
+	FString nicename = FStringf("%s running macOS %s %d.%d.%d (%s) %s", model, name,
 		   int(version.majorVersion), int(version.minorVersion), int(version.patchVersion),
 		   release, architecture);
 
 	sys_ostype.Format("macOS %d.%d %s", int(version.majorVersion), int(version.minorVersion), name);
+
+	return nicename;
 }
 
 

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -5,6 +5,7 @@
 **---------------------------------------------------------------------------
 ** Copyright 1998-2007 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -53,6 +54,7 @@
 #include "m_argv.h"
 #include "printf.h"
 #include "version.h"
+#include "zstring.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -78,6 +80,8 @@ void SignalHandler(int signal);
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
 
+extern const char * const BACKEND = "SDL2";
+
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 FString sys_ostype;
 
@@ -97,7 +101,7 @@ static int GetCrashInfo (char *buffer, char *end)
 	return strlen(buffer);
 }
 
-void I_DetectOS()
+FString I_DetectOS()
 {
 	FString operatingSystem;
 
@@ -142,8 +146,10 @@ void I_DetectOS()
 		sys_ostype.Format("%s %s on %s", unameInfo.sysname, unameInfo.release, unameInfo.machine);
 	}
 
-	if (operatingSystem.Len() > 0)
-		Printf("OS: %s\n", operatingSystem.GetChars());
+	if (operatingSystem.Len() == 0)
+		operatingSystem = "Unknown";
+
+	return operatingSystem;
 }
 
 void I_StartupJoysticks();
@@ -178,8 +184,6 @@ int main (int argc, char **argv)
 		fprintf (stderr, "Could not initialize SDL:\n%s\n", SDL_GetError());
 		return -1;
 	}
-
-	printf("\n");
 
 	Args = new FArgs(argc, argv);
 

--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -4,6 +4,7 @@
 **---------------------------------------------------------------------------
 ** Copyright 2005-2016 Christoph Oelckers et.al.
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -85,6 +86,7 @@ EXTERN_CVAR (Int, vid_defwidth)
 EXTERN_CVAR (Int, vid_defheight)
 EXTERN_CVAR (Bool, cl_capfps)
 EXTERN_CVAR(Bool, vk_debug)
+EXTERN_FARG(glversion);
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
@@ -544,7 +546,7 @@ SystemGLFrameBuffer::SystemGLFrameBuffer(void *hMonitor, bool fullscreen)
 	int glveridx = 0;
 	int i;
 
-	const char *version = Args->CheckValue("-glversion");
+	const char *version = Args->CheckValue(FArg_glversion);
 	if (version != NULL)
 	{
 		double gl_version = strtod(version, NULL) + 0.01;

--- a/src/common/platform/win32/base_sysfb.cpp
+++ b/src/common/platform/win32/base_sysfb.cpp
@@ -62,7 +62,8 @@ extern "C" {
 EXTERN_CVAR(Int, vid_defwidth)
 EXTERN_CVAR(Int, vid_defheight)
 
-FARG(0, "", "", "", "");
+FARG(0, "Debug", "Resets window position.", "",
+	"Resets the window position to the top-left corner of the screen.");
 
 //==========================================================================
 //

--- a/src/common/platform/win32/base_sysfb.cpp
+++ b/src/common/platform/win32/base_sysfb.cpp
@@ -4,6 +4,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 2003-2005 Tim Stump
 ** Copyright 2005-2016 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -59,6 +61,8 @@ extern "C" {
 
 EXTERN_CVAR(Int, vid_defwidth)
 EXTERN_CVAR(Int, vid_defheight)
+
+FARG(0, "", "", "", "");
 
 //==========================================================================
 //
@@ -131,7 +135,7 @@ void SystemBaseFrameBuffer::KeepWindowOnScreen(int &winx, int &winy, int winw, i
 void SystemBaseFrameBuffer::SaveWindowedPos()
 {
 	// Don't save if we were run with the -0 option.
-	if (Args->CheckParm("-0"))
+	if (Args->CheckParm(FArg_0))
 	{
 		return;
 	}
@@ -186,7 +190,7 @@ void SystemBaseFrameBuffer::RestoreWindowedPos()
 	GetCenteredPos(win_w, win_h, winx, winy, winw, winh, scrwidth, scrheight);
 
 	// Just move to (0,0) if we were run with the -0 option.
-	if (Args->CheckParm("-0"))
+	if (Args->CheckParm(FArg_0))
 	{
 		winx = winy = 0;
 	}
@@ -204,7 +208,7 @@ void SystemBaseFrameBuffer::RestoreWindowedPos()
 	}
 	SetWindowPos(mainwindow.GetHandle(), nullptr, winx, winy, winw, winh, SWP_NOZORDER | SWP_FRAMECHANGED);
 
-	if (win_maximized && !Args->CheckParm("-0"))
+	if (win_maximized && !Args->CheckParm(FArg_0))
 		ShowWindow(mainwindow.GetHandle(), SW_MAXIMIZE);
 }
 
@@ -237,7 +241,7 @@ void SystemBaseFrameBuffer::SetWindowSize(int w, int h)
 		GetCenteredPos(w, h, winx, winy, winw, winh, scrwidth, scrheight);
 
 		// Just move to (0,0) if we were run with the -0 option.
-		if (Args->CheckParm("-0"))
+		if (Args->CheckParm(FArg_0))
 		{
 			winx = winy = 0;
 		}

--- a/src/common/platform/win32/base_sysfb.h
+++ b/src/common/platform/win32/base_sysfb.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "m_argv.h"
 #include "v_video.h"
+
+EXTERN_FARG(0);
 
 class SystemBaseFrameBuffer : public DFrameBuffer
 {

--- a/src/common/platform/win32/i_dijoy.cpp
+++ b/src/common/platform/win32/i_dijoy.cpp
@@ -7,6 +7,7 @@
 **
 ** Copyright 2005-2016 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -293,6 +294,7 @@ protected:
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
 
 extern LPDIRECTINPUT8 g_pdi;
+EXTERN_FARG(nojoy);
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
@@ -1561,7 +1563,7 @@ IJoystickConfig *FDInputJoystickManager::Rescan()
 
 void I_StartupDirectInputJoystick()
 {
-	if (!joy_dinput || !use_joystick || Args->CheckParm("-nojoy"))
+	if (!joy_dinput || !use_joystick || Args->CheckParm(FArg_nojoy))
 	{
 		if (JoyDevices[INPUT_DIJoy] != NULL)
 		{

--- a/src/common/platform/win32/i_input.cpp
+++ b/src/common/platform/win32/i_input.cpp
@@ -131,7 +131,8 @@ EXTERN_CVAR(Bool, i_pauseinbackground);
 
 CVAR (Bool, k_allowfullscreentoggle, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
-FARG(noidle, "", "", "", "");
+FARG_ADVANCED(noidle, "Deprecated", "",
+	"No longer has any effect. Used to reduce priority class when window was in background.");
 
 static void I_CheckGUICapture ()
 {

--- a/src/common/platform/win32/i_input.cpp
+++ b/src/common/platform/win32/i_input.cpp
@@ -6,6 +6,7 @@
 **---------------------------------------------------------------------------
 ** Copyright 1998-2009 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -129,6 +130,8 @@ bool win32EnableInput = true;
 EXTERN_CVAR(Bool, i_pauseinbackground);
 
 CVAR (Bool, k_allowfullscreentoggle, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+
+FARG(noidle, "", "", "", "");
 
 static void I_CheckGUICapture ()
 {
@@ -511,7 +514,7 @@ bool I_InitInput (void *hwnd)
 
 	Printf ("I_InitInput\n");
 
-	noidle = !!Args->CheckParm ("-noidle");
+	noidle = !!Args->CheckParm (FArg_noidle);
 	g_pdi = NULL;
 
 	hr = DirectInput8Create(g_hInst, DIRECTINPUT_VERSION, IID_IDirectInput8, (void **)&g_pdi, NULL);

--- a/src/common/platform/win32/i_main.cpp
+++ b/src/common/platform/win32/i_main.cpp
@@ -112,6 +112,7 @@ void SignalHandler(int signal);
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
 
+extern const char * const BACKEND = "Win32";
 extern EXCEPTION_POINTERS CrashPointers;
 extern UINT TimerPeriod;
 EXTERN_FARG(0);

--- a/src/common/platform/win32/i_main.cpp
+++ b/src/common/platform/win32/i_main.cpp
@@ -5,6 +5,7 @@
 **---------------------------------------------------------------------------
 ** Copyright 1998-2009 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -79,6 +80,7 @@
 #include "i_interface.h"
 #include "startupinfo.h"
 #include "printf.h"
+#include "base_sysfb.h"
 
 #include "i_mainwindow.h"
 
@@ -112,6 +114,14 @@ void SignalHandler(int signal);
 
 extern EXCEPTION_POINTERS CrashPointers;
 extern UINT TimerPeriod;
+EXTERN_FARG(0);
+EXTERN_FARG(norun);
+EXTERN_FARG(help);
+EXTERN_FARG(h);
+EXTERN_FARG(doshelp);
+EXTERN_FARG(help_all);
+EXTERN_FARG(version);
+EXTERN_FARG(v);
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
@@ -123,6 +133,9 @@ HANDLE			MainThread;
 DWORD			MainThreadID;
 HANDLE			StdOut;
 bool			FancyStdOut, AttachedStdOut;
+
+// use custom here, because types are confusing sometimes
+FARG_CUSTOM(stdout, "-stdout", "", false, "", "", "");
 
 // CODE --------------------------------------------------------------------
 
@@ -196,7 +209,7 @@ int DoMain (HINSTANCE hInstance)
 	auto wargv = __wargv;
 	for (int i = 0; i < argc; i++)
 	{
-		Args->AppendArg(FString(wargv[i]));
+		Args->AppendRawArg(FString(wargv[i]));
 	}
 
 	if (isConsoleApp())
@@ -214,7 +227,16 @@ int DoMain (HINSTANCE hInstance)
 				FancyStdOut = IsWindows10OrGreater(); // Windows 8.1 and lower do not understand ANSI formatting.
 		}
 	}
-	else if (Args->CheckParm("-stdout") || Args->CheckParm("-norun"))
+	else if (
+		Args->CheckParm(FArg_stdout)
+		|| Args->CheckParm(FArg_norun)
+		|| Args->CheckParm(FArg_help)
+		|| Args->CheckParm(FArg_h)
+		|| Args->CheckParm(FArg_help_all)
+		|| Args->CheckParm(FArg_doshelp)
+		|| Args->CheckParm(FArg_version)
+		|| Args->CheckParm(FArg_v)
+	)
 	{
 		// As a GUI application, we don't normally get a console when we start.
 		// If we were run from the shell and are on XP+, we can attach to its
@@ -302,7 +324,7 @@ int DoMain (HINSTANCE hInstance)
 	x = (displaysettings.dmPelsWidth - width) / 2;
 	y = (displaysettings.dmPelsHeight - height) / 2;
 
-	if (Args->CheckParm ("-0"))
+	if (Args->CheckParm (FArg_0))
 	{
 		x = y = 0;
 	}

--- a/src/common/platform/win32/i_main.cpp
+++ b/src/common/platform/win32/i_main.cpp
@@ -136,7 +136,9 @@ HANDLE			StdOut;
 bool			FancyStdOut, AttachedStdOut;
 
 // use custom here, because types are confusing sometimes
-FARG_CUSTOM(stdout, "-stdout", "", false, "", "", "");
+FARG_CUSTOM(stdout, "-stdout", "Debug", false, "Print output to system console", "",
+	"(Win32 only)\nSends all output to a system console. Unix and MacOS builds of ZDoom will"
+	" always do that.");
 
 // CODE --------------------------------------------------------------------
 

--- a/src/common/platform/win32/i_rawps2.cpp
+++ b/src/common/platform/win32/i_rawps2.cpp
@@ -4,6 +4,8 @@
 **---------------------------------------------------------------------------
 **
 ** Copyright 2005-2016 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -237,6 +239,8 @@ struct PS2Descriptor
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
+
+EXTERN_FARG(nojoy);
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
@@ -1484,7 +1488,7 @@ void FRawPS2Manager::DoRegister()
 
 void I_StartupRawPS2()
 {
-	if (!joy_ps2raw || !use_joystick || Args->CheckParm("-nojoy"))
+	if (!joy_ps2raw || !use_joystick || Args->CheckParm(FArg_nojoy))
 	{
 		if (JoyDevices[INPUT_RawPS2] != NULL)
 		{

--- a/src/common/platform/win32/i_system.cpp
+++ b/src/common/platform/win32/i_system.cpp
@@ -4,9 +4,10 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2009 Randy Heit
-** Copyright (C) 2007-2012 Skulltag Development Team
-** Copyright (C) 2007-2016 Zandronum Development Team
-** Copyright (C) 2017-2022 GZDoom Development Team
+** Copyright 2007-2012 Skulltag Development Team
+** Copyright 2007-2016 Zandronum Development Team
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -150,7 +151,7 @@ static HCURSOR CustomCursor;
 //
 //==========================================================================
 
-void I_DetectOS(void)
+FString I_DetectOS(void)
 {
 	OSVERSIONINFOEX info;
 	const char *osname;
@@ -204,12 +205,14 @@ void I_DetectOS(void)
 		break;
 	}
 
-	if (!batchrun) Printf ("OS: Windows %s (NT %lu.%lu) Build %lu\n    %s\n",
-			osname,
-			info.dwMajorVersion, info.dwMinorVersion,
-			info.dwBuildNumber, info.szCSDVersion);
+	auto nicename = FStringf("Windows %s (NT %lu.%lu) Build %lu %s",
+		osname,
+		info.dwMajorVersion, info.dwMinorVersion,
+		info.dwBuildNumber, info.szCSDVersion);
 
 	sys_ostype = osname;
+
+	return nicename;
 }
 
 //==========================================================================

--- a/src/common/platform/win32/i_system.h
+++ b/src/common/platform/win32/i_system.h
@@ -1,4 +1,3 @@
-
 #ifndef __I_SYSTEM__
 #define __I_SYSTEM__
 
@@ -12,7 +11,7 @@ struct WadStuff;
 struct FStartupSelectionInfo;
 
 // [RH] Detects the OS the game is running under.
-void I_DetectOS (void);
+FString I_DetectOS (void);
 
 // Called by DoomMain.
 void CalculateCPUSpeed (void);

--- a/src/common/platform/win32/i_xinput.cpp
+++ b/src/common/platform/win32/i_xinput.cpp
@@ -7,6 +7,7 @@
 **
 ** Copyright 2005-2016 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -210,6 +211,8 @@ protected:
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
+
+EXTERN_FARG(nojoy);
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
@@ -1062,7 +1065,7 @@ IJoystickConfig *FXInputManager::Rescan()
 
 void I_StartupXInput()
 {
-	if (!joy_xinput || !use_joystick || Args->CheckParm("-nojoy"))
+	if (!joy_xinput || !use_joystick || Args->CheckParm(FArg_nojoy))
 	{
 		if (JoyDevices[INPUT_XInput] != NULL)
 		{

--- a/src/common/rendering/gl_load/gl_interface.cpp
+++ b/src/common/rendering/gl_load/gl_interface.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 2005-2019 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -46,6 +48,8 @@ static TArray<FString>  m_Extensions;
 RenderContext gl;
 static double realglversion;
 static bool bindless;
+
+FARG(glversion, "", "", "", "");
 
 //==========================================================================
 //
@@ -115,7 +119,7 @@ void gl_LoadExtensions()
 
 	const char *glversion = (const char*)glGetString(GL_VERSION);
 
-	const char *version = Args->CheckValue("-glversion");
+	const char *version = Args->CheckValue(FArg_glversion);
 	realglversion = strtod(glversion, NULL);
 
 

--- a/src/common/rendering/gl_load/gl_interface.cpp
+++ b/src/common/rendering/gl_load/gl_interface.cpp
@@ -49,7 +49,8 @@ RenderContext gl;
 static double realglversion;
 static bool bindless;
 
-FARG(glversion, "", "", "", "");
+FARG(glversion, "", "", "",
+	"");
 
 //==========================================================================
 //

--- a/src/common/rendering/gl_load/gl_interface.h
+++ b/src/common/rendering/gl_load/gl_interface.h
@@ -1,6 +1,7 @@
 #ifndef R_RENDER
 #define R_RENDER
 
+#include "m_argv.h"
 struct RenderContext
 {
 	unsigned int flags;
@@ -14,6 +15,8 @@ struct RenderContext
 };
 
 extern RenderContext gl;
+
+EXTERN_FARG(glversion);
 
 #endif
 

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -4,6 +4,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 1999-2016 Randy Heit
 ** Copyright 2005-2016 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -65,6 +67,8 @@
 
 EXTERN_CVAR(Int, menu_resolution_custom_width)
 EXTERN_CVAR(Int, menu_resolution_custom_height)
+
+EXTERN_FARG(devparm);
 
 CVAR(Int, win_x, -1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, win_y, -1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
@@ -150,7 +154,8 @@ CUSTOM_CVAR(Int, uiscale, 0, CVAR_ARCHIVE | CVAR_NOINITCALL)
 	setsizeneeded = true;
 }
 
-
+FARG(width, "", "", "", "");
+FARG(height, "", "", "", "");
 
 EXTERN_CVAR(Bool, r_blendmethod)
 
@@ -361,10 +366,10 @@ void V_InitScreenSize ()
 
 	width = height = bits = 0;
 
-	if ( (i = Args->CheckValue ("-width")) )
+	if ( (i = Args->CheckValue (FArg_width)) )
 		width = atoi (i);
 
-	if ( (i = Args->CheckValue ("-height")) )
+	if ( (i = Args->CheckValue (FArg_height)) )
 		height = atoi (i);
 
 	if (width == 0)
@@ -403,7 +408,7 @@ void V_Init2()
 
 	UCVarValue val;
 
-	val.Bool = !!Args->CheckParm("-devparm");
+	val.Bool = !!Args->CheckParm(FArg_devparm);
 	ticker->SetGenericRepDefault(val, CVAR_Bool);
 
 

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -154,10 +154,22 @@ CUSTOM_CVAR(Int, uiscale, 0, CVAR_ARCHIVE | CVAR_NOINITCALL)
 	setsizeneeded = true;
 }
 
-FARG(width, "", "", "", "");
-FARG(height, "", "", "", "");
+EXTERN_CVAR(Bool, r_blendmethod);
 
-EXTERN_CVAR(Bool, r_blendmethod)
+FARG(width, "Configuration", "Sets " GAMENAME "'s horizontal resolution.", "x",
+	"Specifies the desired resolution of the screen. If only one of -width or -height is"
+	" specified, " GAMENAME " will try to guess the other one based on a standard aspect ratio. If"
+	" the specified resolution is not supported by your SDL/DirectDraw drivers, " GAMENAME " will"
+	" try various resolutions until it either finds one that works, or it will finally give up. To"
+	" determine which resolutions " GAMENAME " can use, use the vid_describemodes command from the"
+	" console once you have started the game.");
+FARG(height, "Configuration", "Sets " GAMENAME "'s vertical resolution.", "y",
+	"Specifies the desired resolution of the screen. If only one of -width or -height is"
+	" specified, " GAMENAME " will try to guess the other one based on a standard aspect ratio. If"
+	" the specified resolution is not supported by your SDL/DirectDraw drivers, " GAMENAME " will"
+	" try various resolutions until it either finds one that works, or it will finally give up. To"
+	" determine which resolutions " GAMENAME " can use, use the vid_describemodes command from the"
+	" console once you have started the game.");
 
 int active_con_scale();
 

--- a/src/common/scripting/backend/vmbuilder.cpp
+++ b/src/common/scripting/backend/vmbuilder.cpp
@@ -4,6 +4,8 @@
 **---------------------------------------------------------------------------
 ** Copyright -2016 Randy Heit
 ** Copyright 2016-2017 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -42,8 +44,13 @@
 CVAR(Bool, strictdecorate, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 CVAR(Bool, warningstoerrors, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 
+FARG(dumpjitmod, "", "", "", "");
+FARG(dumpdisasm, "", "", "", "");
+
 EXTERN_CVAR(Bool, vm_jit)
 EXTERN_CVAR(Bool, vm_jit_aot)
+
+EXTERN_FARG(dumpjit);
 
 struct VMRemap
 {
@@ -975,8 +982,8 @@ void FFunctionBuildList::Build()
 
 	if (FScriptPosition::ErrorCounter == 0)
 	{
-		if (Args->CheckParm("-dumpjit")) DumpJit(true);
-		else if (Args->CheckParm("-dumpjitmod")) DumpJit(false);
+		if (Args->CheckParm(FArg_dumpjit)) DumpJit(true);
+		else if (Args->CheckParm(FArg_dumpjitmod)) DumpJit(false);
 	}
 	mItems.Clear();
 	mItems.ShrinkToFit();
@@ -1202,12 +1209,10 @@ ExpEmit FunctionCallEmitter::EmitCall(VMFunctionBuilder *build, TArray<ExpEmit> 
 
 VMDisassemblyDumper::VMDisassemblyDumper(const FileOperationType operation)
 {
-	static const char *const DUMP_ARG_NAME = "-dumpdisasm";
-
-	if (Args->CheckParm(DUMP_ARG_NAME))
+	if (Args->CheckParm(FArg_dumpdisasm))
 	{
 		dump = fopen("disasm.txt", operation == Overwrite ? "w" : "a");
-		namefilter = Args->CheckValue(DUMP_ARG_NAME);
+		namefilter = Args->CheckValue(FArg_dumpdisasm);
 		namefilter.ToLower();
 	}
 }

--- a/src/common/scripting/backend/vmbuilder.cpp
+++ b/src/common/scripting/backend/vmbuilder.cpp
@@ -44,8 +44,10 @@
 CVAR(Bool, strictdecorate, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 CVAR(Bool, warningstoerrors, false, CVAR_GLOBALCONFIG | CVAR_ARCHIVE)
 
-FARG(dumpjitmod, "", "", "", "");
-FARG(dumpdisasm, "", "", "", "");
+FARG(dumpjitmod, "", "", "",
+	"");
+FARG_ADVANCED(dumpdisasm , "Debug", "",
+	"Dissembles compiled VM code and dumps output to disasm.txt");
 
 EXTERN_CVAR(Bool, vm_jit)
 EXTERN_CVAR(Bool, vm_jit_aot)

--- a/src/common/scripting/backend/vmbuilder.h
+++ b/src/common/scripting/backend/vmbuilder.h
@@ -2,6 +2,7 @@
 #define VMUTIL_H
 
 #include "dobject.h"
+#include "m_argv.h"
 #include "vmintern.h"
 #include <vector>
 #include <functional>

--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -295,8 +295,11 @@ static void InitTokenMap()
 #undef TOKENDEF
 #undef TOKENDEF2
 
-FARG(dumpast, "", "", "", "");
-FARG(tracefile, "", "", "", "");
+FARG_ADVANCED(dumpast, "Debug", "",
+	"Writes ZScript AST in a LISP-like format to a file");
+FARG_ADVANCED(tracefile, "Debug", "",
+	"Invokes Lemon's debug tracer output to print messages for every change of the parser state."
+	" See https://sqlite.org/src/doc/trunk/doc/lemon.html");
 
 //**--------------------------------------------------------------------------
 

--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -4,6 +4,7 @@
 **---------------------------------------------------------------------------
 ** Copyright -2016 Randy Heit
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -294,6 +295,9 @@ static void InitTokenMap()
 #undef TOKENDEF
 #undef TOKENDEF2
 
+FARG(dumpast, "", "", "", "");
+FARG(tracefile, "", "", "", "");
+
 //**--------------------------------------------------------------------------
 
 static void ParseSingleFile(FScanner *pSC, const char *filename, int lump, void *parser, ZCCParseState &state)
@@ -430,7 +434,7 @@ PNamespace *ParseOneScript(const int baselump, ZCCParseState &state)
 
 #ifndef NDEBUG
 	FILE *f = nullptr;
-	const char *tracefile = Args->CheckValue("-tracefile");
+	const char *tracefile = Args->CheckValue(FArg_tracefile);
 	if (tracefile != nullptr)
 	{
 		f = fopen(tracefile, "w");
@@ -524,7 +528,7 @@ PNamespace *ParseOneScript(const int baselump, ZCCParseState &state)
 #endif
 
 	// Make a dump of the AST before running the compiler for diagnostic purposes.
-	if (Args->CheckParm("-dumpast"))
+	if (Args->CheckParm(FArg_dumpast))
 	{
 		FString ast = ZCC_PrintAST(state.TopNode);
 		FString filename = fileSystem.GetFileFullPath(baselump).c_str();

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -344,7 +344,9 @@ FStartScreen* CreateHereticStartScreen(int max_progress);
 FStartScreen* CreateStrifeStartScreen(int max_progress);
 FStartScreen* CreateGenericStartScreen(int max_progress);
 
-FARG(nostartup, "", "", "", "");
+FARG(nostartup, "Configuration", "Forces use of text-mode startup screen.", "",
+	"Disables the startup screens used by Heretic, Hexen and Strife, and use the Doom text-mode"
+	" startup instead.");
 
 FStartScreen* GetGameStartScreen(int max_progress)
 {

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -5,6 +5,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 2006-2007 Randy Heit
 ** Copyright 2006-2022 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -342,10 +344,11 @@ FStartScreen* CreateHereticStartScreen(int max_progress);
 FStartScreen* CreateStrifeStartScreen(int max_progress);
 FStartScreen* CreateGenericStartScreen(int max_progress);
 
+FARG(nostartup, "", "", "", "");
 
 FStartScreen* GetGameStartScreen(int max_progress)
 {
-	if (!Args->CheckParm("-nostartup"))
+	if (!Args->CheckParm(FArg_nostartup))
 	{
 		try
 		{

--- a/src/common/utility/m_argv.cpp
+++ b/src/common/utility/m_argv.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -32,9 +34,50 @@
 **
 */
 
-#include <string.h>
+#include <cassert>
 #include "m_argv.h"
+#include "name.h"
+#include "tarray.h"
 #include "zstring.h"
+
+#ifdef __linux
+#include <sys/ioctl.h>
+#include <unistd.h>
+#endif
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+FArg::FArg(
+	const char * _name,
+	const char * _section,
+	const char * _summary,
+	const char * _usage,
+	const char * _details,
+	bool _advanced
+):
+	name(_name),
+	section(_section),
+	summary(_summary),
+	usage(_usage),
+	advanced(_advanced)
+{
+	assert(FArg::Available().CheckKey(name) == nullptr);
+
+	if (section == "")
+	{
+		section = "Unknown";
+		advanced = true;
+	}
+
+	details = (strlen(_details) > 0)
+		? _details
+		: _summary;
+
+	FArg::Available().Insert(name, this);
+}
 
 //===========================================================================
 //
@@ -65,7 +108,7 @@ FArgs::FArgs(const FArgs &other)
 
 FArgs::FArgs(int argc, char **argv)
 {
-	SetArgs(argc, argv);
+	SetRawArgs(argc, argv);
 }
 
 //===========================================================================
@@ -76,7 +119,7 @@ FArgs::FArgs(int argc, char **argv)
 
 FArgs::FArgs(int argc, const char** argv)
 {
-	SetArgs(argc, const_cast<char **>(argv));	// Thanks, C++, for the inflexible const casting rules...
+	SetRawArgs(argc, const_cast<char **>(argv));	// Thanks, C++, for the inflexible const casting rules...
 }
 
 //===========================================================================
@@ -87,10 +130,8 @@ FArgs::FArgs(int argc, const char** argv)
 
 FArgs::FArgs(int argc, FString *argv)
 {
-	AppendArgs(argc, argv);
+	AppendRawArgs(argc, argv);
 }
-
-
 
 //===========================================================================
 //
@@ -106,11 +147,11 @@ FArgs &FArgs::operator=(const FArgs &other)
 
 //===========================================================================
 //
-// FArgs :: SetArgs
+// FArgs :: SetRawArgs
 //
 //===========================================================================
 
-void FArgs::SetArgs(int argc, char **argv)
+void FArgs::SetRawArgs(int argc, char **argv)
 {
 	Argv.Resize(argc);
 	for (int i = 0; i < argc; ++i)
@@ -139,26 +180,28 @@ void FArgs::FlushArgs()
 //
 //===========================================================================
 
-int stricmp(const char** check, const char* str)
+
+int FArgs::CheckParm(const FArg check, int start) const
+{
+	const FArg * array[] = { &check, nullptr };
+	return CheckParm(array, start);
+}
+
+int FArgs::TestArgList(const FArg** check, const char* str)
 {
 	for (int i = 0; check[i]; i++)
 	{
-		if (!stricmp(check[i], str)) return 0;
+		const char * name = check[i]->name.GetChars();
+		if (!stricmp(name, str)) return 0;
 	}
 	return 1;	// we do not care about order here.
 }
 
-int FArgs::CheckParm(const char* check, int start) const
-{
-	const char* array[] = { check, nullptr };
-	return CheckParm(array, start);
-}
-
-int FArgs::CheckParm(const char** check, int start) const
+int FArgs::CheckParm(const FArg ** check, int start) const
 {
 	for (unsigned i = start; i < Argv.Size(); ++i)
 	{
-		if (0 == stricmp(check, Argv[i].GetChars()))
+		if (0 == TestArgList(check, Argv[i].GetChars()))
 		{
 			return i;
 		}
@@ -175,7 +218,7 @@ int FArgs::CheckParm(const char** check, int start) const
 //
 //===========================================================================
 
-int FArgs::CheckParmList(const char *check, FString **strings, int start) const
+int FArgs::CheckParmList(const FArg check, FString **strings, int start) const
 {
 	unsigned int i, parmat = CheckParm(check, start);
 
@@ -210,7 +253,7 @@ int FArgs::CheckParmList(const char *check, FString **strings, int start) const
 //
 //===========================================================================
 
-const char *FArgs::CheckValue(const char *check) const
+const char * FArgs::CheckValue(const FArg check) const
 {
 	int i = CheckParm(check);
 
@@ -234,7 +277,7 @@ const char *FArgs::CheckValue(const char *check) const
 //
 //===========================================================================
 
-FString FArgs::TakeValue(const char *check)
+FString FArgs::TakeValue(const FArg check)
 {
 	int i = CheckParm(check);
 	FString out;
@@ -260,13 +303,13 @@ FString FArgs::TakeValue(const char *check)
 //
 //===========================================================================
 
-void FArgs::RemoveArgs(const char *check)
+void FArgs::RemoveArgs(const FArg check)
 {
 	int i = CheckParm(check);
 
 	if (i > 0 && i < (int)Argv.Size() - 1)
 	{
-		do 
+		do
 		{
 			RemoveArg(i);
 		}
@@ -313,6 +356,21 @@ int FArgs::NumArgs() const
 
 //===========================================================================
 //
+// FArgs :: AppendRawArg
+//
+// Adds another argument to argv. Invalidates any previous results from
+// GetArgList(). This is to only be used for parsing text from external
+// sources, not from internal sources
+//
+//===========================================================================
+
+void FArgs::AppendRawArg(FString arg)
+{
+	Argv.Push(arg);
+}
+
+//===========================================================================
+//
 // FArgs :: AppendArg
 //
 // Adds another argument to argv. Invalidates any previous results from
@@ -320,20 +378,22 @@ int FArgs::NumArgs() const
 //
 //===========================================================================
 
-void FArgs::AppendArg(FString arg)
+void FArgs::AppendArg(const FArg arg)
 {
-	Argv.Push(arg);
+	Argv.Push(arg.name.GetChars());
 }
 
 //===========================================================================
 //
-// FArgs :: AppendArgs
+// FArgs :: AppendRawArgs
 //
-// Adds an array of FStrings to argv.
+// Adds an array of FStrings to argv. Invalidates any previous results from
+// GetArgList(). This is to only be used for parsing text from external
+// sources, not from internal sources
 //
 //===========================================================================
 
-void FArgs::AppendArgs(int argc, const FString *argv)
+void FArgs::AppendRawArgs(int argc, const FString *argv)
 {
 	if (argv != NULL && argc > 0)
 	{
@@ -347,14 +407,16 @@ void FArgs::AppendArgs(int argc, const FString *argv)
 
 //===========================================================================
 //
-// FArgs :: AppendArgsString
+// FArgs :: AppendRawArgsString
 //
-// Adds extra args as a space-separated string, supporting simple quoting, and inserting -file args into the right place
+// Adds extra args as a space-separated string, supporting simple quoting,
+// and inserting -file args into the right place. Invalidates any previous
+// results from GetArgList(). This is to only be used for parsing text from
+// externalw sources, not from internal sources
 //
 //===========================================================================
 
-
-void FArgs::AppendArgsString(FString argv)
+void FArgs::AppendRawArgsString(FString argv)
 {
 	auto file_index = Argv.Find("-file");
 	auto files_end = file_index + 1;
@@ -477,10 +539,32 @@ void FArgs::RemoveArg(int argindex)
 //
 //===========================================================================
 
-void FArgs::CollectFiles(const char* param, const char* extension)
+void FArgs::CollectFiles(const FArg arg, const char* extension)
 {
+	const char * param = arg.name.GetChars();
 	const char* array[] = { param, nullptr };
 	CollectFiles(param, array, extension);
+}
+
+int stricmp(const char** check, const char* str)
+{
+	for (int i = 0; check[i]; i++)
+	{
+		if (!stricmp(check[i], str)) return 0;
+	}
+	return 1;	// we do not care about order here.
+}
+
+int _CheckParm(TArray<FString> Argv, const char ** check, int start)
+{
+	for (unsigned i = start; i < Argv.Size(); ++i)
+	{
+		if (0 == stricmp(check, Argv[i].GetChars()))
+		{
+			return i;
+		}
+	}
+	return 0;
 }
 
 void FArgs::CollectFiles(const char *finalname, const char **param, const char *extension)
@@ -516,7 +600,7 @@ void FArgs::CollectFiles(const char *finalname, const char **param, const char *
 	}
 
 	// Step 2: Find each occurence of -param and add its arguments to work.
-	while ((i = CheckParm(param, i)) > 0)
+	while ((i = _CheckParm(Argv, param, i)) > 0)
 	{
 		Argv.Delete(i);
 		while (i < Argv.Size() && Argv[i][0] != '-' && Argv[i][0] != '+')
@@ -538,7 +622,7 @@ void FArgs::CollectFiles(const char *finalname, const char **param, const char *
 	if (work.Size() > 0)
 	{
 		Argv.Push(finalname);
-		AppendArgs(work.Size(), &work[0]);
+		AppendRawArgs(work.Size(), &work[0]);
 	}
 }
 
@@ -552,7 +636,7 @@ void FArgs::CollectFiles(const char *finalname, const char **param, const char *
 //
 //===========================================================================
 
-FArgs *FArgs::GatherFiles(const char *param) const
+FArgs *FArgs::GatherFiles(const FArg param) const
 {
 	FString *files;
 	int filecount;

--- a/src/common/utility/m_argv.cpp
+++ b/src/common/utility/m_argv.cpp
@@ -37,6 +37,7 @@
 #include <cassert>
 #include "m_argv.h"
 #include "name.h"
+#include "printf.h"
 #include "tarray.h"
 #include "zstring.h"
 
@@ -77,6 +78,164 @@ FArg::FArg(
 		: _summary;
 
 	FArg::Available().Insert(name, this);
+}
+
+void FArgs::PrintHelpMessage(bool full)
+{
+	int fullwidth = 80;
+
+	// I tried using TEXTCOLOR_BOLD and TEXTCOLOR_OFF, but they just make white text. :(
+	// Also, these are supported on the windows 10 terminal, so I see no reason to disable them on windows.
+#define OFF "\x1b[0m"
+#define BOLD "\x1b[1m"
+#define DIM "\x1b[2m"
+
+#if defined(__linux)
+	if (isatty(STDOUT_FILENO))
+	{
+		struct winsize sizeOfWindow;
+		ioctl(STDOUT_FILENO, TIOCGWINSZ, &sizeOfWindow);
+		fullwidth = sizeOfWindow.ws_col;
+	}
+#elif defined(_WIN32)
+	HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+
+	if (hConsole != INVALID_HANDLE_VALUE && GetConsoleScreenBufferInfo(hConsole, &csbi))
+	{
+		fullwidth = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+	}
+#endif
+
+	TMap<FName, TMap<FString, FArg>> args;
+	TArray<FName> sections;
+	int maxlen = 0;
+
+	{
+		TMapIterator<FString, FArg *> it(FArg::Available());
+		TMap<FString, FArg*>::Pair * pair;
+
+		while (it.NextPair(pair))
+		{
+			if (pair->Value->advanced && !full) continue;
+
+			auto* sectionMap = args.CheckKey(pair->Value->section);
+			if (!sectionMap)
+			{
+				TMap<FString, FArg> newMap;
+				args.Insert(pair->Value->section, newMap);
+				sections.Push(pair->Value->section.GetChars());
+				sectionMap = args.CheckKey(pair->Value->section);
+			}
+
+			sectionMap->Insert(pair->Key, *pair->Value);
+
+			int len = strlen(pair->Key.GetChars());
+			if (maxlen < len) maxlen = len;
+		}
+	}
+
+	std::sort(sections.begin(), sections.end());
+
+	int indent = maxlen + 1;
+	bool breaklines = indent >= fullwidth / 2;
+	if (breaklines) indent = 4;
+	maxlen = fullwidth - indent - 1;
+
+	for (int i = 0; i < sections.SSize(); i++)
+	{
+		auto section = * args.CheckKey(sections[i]);
+		TArray<FString> lines;
+
+		{
+			TMapIterator<FString, FArg> it(section);
+			TMap<FString, FArg>::Pair * pair;
+			while (it.NextPair(pair))
+			{
+				lines.Push(pair->Value.name.GetChars());
+			}
+			std::sort(lines.begin(), lines.end());
+		}
+
+		Printf(
+			"\n" BOLD "%s%s options:" OFF "\n",
+			FString(sections[i].GetChars()).Left(1).MakeUpper().GetChars(),
+			FString(sections[i].GetChars()).Mid(1).MakeLower().GetChars()
+		);
+
+		if (breaklines)
+		{
+			for (int j = 0; j < lines.SSize(); j++)
+			{
+				auto arg = section.CheckKey(lines[j]);
+
+				auto name = arg->name;
+				auto usage = (!full || arg->usage.IsEmpty())
+					? ""
+					: FStringf(" " DIM "%s" OFF, arg->usage.GetChars());
+				auto blurb = full? arg->details: arg->summary;
+
+				Printf("\n" BOLD "%s" OFF "%s\n%s\n", name.GetChars(), usage.GetChars(), blurb.GetChars());
+			}
+		}
+		else
+		{
+			auto fformat = FStringf(BOLD "%%%ds" OFF " %%s\n", indent);
+			auto format = fformat.GetChars();
+
+			if (!full) Printf("\n");
+
+			for (int j = 0; j < lines.SSize(); j++)
+			{
+				auto arg = section.CheckKey(lines[j]);
+				auto desc = (!full)
+					? arg->summary
+					: (arg->usage.IsEmpty())
+						? arg->details
+						: FStringf(DIM "%s" OFF "\n%s", arg->usage.GetChars(), arg->details.GetChars());
+
+				FString left = arg->name.GetChars(), right;
+				int space, nextSpace = 0;
+				left.ToLower();
+
+				if (full) Printf("\n");
+
+				do
+				{
+					int nextBreak = desc.IndexOf("\n", nextSpace+1);
+
+					if (nextBreak != -1 || desc.Len() > unsigned(maxlen))
+					{
+						do
+						{
+							space = nextSpace;
+
+							nextBreak = desc.IndexOf("\n", nextSpace+1);
+							nextSpace = desc.IndexOf(" ", nextSpace+1);
+
+							if (nextBreak > -1 && nextBreak < nextSpace)
+							{
+								space = nextBreak;
+								break;
+							}
+						} while (nextSpace > -1 && nextSpace < maxlen);
+
+						right = desc.Left(space);
+						desc = desc.Mid(space + 1);
+						nextSpace = 0;
+					}
+					else
+					{
+						right = desc;
+						desc = "";
+					}
+
+					Printf(format, left.GetChars(), right.GetChars());
+					left = "";
+				} while (desc.Len() > 0);
+			}
+		}
+	}
 }
 
 //===========================================================================

--- a/src/common/utility/m_argv.h
+++ b/src/common/utility/m_argv.h
@@ -3,6 +3,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -34,8 +36,46 @@
 #ifndef __M_ARGV_H__
 #define __M_ARGV_H__
 
+#include "name.h"
 #include "tarray.h"
 #include "zstring.h"
+
+class FArg {
+friend class FArgs;
+
+public:
+	FArg(
+		const char * name,
+		const char * section,
+		const char * summary,
+		const char * usage,
+		const char * details,
+		bool advanced = false
+	);
+
+protected:
+	FString name;
+	FName section;
+	FString summary, usage, details;
+	bool advanced;
+
+    static TMap<FString, FArg *>& Available() {
+		static TMap<FString, FArg *> Map;
+		return Map;
+	}
+};
+
+#define EXTERN_FARG(argument) \
+	extern FArg FArg_##argument
+
+#define FARG_CUSTOM(name, argument, section, advanced, summary, usage, details) \
+	FArg FArg_##name (argument, section, summary, usage, details, advanced)
+
+#define FARG(argument, section, summary, usage, details) \
+	FARG_CUSTOM(argument, "-" #argument, section, false, summary, usage, details)
+
+#define FARG_ADVANCED(argument, section, usage, details) \
+	FARG_CUSTOM(argument, "-" #argument, section, true, details, usage, "")
 
 //
 // MISC
@@ -83,30 +123,36 @@ public:
 	FArgs &operator=(const FArgs &other);
 	const FString& operator[](size_t index) { return Argv[index]; }
 
-	void AppendArg(FString arg);
-	void AppendArgs(int argc, const FString *argv);
-	void AppendArgsString(FString argv);
-	void RemoveArg(int argindex);
-	void RemoveArgs(const char *check);
-	void SetArgs(int argc, char **argv);
-	void CollectFiles(const char *finalname, const char** param, const char* extension);
-	void CollectFiles(const char *param, const char *extension);
-	FArgs *GatherFiles(const char *param) const;
-	void SetArg(int argnum, const char *arg);
+	void AppendRawArg(FString arg);
+	void AppendRawArgsString(FString argv);
 
-	int CheckParm(const char *check, int start=1) const;	// Returns the position of the given parameter in the arg list (0 if not found).
-	int CheckParm(const char** check, int start = 1) const;	// Returns the position of the given parameter in the arg list (0 if not found). Allows checking for multiple switches
-	int CheckParmList(const char *check, FString **strings, int start=1) const;
-	const char *CheckValue(const char *check) const;
+	void AppendArg(const FArg arg);
+	void RemoveArg(int argindex);
+	void RemoveArgs(const FArg check);
+	void CollectFiles(const FArg arg, const char *extension);
+	FArgs *GatherFiles(const FArg arg) const;
+
+	int CheckParm(const FArg check, int start=1) const;	// Returns the position of the given parameter in the arg list (0 if not found).
+	int CheckParm(const FArg ** check, int start = 1) const;	// Returns the position of the given parameter in the arg list (0 if not found). Allows checking for multiple switches
+	int CheckParmList(const FArg check, FString **strings, int start=1) const;
+	const char *CheckValue(const FArg check) const;
+
 	const char *GetArg(int arg) const;
 	FString *GetArgList(int arg) const;
-	FString TakeValue(const char *check);
+	FString TakeValue(const FArg check);
 	int NumArgs() const;
-	void FlushArgs();
-	TArray<FString>& Array() { return Argv; }
 
 private:
+	void FlushArgs();
+	void SetArg(int argnum, const char *arg);
+	void SetRawArgs(int argc, char **argv);
+	void AppendRawArgs(int argc, const FString *argv);
+	void CollectFiles(const char *finalname, const char** arg, const char* extension);
+
+	TArray<FString>& Array() { return Argv; }
 	TArray<FString> Argv;
+
+	static int TestArgList(const FArg ** check, const char * str);
 };
 
 extern FArgs *Args;

--- a/src/common/utility/m_argv.h
+++ b/src/common/utility/m_argv.h
@@ -142,6 +142,8 @@ public:
 	FString TakeValue(const FArg check);
 	int NumArgs() const;
 
+	static void PrintHelpMessage(bool full);
+
 private:
 	void FlushArgs();
 	void SetArg(int argnum, const char *arg);

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -6,6 +6,7 @@
 ** Copyright 1998-2009 Randy Heit
 ** Copyright 2009 Christoph Oelckers
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -59,6 +60,10 @@ EXTERN_CVAR(Bool, autoloadwidescreen)
 EXTERN_CVAR(String, language)
 
 CVAR(Bool, i_loadsupportwad, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG) // Disabled in net games.
+
+EXTERN_FARG(iwad);
+EXTERN_FARG(host);
+EXTERN_FARG(join);
 
 bool foundprio = false; // global to prevent iwad box from appearing
 
@@ -608,7 +613,7 @@ FString FIWadManager::IWADPathFileSearch(const FString &file)
 
 int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad)
 {
-	const char *iwadparm = Args->CheckValue ("-iwad");
+	const char *iwadparm = Args->CheckValue (FArg_iwad);
 	FString custwad;
 
 	CollectSearchPaths();
@@ -800,7 +805,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 	int pick = 0;
 
 	// Present the IWAD selection box.
-	bool alwaysshow = (queryiwad && !Args->CheckParm("-iwad") && !foundprio);
+	bool alwaysshow = (queryiwad && !Args->CheckParm(FArg_iwad) && !foundprio);
 
 	if (!havepicked && (alwaysshow || picks.Size() > 1))
 	{
@@ -863,7 +868,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, const char
 	{
 		// For net games all wads must be explicitly named to make it easier for the host to know
 		// exactly what's being loaded.
-		if (i_loadsupportwad && !Args->CheckParm("-join") && !Args->CheckParm("-host"))
+		if (i_loadsupportwad && !Args->CheckParm(FArg_join) && !Args->CheckParm(FArg_host))
 		{
 			FString supportWAD = IWADPathFileSearch(info.SupportWAD);
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -31,8 +31,8 @@
 // HEADER FILES ------------------------------------------------------------
 
 #include "c_cvars.h"
-#include "i_soundinternal.h"
 #include "i_net.h"
+#include "i_soundinternal.h"
 
 #ifdef _WIN32
 #include <direct.h>
@@ -55,6 +55,7 @@
 #include "c_dispatch.h"
 #include "cmdlib.h"
 #include "common/scripting/dap/DebugServer.h"
+#include "common/widgets/errorwindow.h"
 #include "d_buttons.h"
 #include "d_dehacked.h"
 #include "d_event.h"
@@ -97,6 +98,7 @@
 #include "p_local.h"
 #include "p_setup.h"
 #include "po_man.h"
+#include "printf.h"
 #include "r_data/r_vanillatrans.h"
 #include "r_sky.h"
 #include "r_utility.h"
@@ -211,7 +213,7 @@ extern const char * const BACKEND;
 
 void DrawHUD();
 void D_DoAnonStats();
-void I_DetectOS();
+FString I_DetectOS();
 void UpdateGenericUI(bool cvar);
 void Local_Job_Init();
 
@@ -3856,6 +3858,16 @@ static int D_DoomMain_Internal (void)
 
 	C_InitConsole(80*8, 25*8, false);
 
+	Printf(
+		"%s version %s\nBuild: %s version compiled on %s, dated %s\nOS: %s\n",
+		GAMENAME,
+		GetVersionString(),
+		BACKEND,
+		__DATE__,
+		GetGitTime(),
+		I_DetectOS().GetChars()
+	);
+
 	bool wantsVersion = Args->CheckParm(FArg_version)
 		|| Args->CheckParm(FArg_v);
 	bool wantsHelp = Args->CheckParm(FArg_help)
@@ -3869,8 +3881,6 @@ static int D_DoomMain_Internal (void)
 			FArgs::PrintHelpMessage(Args->CheckParm(FArg_help_all));
 		return 0;
 	}
-
-	I_DetectOS();
 
 	// +logfile gets checked too late to catch the full startup log in the logfile so do some extra check for it here.
 	FString logfile = Args->TakeValue(FArg_logfile);

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3856,6 +3856,20 @@ static int D_DoomMain_Internal (void)
 
 	C_InitConsole(80*8, 25*8, false);
 
+	bool wantsVersion = Args->CheckParm(FArg_version)
+		|| Args->CheckParm(FArg_v);
+	bool wantsHelp = Args->CheckParm(FArg_help)
+		|| Args->CheckParm(FArg_h)
+		|| Args->CheckParm(FArg_help_all)
+		|| Args->CheckParm(FArg_doshelp);
+
+	if (wantsVersion || wantsHelp)
+	{
+		if (wantsHelp)
+			FArgs::PrintHelpMessage(Args->CheckParm(FArg_help_all));
+		return 0;
+	}
+
 	I_DetectOS();
 
 	// +logfile gets checked too late to catch the full startup log in the logfile so do some extra check for it here.

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -4,6 +4,7 @@
 // Copyright 1999-2016 Randy Heit
 // Copyright 2002-2016 Christoph Oelckers
 // Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -31,6 +32,8 @@
 
 #include "c_cvars.h"
 #include "i_soundinternal.h"
+#include "i_net.h"
+
 #ifdef _WIN32
 #include <direct.h>
 #endif
@@ -135,6 +138,76 @@ EXTERN_CVAR(Bool, dlg_vgafont)
 EXTERN_CVAR(Bool, vm_jit)
 EXTERN_CVAR(Bool, vm_jit_aot)
 CVAR(Int, vid_renderer, 1, 0)	// for some stupid mods which threw caution out of the window...
+
+FARG(nomonsters, "", "", "", "");
+FARG(respawn, "", "", "", "");
+FARG(fast, "", "", "", "");
+FARG(turbo, "", "", "", "");
+FARG(timer, "", "", "", "");
+FARG(avg, "", "", "", "");
+
+FARG(oldsprites, "", "", "", "");
+FARG(iwad, "", "", "", "");
+FARG(savedir, "", "", "", "");
+
+FARG(devparm, "", "", "", "");
+FARG(norun, "", "", "", "");
+FARG(dumpjit, "", "", "", "");
+
+FARG(altdeath, "", "", "", "");
+FARG(deathmatch, "", "", "", "");
+
+FARG(file, "", "", "", "");
+FARG(optfile, "", "", "", "");
+FARG(noautoload, "", "", "", "");
+FARG(warp, "", "", "", "");
+FARG(noautoexec, "", "", "", "");
+FARG(allowduplicates, "", "", "", "");
+FARG(warpwipe, "", "", "", "");
+FARG(deh, "", "", "", "");
+FARG(bex, "", "", "", "");
+FARG(skill, "", "", "", "");
+FARG(record, "", "", "", "");
+FARG(loadgame, "", "", "", "");
+FARG(playdemo, "", "", "", "");
+FARG(timedemo, "", "", "", "");
+FARG(xlat, "", "", "", "");
+
+FARG(version, "", "", "", "");
+FARG_ADVANCED(v, "", "", "");
+
+FARG(help, "", "", "", "");
+FARG_ADVANCED(h, "", "", "");
+
+FARG_CUSTOM(help_all, "-help-all", "", false, "", "", "");
+
+#ifdef _WIN32
+FARG_CUSTOM(doshelp, "/?", "", false, "", "", "");
+#else
+FARG_CUSTOM(doshelp, "/?", "", true, "", "", "");
+#endif
+
+FARG(exec, "", "", "", "");
+
+FARG(episode, "", "", "", "");
+FARG(rngseed, "", "", "", "");
+FARG(compatmode, "", "", "", "");
+FARG(errorlog, "", "", "", "");
+FARG(noextras, "", "", "", "");
+FARG(coop, "", "", "", "");
+FARG(nointro, "", "", "", "");
+FARG(nolights, "", "", "", "");
+FARG(nobrightmaps, "", "", "", "");
+FARG(nowidescreen, "", "", "", "");
+FARG(bots, "", "", "", "");
+FARG(debug, "", "", "", "");
+FARG_CUSTOM(map, "+map", "", false, "", "", "");
+FARG_CUSTOM(logfile, "+logfile", "", false, "", "", "");
+
+EXTERN_FARG(join);
+EXTERN_FARG(host);
+
+extern const char * const BACKEND;
 
 void DrawHUD();
 void D_DoAnonStats();
@@ -279,7 +352,7 @@ CVAR (Int, snd_drawoutput, 0, 0);
 CUSTOM_CVAR (String, vid_cursor, "None", CVAR_ARCHIVE | CVAR_NOINITCALL)
 {
 	bool res = false;
-	
+
 
 	if (!stricmp(self, "None" ) && gameinfo.CursorPic.IsNotEmpty())
 	{
@@ -771,7 +844,7 @@ static uint32_t GetCaps()
 
 //==========================================================================
 //
-// 
+//
 //
 //==========================================================================
 
@@ -924,7 +997,7 @@ void D_Display ()
 	}
 
 	cycle_t cycles;
-	
+
 	cycles.Reset();
 	cycles.Clock();
 
@@ -1011,7 +1084,7 @@ void D_Display ()
 	{
 		wipestart = nullptr;
 	}
-	
+
 	screen->FrameTime = I_msTimeFS();
 	TexAnim.UpdateAnimations(screen->FrameTime);
 	R_UpdateSky(screen->FrameTime);
@@ -1022,7 +1095,7 @@ void D_Display ()
 		// [ZZ] execute event hook that we just started the frame
 		//E_RenderFrame();
 		//
-		
+
 		D_Render([&]()
 		{
 			viewsec = RenderView(&players[consoleplayer]);
@@ -1036,7 +1109,7 @@ void D_Display ()
 			{
 				primaryLevel->automap->Drawer ((hud_althud && viewheight == SCREENHEIGHT) ? viewheight : StatusBar->GetTopOfStatusbar());
 			}
-		
+
 			// for timing the statusbar code.
 			//cycle_t stb;
 			//stb.Reset();
@@ -1084,11 +1157,11 @@ void D_Display ()
 				M_Drawer ();
 				End2DAndUpdate ();
 				return;
-				
+
 			case GS_DEMOSCREEN:
 				D_PageDrawer ();
 				break;
-				
+
 		case GS_CUTSCENE:
 		case GS_INTRO:
 			ScreenJobDraw();
@@ -1780,7 +1853,7 @@ void ParseCVarInfo()
 	{
 		GameConfig->DoModSetup (gameinfo.ConfigName.GetChars());
 	}
-}	
+}
 
 //==========================================================================
 //
@@ -1790,7 +1863,7 @@ void ParseCVarInfo()
 //
 //==========================================================================
 
-bool ConsiderPatches (const char *arg)
+bool ConsiderPatches (const FArg arg)
 {
 	int i, argc;
 	FString *args;
@@ -1829,7 +1902,7 @@ static void GetCmdLineFiles(std::vector<std::string>& wadfiles, bool optional)
 	int i;
 	int argc;
 
-	argc = optional ? Args->CheckParmList("-optfile", &args) : Args->CheckParmList("-file", &args);
+	argc = optional ? Args->CheckParmList(FArg_optfile, &args) : Args->CheckParmList(FArg_file, &args);
 
 	assert(wadfiles.size() < INT_MAX);
 
@@ -2024,12 +2097,12 @@ static void D_DoomInit()
 	M_FindResponseFile ();
 
 	// Combine different file parameters with their pre-switch bits.
-	Args->CollectFiles("-deh", ".deh");
-	Args->CollectFiles("-bex", ".bex");
-	Args->CollectFiles("-exec", ".cfg");
-	Args->CollectFiles("-playdemo", ".lmp");
-	Args->CollectFiles("-file", nullptr);	// anything left goes after -file
-	Args->CollectFiles("-optfile", nullptr);
+	Args->CollectFiles(FArg_deh, ".deh");
+	Args->CollectFiles(FArg_bex, ".bex");
+	Args->CollectFiles(FArg_exec, ".cfg");
+	Args->CollectFiles(FArg_playdemo, ".lmp");
+	Args->CollectFiles(FArg_file, nullptr);	// anything left goes after -file
+	Args->CollectFiles(FArg_optfile, nullptr);
 
 	gamestate = GS_STARTUP;
 
@@ -2045,24 +2118,24 @@ static void D_DoomInit()
 
 static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& allwads)
 {
-	LumpFilterIWAD.Format("%s.", autoname);	// The '.' is appened to simplify parsing the string 
+	LumpFilterIWAD.Format("%s.", autoname);	// The '.' is appened to simplify parsing the string
 
 	// [SP] Dialog reaction - load lights.pk3 and brightmaps.pk3 based on user choices
-	if (!(gameinfo.flags & GI_SHAREWARE) && !(Args->CheckParm("-noextras")))
+	if (!(gameinfo.flags & GI_SHAREWARE) && !(Args->CheckParm(FArg_noextras)))
 	{
-		if ((GameStartupInfo.LoadLights == 1 || (GameStartupInfo.LoadLights != 0 && autoloadlights)) && !(Args->CheckParm("-nolights")))
+		if ((GameStartupInfo.LoadLights == 1 || (GameStartupInfo.LoadLights != 0 && autoloadlights)) && !(Args->CheckParm(FArg_nolights)))
 		{
 			const char *lightswad = BaseFileSearch ("lights.pk3", NULL, true, GameConfig);
 			if (lightswad)
 				D_AddFile (allwads, lightswad, true, -1, GameConfig, true);
 		}
-		if ((GameStartupInfo.LoadBrightmaps == 1 || (GameStartupInfo.LoadBrightmaps != 0 && autoloadbrightmaps)) && !(Args->CheckParm("-nobrightmaps")))
+		if ((GameStartupInfo.LoadBrightmaps == 1 || (GameStartupInfo.LoadBrightmaps != 0 && autoloadbrightmaps)) && !(Args->CheckParm(FArg_nobrightmaps)))
 		{
 			const char *bmwad = BaseFileSearch ("brightmaps.pk3", NULL, true, GameConfig);
 			if (bmwad)
 				D_AddFile (allwads, bmwad, true, -1, GameConfig, true);
 		}
-		if ((GameStartupInfo.LoadWidescreen == 1 || (GameStartupInfo.LoadWidescreen != 0 && autoloadwidescreen)) && !(Args->CheckParm("-nowidescreen")))
+		if ((GameStartupInfo.LoadWidescreen == 1 || (GameStartupInfo.LoadWidescreen != 0 && autoloadwidescreen)) && !(Args->CheckParm(FArg_nowidescreen)))
 		{
 			const char *wswad = BaseFileSearch ("game_widescreen_gfx.pk3", NULL, true, GameConfig);
 			if (wswad)
@@ -2071,7 +2144,7 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 	}
 
 	// Disable autoloading in netgames as we don't want people who are hosting/joining loading up random files.
-	if (!(gameinfo.flags & GI_SHAREWARE) && !Args->CheckParm("-noautoload") && !disableautoload && !Args->CheckParm("-host") && !Args->CheckParm("-join"))
+	if (!(gameinfo.flags & GI_SHAREWARE) && !Args->CheckParm(FArg_noautoload) && !disableautoload && !Args->CheckParm(FArg_host) && !Args->CheckParm(FArg_join))
 	{
 		FString file;
 
@@ -2083,7 +2156,7 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 		const char *wad = BaseFileSearch ("zvox.wad", NULL, false, GameConfig);
 		if (wad)
 			D_AddFile (allwads, wad, true, -1, GameConfig, true);
-	
+
 		// [RH] Add any .wad files in the skins directory
 #ifdef __unix__
 		file = SHARE_DIR;
@@ -2096,7 +2169,7 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 #ifdef __unix__
 		file = NicePath("$HOME/" GAME_DIR "/skins");
 		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig);
-#endif	
+#endif
 
 		// Add common (global) wads
 		D_AddConfigFiles(allwads, "Global.Autoload", "*.wad", GameConfig, true);
@@ -2127,23 +2200,23 @@ static void CheckCmdLine()
 	const char *v;
 
 	if (!batchrun) Printf ("Checking cmd-line parameters...\n");
-	if (Args->CheckParm ("-nomonsters"))	flags |= DF_NO_MONSTERS;
-	if (Args->CheckParm ("-respawn"))		flags |= DF_MONSTERS_RESPAWN;
-	if (Args->CheckParm ("-fast"))			flags |= DF_FAST_MONSTERS;
+	if (Args->CheckParm (FArg_nomonsters))	flags |= DF_NO_MONSTERS;
+	if (Args->CheckParm (FArg_respawn))		flags |= DF_MONSTERS_RESPAWN;
+	if (Args->CheckParm (FArg_fast))			flags |= DF_FAST_MONSTERS;
 
-	devparm = !!Args->CheckParm ("-devparm");
+	devparm = !!Args->CheckParm (FArg_devparm);
 
-	if (Args->CheckParm ("-altdeath"))
+	if (Args->CheckParm (FArg_altdeath))
 	{
 		deathmatch = 1;
 		flags |= DF_ITEMS_RESPAWN;
 	}
-	else if (Args->CheckParm ("-deathmatch"))
+	else if (Args->CheckParm (FArg_deathmatch))
 	{
 		deathmatch = 1;
 		flags |= DF_WEAPONS_STAY | DF_ITEMS_RESPAWN;
 	}
-	else if (Args->CheckParm("-coop"))
+	else if (Args->CheckParm(FArg_coop))
 	{
 		deathmatch = teamplay = 0;
 		flags |= DF_NO_COOP_WEAPON_SPAWN;
@@ -2169,14 +2242,14 @@ static void CheckCmdLine()
 	autostart = StoredWarp.IsNotEmpty();
 
 	setskill = -1;
-	const char *val = Args->CheckValue ("-skill");
+	const char *val = Args->CheckValue (FArg_skill);
 	if (val)
 	{
 		setskill = val[0] - '1';
 		autostart = true;
 	}
 
-	p = Args->CheckParm ("-warp");
+	p = Args->CheckParm (FArg_warp);
 	if (p && p < Args->NumArgs() - 1)
 	{
 		int ep, map;
@@ -2186,7 +2259,7 @@ static void CheckCmdLine()
 			ep = 1;
 			map = atoi (Args->GetArg(p+1));
 		}
-		else 
+		else
 		{
 			ep = atoi (Args->GetArg(p+1));
 			map = p < Args->NumArgs() - 2 ? atoi (Args->GetArg(p+2)) : 10;
@@ -2204,7 +2277,7 @@ static void CheckCmdLine()
 	// [RH] Hack to handle +map. The standard console command line handler
 	// won't be able to handle it, so we take it out of the command line and set
 	// it up like -warp.
-	FString mapvalue = Args->TakeValue("+map");
+	FString mapvalue = Args->TakeValue(FArg_map);
 	if (mapvalue.IsNotEmpty())
 	{
 		if (!P_CheckMapData(mapvalue.GetChars()))
@@ -2224,7 +2297,7 @@ static void CheckCmdLine()
 	}
 
 	// turbo option  // [RH] (now a cvar)
-	v = Args->CheckValue("-turbo");
+	v = Args->CheckValue(FArg_turbo);
 	if (v != NULL)
 	{
 		double amt = atof(v);
@@ -2232,7 +2305,7 @@ static void CheckCmdLine()
 		turbo = (float)amt;
 	}
 
-	v = Args->CheckValue ("-timer");
+	v = Args->CheckValue (FArg_timer);
 	if (v)
 	{
 		double time = strtod (v, NULL);
@@ -2240,7 +2313,7 @@ static void CheckCmdLine()
 		timelimit = (float)time;
 	}
 
-	v = Args->CheckValue ("-avg");
+	v = Args->CheckValue (FArg_avg);
 	if (v)
 	{
 		Printf ("Austin Virtual Gaming: Levels will end after 20 minutes\n");
@@ -2270,7 +2343,7 @@ static void CheckEpisodeCmd()
 {
 	bool setEpisode = false;
 	int episode = 0;
-	auto v = Args->CheckValue("-episode");
+	auto v = Args->CheckValue(FArg_episode);
 	if (v != nullptr)
 	{
 		episode = atoi(v) - 1;
@@ -2417,7 +2490,7 @@ static void RenameSprites(FileSystem &fileSystem, const TArray<FString>& deletel
 		}
 	}
 
-	renameAll = !!Args->CheckParm("-oldsprites") || nospriterename;
+	renameAll = !!Args->CheckParm(FArg_oldsprites) || nospriterename;
 
 	for (uint32_t i = 0; i < NumFiles; i++)
 	{
@@ -3015,7 +3088,7 @@ static void CheckForHacks(BuildInfo& buildinfo)
 		buildinfo.Name[3] <= '3' &&
 		buildinfo.Height == 128 &&
 		buildinfo.Parts.Size() == 1)
-	{ 
+	{
 		// This must alter the size of both the texture image and the game texture.
 		buildinfo.Height = buildinfo.Parts[0].TexImage->GetImage()->GetHeight();
 		buildinfo.texture->SetSize(buildinfo.Width, buildinfo.Height);
@@ -3072,9 +3145,9 @@ static void FixWideStatusBar()
 //
 //==========================================================================
 
-static void Doom_CastSpriteIDToString(FString* a, unsigned int b) 
-{ 
-	*a = (b >= sprites.Size()) ? "TNT1" : sprites[b].name; 
+static void Doom_CastSpriteIDToString(FString* a, unsigned int b)
+{
+	*a = (b >= sprites.Size()) ? "TNT1" : sprites[b].name;
 }
 
 extern DThinker* NextToThink;
@@ -3185,8 +3258,9 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& pwads)
 {
 	NetworkEntityManager::InitializeNetworkEntities();
-	bool dap_debugging = *vm_debug;
-	if (Args->CheckValue("-debug") || dap_debugging)
+
+	bool dap_debugging = vm_debug;
+	if (Args->CheckValue(FArg_debug) || dap_debugging)
 	{
 		dap_debugging = true;
 		// disable vm_jit and vm_jit_aot when debugging
@@ -3206,7 +3280,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	gameinfo.nokeyboardcheats = iwad_info->nokeyboardcheats;
 	gameinfo.ConfigName = iwad_info->Configname;
 
-	const char *v = Args->CheckValue("-rngseed");
+	const char *v = Args->CheckValue(FArg_rngseed);
 	if (v)
 	{
 		rngseed = staticrngseed = atoi(v);
@@ -3219,7 +3293,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		use_staticrng = false;
 	}
 	srand(rngseed);
-		
+
 	FRandom::StaticClearRandom ();
 
 	FBaseCVar::DisableCallbacks();
@@ -3230,13 +3304,13 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	// Process automatically executed files
 	FExecList *exec;
 	FArgs *execFiles = new FArgs;
-	if (!(Args->CheckParm("-noautoexec")))
+	if (!(Args->CheckParm(FArg_noautoexec)))
 		GameConfig->AddAutoexec(execFiles, gameinfo.ConfigName.GetChars());
 	exec = D_MultiExec(execFiles, NULL);
 	delete execFiles;
 
 	// Process .cfg files at the start of the command line.
-	execFiles = Args->GatherFiles ("-exec");
+	execFiles = Args->GatherFiles (FArg_exec);
 	exec = D_MultiExec(execFiles, exec);
 	delete execFiles;
 
@@ -3289,7 +3363,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		std::make_move_iterator(pwads.end())
 	);
 
-	bool allowduplicates = Args->CheckParm("-allowduplicates");
+	bool allowduplicates = Args->CheckParm(FArg_allowduplicates);
 	if (!fileSystem.InitMultipleFiles(allwads, &lfi, FileSystemPrintf, allowduplicates))
 	{
 		I_FatalError("FileSystem: no files found");
@@ -3307,8 +3381,8 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	int max_progress = TexMan.GuesstimateNumTextures();
 	int per_shader_progress = 0;//screen->GetShaderCount()? (max_progress / 10 / screen->GetShaderCount()) : 0;
 
-	bool norun = Args->CheckParm("-norun");
-	bool nostartscreen = batchrun || restart || Args->CheckParm("-join") || Args->CheckParm("-host") || norun;
+	bool norun = Args->CheckParm(FArg_norun);
+	bool nostartscreen = batchrun || restart || Args->CheckParm(FArg_join) || Args->CheckParm(FArg_host) || norun;
 
 	if (GameStartupInfo.Type == FStartupInfo::DefaultStartup)
 	{
@@ -3319,7 +3393,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		else if (gameinfo.gametype == GAME_Strife)
 			GameStartupInfo.Type = FStartupInfo::StrifeStartup;
 	}
-	
+
 	GameConfig->DoKeySetup(gameinfo.ConfigName.GetChars());
 
 	// Now that wads are loaded, define mod-specific cvars.
@@ -3336,7 +3410,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!(restart || norun))
 		V_Init2();
 
-	// [RH] Initialize localizable strings. 
+	// [RH] Initialize localizable strings.
 	GStrings.LoadStrings(fileSystem, language);
 
 	V_InitFontColors ();
@@ -3374,9 +3448,9 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	StartScreen = nostartscreen? nullptr : GetGameStartScreen(per_shader_progress > 0 ? max_progress * 10 / 9 : max_progress + 3);
 	setmodeneeded = true;
 	if (StartScreen != nullptr) StartScreen->Render();
-	
+
 	// +compatmode cannot be used on the command line, so use this as a substitute
-	auto compatmodeval = Args->CheckValue("-compatmode");
+	auto compatmodeval = Args->CheckValue(FArg_compatmode);
 	if (compatmodeval)
 	{
 		compatmode = (int)strtoll(compatmodeval, nullptr, 10);
@@ -3417,10 +3491,10 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!batchrun) Printf ("Texman.Init: Init texture manager.\n");
 	UpdateUpscaleMask();
 	SpriteFrames.Clear();
-	TexMan.AddTextures([]() 
-	{ 
-		StartWindow->Progress(); 
-		if (StartScreen) StartScreen->Progress(1); 
+	TexMan.AddTextures([]()
+	{
+		StartWindow->Progress();
+		if (StartScreen) StartScreen->Progress(1);
 	}, CheckForHacks, InitBuildTiles);
 	PatchTextures();
 	TexAnim.Init();
@@ -3429,7 +3503,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 
 	FixWideStatusBar();
 
-	StartWindow->Progress(); 
+	StartWindow->Progress();
 	if (StartScreen) StartScreen->Progress(1);
 	V_InitFonts();
 	InitDoomFonts();
@@ -3443,7 +3517,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	R_ParseTrnslate();
 	PClassActor::StaticInit ();
 	FBaseCVar::InitZSCallbacks ();
-	
+
 	Job_Init();
 
 	// [GRB] Initialize player class list
@@ -3458,7 +3532,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		I_FatalError ("No player classes defined");
 	}
 
-	StartWindow->Progress(); 
+	StartWindow->Progress();
 	if (StartScreen) StartScreen->Progress (1);
 
 	ParseGLDefs();
@@ -3466,7 +3540,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!batchrun) Printf ("R_Init: Init %s refresh subsystem.\n", gameinfo.ConfigName.GetChars());
 	if (StartScreen) StartScreen->LoadingStatus ("Loading graphics", 0x3f);
 	if (StartScreen) StartScreen->Progress(1);
-	StartWindow->Progress(); 
+	StartWindow->Progress();
 	R_Init ();
 
 	if (!batchrun) Printf ("DecalLibrary: Load decals.\n");
@@ -3480,8 +3554,8 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	// [RH] Add any .deh and .bex files on the command line.
 	// If there are none, try adding any in the config file.
 	// Note that the command line overrides defaults from the config.
-	bool foundDeh = ConsiderPatches("-deh");
-	bool foundBex = ConsiderPatches("-bex");
+	bool foundDeh = ConsiderPatches(FArg_deh);
+	bool foundBex = ConsiderPatches(FArg_bex);
 	if (!foundDeh && !foundBex &&
 		gameinfo.gametype == GAME_Doom && GameConfig->SetSection ("Doom.DefaultDehacked"))
 	{
@@ -3521,9 +3595,9 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 
 	//Added by MC:
 	primaryLevel->BotInfo.getspawned.Clear();
-	
+
 	FString *args;
-	int argcount = Args->CheckParmList("-bots", &args);
+	int argcount = Args->CheckParmList(FArg_bots, &args);
 	for (int p = 0; p < argcount; ++p)
 	{
 		primaryLevel->BotInfo.getspawned.Push(args[p]);
@@ -3593,7 +3667,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	if (!restart)
 	{
 		// start the apropriate game based on parms
-		auto v = Args->CheckValue ("-record");
+		auto v = Args->CheckValue (FArg_record);
 
 		if (v)
 		{
@@ -3627,7 +3701,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		UpdateVRModes();
 		Local_Job_Init();
 
-		v = Args->CheckValue ("-loadgame");
+		v = Args->CheckValue (FArg_loadgame);
 		if (v)
 		{
 			FString file = G_BuildSaveName(v);
@@ -3638,7 +3712,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 			G_LoadGame(file.GetChars());
 		}
 
-		v = Args->CheckValue("-playdemo");
+		v = Args->CheckValue(FArg_playdemo);
 		if (v != NULL)
 		{
 			singledemo = true;				// quit after one demo
@@ -3646,7 +3720,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		}
 		else
 		{
-			v = Args->CheckValue("-timedemo");
+			v = Args->CheckValue(FArg_timedemo);
 			if (v)
 			{
 				G_TimeDemo(v);
@@ -3658,7 +3732,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 					if (autostart || netgame)
 					{
 						// Do not do any screenwipes when autostarting a game.
-						if (!Args->CheckParm("-warpwipe"))
+						if (!Args->CheckParm(FArg_warpwipe))
 						{
 							NoWipe = TICRATE;
 						}
@@ -3675,7 +3749,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 					}
 					else
 					{
-						if (multiplayer || cl_nointros || Args->CheckParm("-nointro"))
+						if (multiplayer || cl_nointros || Args->CheckParm(FArg_nointro))
 						{
 							D_StartTitle();
 						}
@@ -3749,7 +3823,7 @@ static int D_DoomMain_Internal (void)
 		nullptr,
 		CheckSkipGameOptionBlock,
 		System_ConsoleToggled,
-		nullptr, 
+		nullptr,
 		nullptr,
 		System_ToggleFullConsole,
 		System_StartCutscene,
@@ -3761,15 +3835,15 @@ static int D_DoomMain_Internal (void)
 		System_LanguageChanged,
 		OkForLocalization,
 		[]() ->FConfigFile* { return GameConfig; },
-		nullptr, 
+		nullptr,
 		RemapUserTranslation
 	};
 
 	std::set_new_handler(NewFailure);
-	const char *batchout = Args->CheckValue("-errorlog");
+	const char *batchout = Args->CheckValue(FArg_errorlog);
 
 	D_DoomInit();
-	
+
 	// [RH] Make sure zdoom.pk3 is always loaded,
 	// as it contains magic stuff we need.
 	wad = BaseFileSearch(BASEWAD, NULL, true, GameConfig);
@@ -3781,10 +3855,11 @@ static int D_DoomMain_Internal (void)
 	InitWidgetResources(wad);
 
 	C_InitConsole(80*8, 25*8, false);
+
 	I_DetectOS();
 
 	// +logfile gets checked too late to catch the full startup log in the logfile so do some extra check for it here.
-	FString logfile = Args->TakeValue("+logfile");
+	FString logfile = Args->TakeValue(FArg_logfile);
 	if (logfile.IsNotEmpty())
 	{
 		execLogfile(logfile.GetChars());
@@ -3802,8 +3877,6 @@ static int D_DoomMain_Internal (void)
 		Printf("\n");
 	}
 
-	Printf("%s version %s\n", GAMENAME, GetVersionString());
-
 	extern void D_ConfirmSendStats();
 	D_ConfirmSendStats();
 
@@ -3817,7 +3890,7 @@ static int D_DoomMain_Internal (void)
 	GameConfig->DoAutoloadSetup(iwad_man);
 
 	bool should_debug = vm_debug;
-	const char * debug_port_arg = Args->CheckValue("-debug");
+	const char * debug_port_arg = Args->CheckValue(FArg_debug);
 	if (debug_port_arg) {
 		should_debug = true;
 	}
@@ -3840,7 +3913,7 @@ static int D_DoomMain_Internal (void)
 			iwad_man = new FIWadManager(basewad.GetChars(), optionalwad.GetChars());
 		}
 
-		// Load zdoom.pk3 alone so that we can get access to the internal gameinfos before 
+		// Load zdoom.pk3 alone so that we can get access to the internal gameinfos before
 		// the IWAD is known.
 
 		std::vector<std::string> pwads;
@@ -3852,7 +3925,7 @@ static int D_DoomMain_Internal (void)
 		if (iwad.IsEmpty()) iwad = lastIWAD;
 
 		std::vector<std::string> allwads;
-		
+
 		const FIWADInfo *iwad_info = iwad_man->FindIWAD(allwads, iwad.GetChars(), basewad.GetChars(), optionalwad.GetChars());
 
 		GetCmdLineFiles(pwads, false); // [RL0] Update with files passed on the launcher extra args
@@ -3917,7 +3990,7 @@ static int D_DoomMain_Internal (void)
 		}
 
 		D_DoomLoop ();		// this only returns if a 'restart' CCMD is given.
-		// 
+		//
 		// Clean up after a restart
 		//
 
@@ -4041,9 +4114,9 @@ void D_Cleanup()
 	// clean up game state
 	D_ErrorCleanup ();
 	P_Shutdown();
-	
+
 	M_SaveDefaults(NULL);			// save config before the restart
-	
+
 	// delete all data that cannot be left until reinitialization
 	CleanSWDrawer();
 	V_ClearFonts();					// must clear global font pointers
@@ -4059,24 +4132,24 @@ void D_Cleanup()
 	LightDefaults.DeleteAndClear();			// this can leak heap memory if it isn't cleared.
 	TexAnim.DeleteAll();
 	TexMan.DeleteAll();
-	
+
 	// delete GameStartupInfo data
 	GameStartupInfo.Name = "";
 	GameStartupInfo.BkColor = GameStartupInfo.FgColor = GameStartupInfo.Type = 0;
 	GameStartupInfo.LoadWidescreen = GameStartupInfo.LoadLights = GameStartupInfo.LoadBrightmaps = -1;
 	GameStartupInfo.DiscordAppId = "";
 	GameStartupInfo.SteamAppId = "";
-		
+
 	GC::FullGC();					// clean up before taking down the object list.
-	
+
 	// Delete the reference to the VM functions here which were deleted and will be recreated after the restart.
 	AutoSegs::ActionFunctons.ForEach([](AFuncDesc *afunc)
 	{
 		*(afunc->VMPointer) = NULL;
 	});
-	
+
 	GC::DelSoftRootHead();
-	
+
 	for (auto& p : players)
 	{
 		p.PendingWeapon = nullptr;
@@ -4084,11 +4157,11 @@ void D_Cleanup()
 	PClassActor::AllActorClasses.Clear();
 	ScriptUtil::Clear();
 	PClass::StaticShutdown();
-	
+
 	GC::FullGC();					// perform one final garbage collection after shutdown
-	
+
 	assert(GC::Root == nullptr);
-	
+
 	restart++;
 	PClass::bShutdown = false;
 	PClass::bVMOperational = false;
@@ -4103,25 +4176,26 @@ void D_Cleanup()
 UNSAFE_CCMD(debug_restart)
 {
 	// remove command line args that would get in the way during restart
-	Args->RemoveArgs("-iwad");
-	Args->RemoveArgs("-deh");
-	Args->RemoveArgs("-bex");
-	Args->RemoveArgs("-playdemo");
-	Args->RemoveArgs("-file");
-	Args->RemoveArgs("-optfile");
-	Args->RemoveArgs("-altdeath");
-	Args->RemoveArgs("-deathmatch");
-	Args->RemoveArgs("-coop");
-	Args->RemoveArgs("-skill");
-	Args->RemoveArgs("-savedir");
-	Args->RemoveArgs("-xlat");
-	Args->RemoveArgs("-oldsprites");
+
+	Args->RemoveArgs(FArg_iwad);
+	Args->RemoveArgs(FArg_deh);
+	Args->RemoveArgs(FArg_bex);
+	Args->RemoveArgs(FArg_playdemo);
+	Args->RemoveArgs(FArg_file);
+	Args->RemoveArgs(FArg_optfile);
+	Args->RemoveArgs(FArg_altdeath);
+	Args->RemoveArgs(FArg_deathmatch);
+	Args->RemoveArgs(FArg_coop);
+	Args->RemoveArgs(FArg_skill);
+	Args->RemoveArgs(FArg_savedir);
+	Args->RemoveArgs(FArg_xlat);
+	Args->RemoveArgs(FArg_oldsprites);
 
 	if (argv.argc() > 1)
 	{
 		for (int i = 1; i<argv.argc(); i++)
 		{
-			Args->AppendArg(argv[i]);
+			Args->AppendRawArg(argv[i]);
 		}
 	}
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -141,70 +141,191 @@ EXTERN_CVAR(Bool, vm_jit)
 EXTERN_CVAR(Bool, vm_jit_aot)
 CVAR(Int, vid_renderer, 1, 0)	// for some stupid mods which threw caution out of the window...
 
-FARG(nomonsters, "", "", "", "");
-FARG(respawn, "", "", "", "");
-FARG(fast, "", "", "", "");
-FARG(turbo, "", "", "", "");
-FARG(timer, "", "", "", "");
-FARG(avg, "", "", "", "");
+FARG(nomonsters, "Play", "Prevents monsters from spawning in levels.", "",
+	"Sets the dmflags CVAR so that monsters are not spawned on levels.");
+FARG(respawn, "Play", "Causes monsters to respawn on lower difficulties.", "",
+	"Sets the dmflags CVAR so that monsters respawn even if you are not playing at Nightmare"
+	" difficulty.");
+FARG(fast, "Play", "Makes monsters fast on lower difficulties.", "",
+	"Sets the dmflags CVAR to make the monsters as fast as in Nightmare mode even if you are not"
+	" playing Nightmare.");
+FARG(turbo, "Play", "Adjusts the player's movement speed.", "x",
+	"Causes player movement to be x% as fast as normal. Valid values are 10–255, with 100 being"
+	" normal. Values larger than 100 are considered cheating. This is equivalent to +set turbo"
+	" x.");
+FARG(timer, "Play", "Time limit in minutes before automatically advancing levels.", "x",
+	"Causes " GAMENAME " to automatically advance to the next level after x minutes. This is"
+	" equivalent to +set timelimit x.");
+FARG(avg, "Play", "Automatically advances to the next level after 20 minutes.", "",
+	"Stands for “Austin Virtual Gaming”. Automatically advances to the next level after 20"
+	" minutes. This is equivalent to +set timelimit 20 or -timer 20.");
+FARG(coop, "Play", "Co-op settings preset", "",
+	"A convenient settings preset (not accurate to vanilla Doom's Co-op). Enabling this ensures"
+	" deathmatch is off, doesn't spawn multiplayer-tagged weapons, disables player collisions and"
+	" friendly fire, allows for key sharing, disables item theft, and rememnbers your last weapon"
+	" upon death.");
 
-FARG(oldsprites, "", "", "", "");
-FARG(iwad, "", "", "", "");
-FARG(savedir, "", "", "", "");
+FARG(oldsprites, "Configuration", "Prevents the game from renaming sprites.", "",
+	"Disables sprite renaming. Unless you are playing a mod for Heretic, Hexen or Strife that"
+	" replaced a few select sprites, you do not need this.");
+FARG(iwad, "Configuration", "Specifies primary game file", "iwadfile[.wad]",
+	"The IWAD file specified after this parameter will be used as the game IWAD file.\n" GAMENAME
+	" will look for the IWAD in the current directory, in the same directory as " GAMENAMELOWERCASE
+	".exe, in the directory set in the DOOMWADDIR environment variable, and in the directory set"
+	" in the HOME environment variable. (Verification needed)");
+FARG(savedir, "Configuration", "Sets an alternate directory for saving game files.", "path",
+	"Specifies an alternate directory to use for saved files. If this is not specified, " GAMENAME
+	" stores them in the directory indicated by the save_dir CVAR.");
 
-FARG(devparm, "", "", "", "");
-FARG(norun, "", "", "", "");
-FARG(dumpjit, "", "", "", "");
+FARG(norun, "Debug", "Quits the game early to check for script errors.", "",
+	"Quits the game just before video initialization. To be used to check for errors in scripts"
+	" without actually running the game.");
+FARG(dumpjit, "Debug", "Outputs the ZScript JIT-compilation result to a text file.", "",
+	"Outputs a result of the ZScript JIT-compilation to Assembler to the external file"
+	" \"dumpjit.txt\".");
+FARG_CUSTOM(logfile, "+logfile", "Debug", false, "Copies console output to file", "log.txt",
+	"Copies output of console to file specified. File saving is relative to working directory");
 
-FARG(altdeath, "", "", "", "");
-FARG(deathmatch, "", "", "", "");
+FARG(altdeath, "Multiplayer", "Starts a deathmatch game with respawning items.", "",
+	"Informs " GAMENAME " that you will be playing a deathmatch game and sets the dmflags CVAR so"
+	" that items other than invulnerability and invisibilty respawn after being picked up. Only"
+	" player 1 needs to specify this.");
+FARG(deathmatch, "Multiplayer", "Starts a deathmatch game.", "",
+	"Informs " GAMENAME " that you will be playing a deathmatch game and sets the dmflags CVAR so"
+	" that weapons stay behind when a player picks them up. Only player 1 needs to specify this.");
 
-FARG(file, "", "", "", "");
-FARG(optfile, "", "", "", "");
-FARG(noautoload, "", "", "", "");
-FARG(warp, "", "", "", "");
-FARG(noautoexec, "", "", "", "");
-FARG(allowduplicates, "", "", "", "");
-FARG(warpwipe, "", "", "", "");
-FARG(deh, "", "", "", "");
-FARG(bex, "", "", "", "");
-FARG(skill, "", "", "", "");
-FARG(record, "", "", "", "");
-FARG(loadgame, "", "", "", "");
-FARG(playdemo, "", "", "", "");
-FARG(timedemo, "", "", "", "");
-FARG(xlat, "", "", "", "");
+FARG(file, "Loading", "Loads one or more custom PWAD files.", "file1[.wad] file2[.wad] ...",
+	"Used to load one or more PWAD files which generally contain user-created levels. Files listed"
+	" further right take precedence to files listed before them, so as an example, if both"
+	" file1.wad and file2.wad contain have a MAP01, the MAP01 in file2.wad will be used instead of"
+	" the one in file1.wad. If the .wad extension is omitted, " GAMENAME " will automatically add"
+	" it.\nUsing this parameter is no longer needed, " GAMENAMELOWERCASE " file1.wad file2.wad"
+	" file3.wad will work just as well as " GAMENAMELOWERCASE " -file file1.wad file2.wad"
+	" file3.wad.");
+FARG_ADVANCED(optfile, "Loading", "file1[.wad] file2[.wad] ...",
+	"Same as -file, but it will ignore missing files");
+FARG(noautoload, "Loading", "Prevents loading files automatically from config.", "",
+	"Prevents files from being autoloaded based on the \"AutoLoad\" sections in the user's"
+	" configuration file. This flag also disables autoloading of zvox.wad and the skins directory."
+	" This can be useful if you use files which are autoloaded when playing normally, but want to"
+	" load without them for debugging purposes or to play a mod which might be incompatible with"
+	" them.");
+FARG(warp, "Loading", "Starts the game on a specific map.", "[e] m",
+	"For Doom II, Final Doom, Hexen and Strife, starts the game on map m. For Chex Quest, Doom and"
+	" Heretic, starts the game on episode e, map m. The +map command can also be used to perform"
+	" this action, but it expects the actual name of the map (e.g. MAP01, E1M1).");
+FARG(noautoexec, "Loading", "Prevents the execution of autoexec.cfg files.", "",
+	"Disables the execution of the autoexec.cfg files.");
+FARG(allowduplicates, "Loading", "Permits the loading of multiple files with the same name.", "",
+	"(Verification needed)\nWhen loading files with -file, files with the same name are discarded"
+	" from the load list to prevent potential errors as a result. This command allows such files"
+	" to be loaded regardless.");
+FARG(warpwipe, "Loading", "Forces a screen wipe effect after loading a map at startup.", "",
+	"Forces a screen wipe to happen after loading a map immediately at startup. Useless unless"
+	" used in conjunction with -warp or +map.");
+FARG(deh, "Loading", "Applies a DeHackEd patch to the game", "dehfile[.deh]",
+	"Causes " GAMENAME " to apply a DeHackEd or .bex patch to the game. This must be a text patch;"
+	" binary patches are not supported. (As far as I know, most patches are text patches, so this"
+	" should not be too much of a problem.) Also, only patch format 6 is known to be supported."
+	" Other formats may or may not work properly. If the .deh extension is omitted, " GAMENAME
+	" will automatically add it.");
+FARG(bex, "Loading", "Applies a .bex patch file to the game", "bexfile[.bex]",
+	"This is the same as -deh, except the default file extension is .bex.");
+FARG(skill, "Loading", "Sets the initial difficulty level for the game.", "x",
+	"Sets the initial skill level. This is overridden if you start a new game from the New Game"
+	" menu.\nNote that this is different from the skill CVAR, which ranges from 0-4.");
+FARG(record, "Loading", "Records a gameplay demo from the start of a map.", "demofile[.lmp]",
+	"Records a demo. The -warp parameter or +map command should also be used if you do not want to"
+	" record the demo on MAP01 or E1M1. You may only record from the start of a map. Loading a"
+	" savegame and recording from there is unsupported.\nTo stop the demo recording, use the"
+	" \"stop\" console command. If the .lmp extension is omitted, it will automatically be added."
+	" Unlike vanilla Doom, only one person in a multiplayer game needs to specify the -record"
+	" parameter if they want to record a demo. However, if someone quits before the person"
+	" recording the demo does, the person recording will automatically quit, too, because demos do"
+	" not have a way to record when a player leaves the game.");
+FARG(loadgame, "Loading", "Automatically loads specified savegame upon starting.", "saveXX.[zds]",
+	"Automatically loads the specified savegame. To find out a save's file name, press F1 while it"
+	" is highlighted in the save or load menu. If you do not include the .zds extension, " GAMENAME
+	" will automatically add it for you.");
+FARG(playdemo, "Loading", "Automatically plays demo file upon startup.", "demofile[.lmp]",
+	GAMENAME " will automatically play the specified demo when it starts. If the .lmp extension is"
+	" omitted, it will automatically be added.");
+FARG(timedemo, "Loading", "Plays back a demo quickly.", "demofile[.lmp]",
+	"Plays back a demo faster than -playdemo and displays a framerate when the demo is over. If"
+	" the .lmp extension is omitted, it will automatically be added.");
+FARG(xlat, "Loading", "Specifies a different default map translator to use.", "file",
+	"Specify a different default map translator to use if one isn't specified in MAPINFO. The"
+	" default translators are xlat/doom.txt for Doom, Chex Quest, Urban Brawl and Harmony;"
+	" xlat/heretic.txt for Heretic and Hexen (though Hexen maps normally need no translator since"
+	" only Doom-format maps are translated) and xlat/strife.txt for Strife. For playing an"
+	" Eternity Engine mod, the xlat/eternity.txt file can be used, though keep in mind that many"
+	" Eternity features are not implemented in " GAMENAME " and will not work even after"
+	" translation. You can specify your own custom translator.");
+FARG(nolights, "Loading", "Disables loading of lights.pk3", "",
+	"Forcefully disables loading of lights.pk3, which contains definitions for adding dynamic"
+	" lights to default Actors");
+FARG(nobrightmaps, "Loading", "Disables loading of brightmaps.pk3", "",
+	"Forcefully disables loading of brightmaps.pk3, which contains brightmaps and their"
+	" definitions for default graphics");
+FARG(nowidescreen, "Loading", "Disables loading of game_widescreen_gfx.pk3", "",
+	"Forcefully disables loading of widescreen_gfx.pk3, which contains widescreen extensions"
+	" for default graphics that were designed for 4:3");
+FARG_CUSTOM(map, "+map", "Loading", false, "Starts the game in a certain map", "MAP01",
+	"Similarly to -warp, this starts the game in a certain map. However, it takes the map's lump"
+	" string, instead of a level number. Level number is automatically set based on a combination"
+	" of the game and the map name, or it's manually set in MAPINFO.");
+FARG(noextras, "Loading", "Disables loading of 'extra graphics' WADs", "",
+	"Forcefully disables loading of lights.pk3, brightmaps.pk3, and widescreen_gfx.pk3. These"
+	" contain definitions for adding dynamic lights to default Actors, brightmaps and their"
+	" definitions for default graphics, and widescreen extensions for default graphics that were"
+	" designed for 4:3");
+FARG(nointro, "Loading", "Skips intro video", "",
+	"If an intro video is defined, then it will play before showing the title screen. Setting this"
+	" skips that behavior and always goes to the title screen immediately.");
+FARG(episode, "Loading", "Starts the game on the first map of an episode", "1",
+	"Like -warp, bu starts the game on the first map of the specified episode");
 
-FARG(version, "", "", "", "");
-FARG_ADVANCED(v, "", "", "");
+FARG(version, "Other", "Print version", "",
+	"Print version and exit.");
+FARG_ADVANCED(v, "Other", "",
+	"Print version and exit.");
 
-FARG(help, "", "", "", "");
-FARG_ADVANCED(h, "", "", "");
+FARG(help, "Other", "Print help message", "",
+	"Print help message and exit.");
+FARG_ADVANCED(h, "Other", "",
+	"Print help message and exit.");
 
-FARG_CUSTOM(help_all, "-help-all", "", false, "", "", "");
+FARG_CUSTOM(help_all, "-help-all", "Other", false, "Print detailed help message", "",
+	"Print full help message and exit.");
 
 #ifdef _WIN32
-FARG_CUSTOM(doshelp, "/?", "", false, "", "", "");
+FARG_CUSTOM(doshelp, "/?", "Other", false, "Print help message", "",
+	"Print help message and exit.");
 #else
-FARG_CUSTOM(doshelp, "/?", "", true, "", "", "");
+FARG_CUSTOM(doshelp, "/?", "Other", true, "Print help message", "",
+	"Print help message and exit.");
 #endif
 
-FARG(exec, "", "", "", "");
+FARG(exec, "Zandronum Specific", "Executes a special config script file.", "Directory",
+	 "Executes a script file that houses configurations such as settings that can be used within"
+	" the virtual world and generalized game server specific settings, such as how votes are"
+	" managed. For example of usage: -exec \"..\\..\\My Configurations\\SpecialServer.cfg\"");
 
-FARG(episode, "", "", "", "");
-FARG(rngseed, "", "", "", "");
-FARG(compatmode, "", "", "", "");
-FARG(errorlog, "", "", "", "");
-FARG(noextras, "", "", "", "");
-FARG(coop, "", "", "", "");
-FARG(nointro, "", "", "", "");
-FARG(nolights, "", "", "", "");
-FARG(nobrightmaps, "", "", "", "");
-FARG(nowidescreen, "", "", "", "");
-FARG(bots, "", "", "", "");
-FARG(debug, "", "", "", "");
-FARG_CUSTOM(map, "+map", "", false, "", "", "");
-FARG_CUSTOM(logfile, "+logfile", "", false, "", "", "");
+FARG_ADVANCED(devparm, "Deprecated", "",
+	"Prints a message telling you that you \"useless mode is activated\". With the original Doom,"
+	" using -devparm was the only way to take screenshots. With " GAMENAME ", screenshot is just"
+	" another command, so -devparm serves no real purpose.");
+
+FARG(rngseed, "", "", "",
+	"");
+FARG(compatmode, "", "", "",
+	"");
+FARG(errorlog, "", "", "",
+	"");
+FARG(bots, "", "", "",
+	"");
+FARG(debug, "", "", "",
+	"");
 
 EXTERN_FARG(join);
 EXTERN_FARG(host);

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -31,6 +31,7 @@
 
 #include "doomtype.h"
 #include "gametype.h"
+#include "m_argv.h"
 #include "startupinfo.h"
 #include "c_cvars.h"
 #include <csignal>
@@ -39,6 +40,20 @@ extern bool		advancedemo;
 extern volatile sig_atomic_t gameloop_abort;
 EXTERN_CVAR(Bool, hud_toggled);
 void D_ToggleHud();
+
+EXTERN_FARG(version);
+EXTERN_FARG(v);
+EXTERN_FARG(help);
+EXTERN_FARG(h);
+EXTERN_FARG(doshelp);
+EXTERN_FARG(help_all);
+EXTERN_FARG(devparm);
+EXTERN_FARG(dumpjit);
+EXTERN_FARG(norun);
+EXTERN_FARG(loadgame);
+EXTERN_FARG(iwad);
+EXTERN_FARG(xlat);
+EXTERN_FARG(savedir);
 
 struct event_t;
 

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -3,6 +3,8 @@
 // Copyright 1993-1996 id Software
 // Copyright 1999-2016 Randy Heit
 // Copyright 2002-2016 Christoph Oelckers
+// Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -73,6 +75,10 @@ EXTERN_CVAR (Int, autosavecount)
 EXTERN_CVAR (Bool, cl_capfps)
 EXTERN_CVAR (Bool, vid_vsync)
 EXTERN_CVAR (Int, vid_maxfps)
+
+EXTERN_FARG(loadgame);
+
+FARG(extratic, "", "", "", "");
 
 extern uint8_t		*demo_p;		// [RH] Special "ticcmds" get recorded in demos
 extern FString	savedescription;
@@ -1862,7 +1868,7 @@ void Net_SetGameInfo(TArrayView<uint8_t>& stream)
 	WriteInt32(rngseed, stream);
 	C_WriteCVars(stream, CVAR_SERVERINFO, true);
 
-	auto load = Args->CheckValue("-loadgame");
+	auto load = Args->CheckValue(FArg_loadgame);
 	if (load != nullptr)
 	{
 		WriteInt8(1, stream);
@@ -1873,6 +1879,7 @@ void Net_SetGameInfo(TArrayView<uint8_t>& stream)
 		WriteInt8(0, stream);
 	}
 }
+
 
 void Net_ReadGameInfo(TArrayView<uint8_t>& stream)
 {
@@ -1885,10 +1892,10 @@ void Net_ReadGameInfo(TArrayView<uint8_t>& stream)
 		auto load = ReadString(stream);
 		// Don't override the existing argument in case they need to use
 		// a custom savefile name.
-		if (!Args->CheckParm("-loadgame"))
+		if (!Args->CheckParm(FArg_loadgame))
 		{
-			Args->AppendArg("-loadgame");
-			Args->AppendArg(load);
+			Args->AppendArg(FArg_loadgame);
+			Args->AppendRawArg(load);
 		}
 	}
 
@@ -1902,7 +1909,7 @@ bool D_CheckNetGame()
 	if (!I_InitNetwork())
 		return false;
 
-	if (Args->CheckParm("-extratic"))
+	if (Args->CheckParm(FArg_extratic))
 		net_extratic = true;
 
 	players[Net_Arbitrator].settings_controller = true;

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -78,7 +78,8 @@ EXTERN_CVAR (Int, vid_maxfps)
 
 EXTERN_FARG(loadgame);
 
-FARG(extratic, "", "", "", "");
+FARG(extratic, "Multiplayer", "Sends backup commands over the network", "",
+	"Causes " GAMENAME " to send a backup copy of every movement command across the network.");
 
 extern uint8_t		*demo_p;		// [RH] Special "ticcmds" get recorded in demos
 extern FString	savedescription;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -124,8 +124,11 @@ EXTERN_CVAR (Float, con_midtime);
 EXTERN_CVAR(Int, net_disablepause);
 EXTERN_CVAR(Bool, net_limitsaves);
 
-FARG(nodraw, "", "", "", "");
-FARG(noblit, "", "", "", "");
+FARG(nodraw, "Debug", "Stops the game from drawing anything.", "",
+	"Causes ZDoom not to draw anything at all. Only useful with -timedemo.");
+FARG(noblit, "Debug", "Prevents the screen from updating.", "",
+	"Causes ZDoom not to update the display on the screen, but it still draws everything to an"
+	" internal buffer. Only useful with -timedemo.");
 
 //==========================================================================
 //

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -4,6 +4,7 @@
 // Copyright 1999-2016 Randy Heit
 // Copyright 2002-2016 Christoph Oelckers
 // Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -118,9 +119,13 @@ CVAR (Bool, longsavemessages, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool, cl_waitforsave, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR (Bool, enablescriptscreenshot, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR (Bool, cl_restartondeath, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
+
 EXTERN_CVAR (Float, con_midtime);
-EXTERN_CVAR(Int, net_disablepause)
-EXTERN_CVAR(Bool, net_limitsaves)
+EXTERN_CVAR(Int, net_disablepause);
+EXTERN_CVAR(Bool, net_limitsaves);
+
+FARG(nodraw, "", "", "", "");
+FARG(noblit, "", "", "", "");
 
 //==========================================================================
 //
@@ -3006,8 +3011,8 @@ void G_DoPlayDemo (void)
 //
 void G_TimeDemo (const char* name)
 {
-	nodrawers = !!Args->CheckParm ("-nodraw");
-	noblit = !!Args->CheckParm ("-noblit");
+	nodrawers = !!Args->CheckParm (FArg_nodraw);
+	noblit = !!Args->CheckParm (FArg_noblit);
 	timingdemo = true;
 
 	defdemoname = name;

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2008 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -81,6 +83,8 @@ EXTERN_CVAR (Int, gl_texture_hqresize_targets)
 EXTERN_CVAR(Int, wipetype)
 EXTERN_CVAR(Bool, i_pauseinbackground)
 EXTERN_CVAR(Bool, i_soundinbackground)
+
+FARG(config, "", "", "", "");
 
 #ifdef _WIN32
 EXTERN_CVAR(Int, in_mouse)
@@ -943,7 +947,7 @@ FString FGameConfigFile::GetConfigPath (bool tryProg)
 {
 	const char *pathval;
 
-	pathval = Args->CheckValue ("-config");
+	pathval = Args->CheckValue (FArg_config);
 	if (pathval != NULL)
 	{
 		return FString(pathval);
@@ -986,7 +990,7 @@ void FGameConfigFile::AddAutoexec (FArgs *list, const char *game)
 				FString expanded_path = ExpandEnvVars(value);
 				if (FileExists(expanded_path))
 				{
-					list->AppendArg (ExpandEnvVars(value));
+					list->AppendRawArg(ExpandEnvVars(value));
 				}
 			}
 		}

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -84,7 +84,9 @@ EXTERN_CVAR(Int, wipetype)
 EXTERN_CVAR(Bool, i_pauseinbackground)
 EXTERN_CVAR(Bool, i_soundinbackground)
 
-FARG(config, "", "", "", "");
+FARG(config, "Configuration", "Specifies an alternative configuration file to use.", "configfile",
+	"Causes " GAMENAME " to use an alternative configuration file. If configfile does not exist,"
+	" it will be created.");
 
 #ifdef _WIN32
 EXTERN_CVAR(Int, in_mouse)

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -71,6 +73,10 @@ void JitDumpLog(FILE *file, VMScriptFunction *func);
 // [SO] Just the way Randy said to do it :)
 // [RH] Made this CVAR_SERVERINFO
 CVAR (Int, infighting, 0, CVAR_SERVERINFO)
+
+#ifdef HAVE_VM_JIT
+EXTERN_FARG(dumpjit);
+#endif // HAVE_VM_JIT
 
 static bool LoadDehSupp ();
 static void UnloadDehSupp ();
@@ -1143,7 +1149,7 @@ static void SetDehParams(FState *state, int codepointer, VMDisassemblyDumper &di
 		disasmdump.Write(sfunc, sfunc->PrintableName);
 
 #ifdef HAVE_VM_JIT
-		if (Args->CheckParm("-dumpjit"))
+		if (Args->CheckParm(FArg_dumpjit))
 		{
 			FILE *dump = fopen("dumpjit.txt", "a");
 			if (dump != nullptr)

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -3,6 +3,8 @@
 // Copyright 1993-1996 id Software
 // Copyright 1999-2016 Randy Heit
 // Copyright 2002-2016 Christoph Oelckers
+// Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -75,8 +77,9 @@ CVAR(String, screenshot_type, "png", CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 CVAR(String, screenshot_dir, "", CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 EXTERN_CVAR(Bool, longsavemessages);
 
-static size_t ParseCommandLine (const char *args, int *argc, char **argv);
+FARG(shotdir, "", "", "", "");
 
+static size_t ParseCommandLine (const char *args, int *argc, char **argv);
 
 //---------------------------------------------------------------------------
 //
@@ -137,15 +140,15 @@ void M_FindResponseFile (void)
 
 				// Copy parameters before response file.
 				for (index = 0; index < i; ++index)
-					newargs->AppendArg(Args->GetArg(index));
+					newargs->AppendRawArg(Args->GetArg(index));
 
 				// Copy parameters from response file.
 				for (index = 0; index < argc; ++index)
-					newargs->AppendArg(argv[index]);
+					newargs->AppendRawArg(argv[index]);
 
 				// Copy parameters after response file.
 				for (index = i + 1; index < Args->NumArgs(); ++index)
-					newargs->AppendArg(Args->GetArg(index));
+					newargs->AppendRawArg(Args->GetArg(index));
 
 				// Use the new argument vector as the global Args object.
 				delete Args;
@@ -581,7 +584,7 @@ void M_ScreenShot (const char *filename)
 	if (filename == NULL || filename[0] == '\0')
 	{
 		size_t dirlen;
-		autoname = Args->CheckValue("-shotdir");
+		autoname = Args->CheckValue(FArg_shotdir);
 		if (autoname.IsEmpty())
 		{
 			autoname = screenshot_dir;
@@ -667,7 +670,7 @@ CCMD(openscreenshots)
 {
 	size_t dirlen;
 	FString autoname;
-	autoname = Args->CheckValue("-shotdir");
+	autoname = Args->CheckValue(FArg_shotdir);
 	if (autoname.IsEmpty())
 	{
 		autoname = screenshot_dir;

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -77,7 +77,9 @@ CVAR(String, screenshot_type, "png", CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 CVAR(String, screenshot_dir, "", CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 EXTERN_CVAR(Bool, longsavemessages);
 
-FARG(shotdir, "", "", "", "");
+FARG(shotdir, "Configuration", "Sets an alternate directory for saving screenshots.", "path",
+	"Specifies an alternate directory to use for screenshots. If this is not specified, " GAMENAME
+	" stores them in the directory indicated by the screenshot_dir CVAR.");
 
 static size_t ParseCommandLine (const char *args, int *argc, char **argv);
 

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -96,8 +96,11 @@ enum
 CVAR (Bool, genblockmap, false, CVAR_SERVERINFO|CVAR_GLOBALCONFIG);
 CVAR (Bool, gennodes, false, CVAR_SERVERINFO|CVAR_GLOBALCONFIG);
 
-FARG(blockmap, "", "", "", "");
-FARG(enablelightmaps, "", "", "", "");
+FARG(blockmap, "Configuration", "Regenerates the map's BLOCKMAP.", "",
+	"Causes " GAMENAME " to ignore all the BLOCKMAP information a map provides and generate it"
+	" instead. This is equivalent to +set genblockmap 1.");
+
+FARG_ADVANCED(enablelightmaps, "Experimental", "", "");
 
 EXTERN_FARG(xlat);
 

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -6,6 +6,7 @@
 // Copyright 2002-2018 Christoph Oelckers
 // Copyright 2010 James Haley
 // Copyright 2017-2025 GZDoom Maintainers and Contributors
+// Copyright 2025 UZDoom Maintainers and Contributors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -94,6 +95,11 @@ enum
 
 CVAR (Bool, genblockmap, false, CVAR_SERVERINFO|CVAR_GLOBALCONFIG);
 CVAR (Bool, gennodes, false, CVAR_SERVERINFO|CVAR_GLOBALCONFIG);
+
+FARG(blockmap, "", "", "", "");
+FARG(enablelightmaps, "", "", "", "");
+
+EXTERN_FARG(xlat);
 
 inline bool P_LoadBuildMap(uint8_t *mapdata, size_t len, FMapThing **things, int *numthings)
 {
@@ -2603,7 +2609,7 @@ void MapLoader::LoadBlockMap (MapData * map)
 
 	if (ForceNodeBuild || genblockmap ||
 		count/2 >= 0x10000 || count == 0 ||
-		Args->CheckParm("-blockmap")
+		Args->CheckParm(FArg_blockmap)
 		)
 	{
 		DPrintf (DMSG_SPAMMY, "Generating BLOCKMAP\n");
@@ -2973,7 +2979,7 @@ void MapLoader::LoadLevel(MapData *map, const char *lumpname, int position)
 		else
 		{
 			// Has the user overridden the game's default translator with a commandline parameter?
-			translator = Args->CheckValue("-xlat");
+			translator = Args->CheckValue(FArg_xlat);
 			if (translator == nullptr)
 			{
 				// Use the game's default.
@@ -3366,7 +3372,7 @@ void MapLoader::LoadLightmap(MapData *map)
 	Level->LPWidth = 0;
 	Level->LPHeight = 0;
 
-	if (!Args->CheckParm("-enablelightmaps"))
+	if (!Args->CheckParm(FArg_enablelightmaps))
 		return;		// this feature is still too early WIP to allow general access
 
 	if (!map->Size(ML_LIGHTMAP))

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -67,7 +67,9 @@ CVAR (Int, r_rail_trailsparsity, 1, CVAR_ARCHIVE);
 CVAR (Bool, r_particles, true, 0);
 EXTERN_CVAR(Int, r_maxparticles);
 
-FARG(numparticles, "", "", "", "");
+FARG(numparticles, "Performance", "Max number of particles", "",
+	"Sets r_maxparticles on a per-run basis, controlling the maximum number of particles that are"
+	" allowed to spawn at one time");
 
 FCRandom pr_railtrail("RailTrail");
 

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -4,6 +4,8 @@
 **
 **---------------------------------------------------------------------------
 ** Copyright 1998-2006 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -64,6 +66,8 @@ CVAR (Int, r_rail_spiralsparsity, 1, CVAR_ARCHIVE);
 CVAR (Int, r_rail_trailsparsity, 1, CVAR_ARCHIVE);
 CVAR (Bool, r_particles, true, 0);
 EXTERN_CVAR(Int, r_maxparticles);
+
+FARG(numparticles, "", "", "", "");
 
 FCRandom pr_railtrail("RailTrail");
 
@@ -173,7 +177,7 @@ void P_InitParticles (FLevelLocals *Level)
 	const char *i;
 	int num;
 
-	if ((i = Args->CheckValue ("-numparticles")))
+	if ((i = Args->CheckValue (FArg_numparticles)))
 		num = atoi (i);
 	// [BC] Use r_maxparticles now.
 	else

--- a/src/scripting/decorate/thingdef_parse.cpp
+++ b/src/scripting/decorate/thingdef_parse.cpp
@@ -6,6 +6,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 2002-2016 Christoph Oelckers
 ** Copyright 2004-2016 Randy Heit
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -53,6 +55,7 @@
 void ParseOldDecoration(FScanner &sc, EDefinitionType def, PNamespace *ns);
 EXTERN_CVAR(Bool, strictdecorate);
 
+FARG(allowdecoratecrossincludes, "", "", "", "");
 
 //==========================================================================
 //
@@ -1280,7 +1283,7 @@ void ParseDecorate (FScanner &sc, PNamespace *ns)
 		{
 			sc.MustGetString();
 			// This check needs to remain overridable for testing purposes.
-			if (fileSystem.GetFileContainer(sc.LumpNum) == 0 && !Args->CheckParm("-allowdecoratecrossincludes"))
+			if (fileSystem.GetFileContainer(sc.LumpNum) == 0 && !Args->CheckParm(FArg_allowdecoratecrossincludes))
 			{
 				int includefile = fileSystem.GetFileContainer(fileSystem.CheckNumForFullName(sc.String, true));
 				if (includefile != 0)

--- a/src/scripting/decorate/thingdef_parse.cpp
+++ b/src/scripting/decorate/thingdef_parse.cpp
@@ -55,7 +55,9 @@
 void ParseOldDecoration(FScanner &sc, EDefinitionType def, PNamespace *ns);
 EXTERN_CVAR(Bool, strictdecorate);
 
-FARG(allowdecoratecrossincludes, "", "", "", "");
+FARG_ADVANCED(allowdecoratecrossincludes, "Deprecated", "",
+	"This disables the check that normally prevents external DECORATE lumps from overriding those"
+	" with the same name in the main .pk3");
 
 //==========================================================================
 //

--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -8,6 +8,7 @@
 ** Copyright 1999-2016 Randy Heit
 ** Copyright 2002-2019 Christoph Oelckers
 ** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 **
 ** Redistribution and use in source and binary forms, with or without
 ** modification, are permitted provided that the following conditions
@@ -214,7 +215,7 @@ void S_Init()
 	}
 
 	I_InitSound();
-	I_InitMusic(Args->CheckParm("-nomusic") || Args->CheckParm("-nosound"));
+	I_InitMusic(Args->CheckParm(FArg_nomusic) || Args->CheckParm(FArg_nosound));
 
 	// Heretic and Hexen have sound curve lookup tables. Doom does not.
 	int curvelump = fileSystem.CheckNumForName("SNDCURVE");


### PR DESCRIPTION
Working towards having a `-help` flag

The idea is that instead of using a raw string to check for args, we use a CVAR style object. When defining the object, the flag can be documented, and that data can be pulled into a commandline help flag

There are 3 main macros:
- `FARG(argument, section, summary, usage, details`
- `FARG_ADVANCED(argument, section, summary, usage, details)`
- `EXTERN_FARG(argument)`

The advanced one will hide the flag from the normal `-help` message, but expose it in a `-help-all`.

`argument` is the name of the arg.
`section` is used for organizing the args in the help message (eg -0 goes into 'Debug', -warp goes into 'Loading')
`summary` is a brief description of the option (currently pulled from wiki and summarized by me)
`usage` shows the args needed for the flag
`description` is a description  of the arg. Currently these are pull from the wiki. (but there a a lot missing).

I believe every commandline arg defined in the code has been covered.

These are all the documented flags (I might have missed osx-specific ones):
> `-0`, `-allowduplicates`, `-altdeath`, `-avg`, `-bex`, `-blockmap`, `-config`, `-deathmatch`, `-deh`, `-devparm`, `-dumpjit`, `-dup`, `-exec`, `-extratic`, `-fast`, `-file`, `-optfile`, `-h`, `-height`, `-help`, `-help-all`, `-host`, `-iwad`, `-join`, `-loadgame`, `-netmode`, `-noautoexec`, `-noautoload`, `-noblit`, `-nodraw`, `-noidle`, `-nojoy`, `-nomonsters`, `-nomusic`, `-norun`, `-nosfx`, `-nosound`, `-nostartup`, `-oldsprites`, `-playdemo`, `-port`, `-record`, `-respawn`, `-savedir`, `-skill`, `-stdout`, `-timedemo`, `-timer`, `-turbo`, `-warp`, `-warpwipe`, `-width`, `-xlat`, `/?`

None of the args have been marked as 'advanced', which would hide them from the basic help menu. I think a fair few of them should.

These are the args I could not find any documentation for:
> `+logfile`, `+map`, `-allowdecoratecrossincludes`, `-bots`, `-compatmode`, `-coop`, `-dumpast`, `-dumpdisasm`, `-dumpjitmod`, `-enablelightmaps`, `-episode`, `-errorlog`, `-glversion`, `-nobrightmaps`, `-nocustommenu`, `-noextras`, `-nointro`, `-nolights`, `-nowidescreen`, `-numparticles`, `-password`, `-rngseed`, `-shotdir`, `-tracefile`

Sample help output screenshot. left is `-help-all` right is `-help`

> <img width="2256" height="1504" alt="Screenshot_20250716_193156" src="https://github.com/user-attachments/assets/8954bae0-d76a-4da1-9edd-e2fecb4d179e" />

Imported from https://github.com/ZDoom/gzdoom/pull/3206