### PR TITLE
[Nit] Editor Configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,11 @@
+BasedOnStyle: Microsoft
+UseTab: AlignWithSpaces
+AlignArrayOfStructures: Right
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: Consecutive
+AlignConsecutiveMacros: Consecutive
+
+# use these to disable formatting, when needed
+# // clang-format off
+# // clang-format on

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/src/common/audio/sound/thirdparty/.clang-format
+++ b/src/common/audio/sound/thirdparty/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/src/common/engine/namedef.h
+++ b/src/common/engine/namedef.h
@@ -1,4 +1,5 @@
 // common names
+// clang-format off
 
 // 'None' must always be the first name.
 xx(None)
@@ -299,3 +300,5 @@ xx(CheckDeprecatedFlags)
 
 xx(ScreenJobRunner)
 xx(Action)
+
+// clang-format on

--- a/src/common/engine/sc_man_tokens.h
+++ b/src/common/engine/sc_man_tokens.h
@@ -1,3 +1,5 @@
+// clang-format off
+
 xx(TK_Identifier,			"identifier")
 xx(TK_StringConst,			"string constant")
 xx(TK_NameConst,			"name constant")
@@ -157,3 +159,5 @@ xx(TK_Bright,				"'bright'")
 xx(TK_Let,					"'let'")
 xx(TK_StaticConst,			"'static const'")
 #undef xx
+
+// clang-format on

--- a/src/common/scripting/vm/vmops.h
+++ b/src/common/scripting/vm/vmops.h
@@ -2,6 +2,8 @@
 #define xx(op, name, mode, alt, kreg, ktype) OP_##op,
 #endif
 
+// clang-format off
+
 // first row is the opcode
 // second row is the disassembly name
 // third row is the disassembly flags
@@ -294,3 +296,5 @@ xx(EQA_K,		beq,	CPRK,		EQA_R,	4, REGT_POINTER)
 xx(NULLCHECK, nullcheck, RP,	NOP, 0, 0) // EmitNullPointerThrow(pA)
 
 #undef xx
+
+// clang-format on

--- a/src/common/thirdparty/.clang-format
+++ b/src/common/thirdparty/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/src/namedef_custom.h
+++ b/src/namedef_custom.h
@@ -1,3 +1,5 @@
+// clang-format off
+
 // GZDoom specific names
 
 xx(Doom)
@@ -927,3 +929,5 @@ xx(movefactor)
 
 xx(Corona)
 xx(BuiltinStateOffset)
+
+// clang-format on


### PR DESCRIPTION
Adds an [.editorconfig](https://editorconfig.org/) file to allow for everyone's text editors to automatically agree on things like indentation and line endings.

Adds a (yet unused) [.clang-format](https://clang.llvm.org/docs/ClangFormat.html) file, to reduce code churn and enforce a consistent style