### PR TITLE
Launcher checks for extra WADs

### DIFF
--- a/src/launcher/settingspage.h
+++ b/src/launcher/settingspage.h
@@ -44,4 +44,6 @@ private:
 
 	TArray<std::pair<FString, FString>> languages;
 	bool hideLanguage = false;
+
+	int ExtraWadFlags = 0;
 };


### PR DESCRIPTION
If these WADs don't exist, then don't show them on the launcher. This is to better support indie games, since these would all be illegal to distribute in paid products.

# Testing steps

1. Make sure all of the extra WADs (lights.pk3, brightmaps.pk3, game_widescreen_gfx.pk3) are present
2. Open as launcher, ensure the "Extra Graphics" section is present (it is on the top-right of the "Options" tab)
3. Close launcher, move/delete the extra WADs
4. Re-open launcher, ensure the "Extra Graphics" section is gone

You can also test different combinations of files being present. This should function fine, but it's also not really a priority for support (distributions are expected to be be all-or-nothing).

I have currently definitively tested this on Windows, on Linux directly, and as a Linux AppImage. Help testing as many Linux distros is always appreciated, and I have no way to test it on Mac.

I also would appreciate any testing from people with poor disk speeds, because I'm worried that the search required to find the extra WADs may take a while, especially if you have a lot of IWADSearch paths. (It's probably fine, I'm just paranoid.)
