### PR TITLE
Default autostart / skill cvar to MAPINFO's defaultskill

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -321,6 +321,7 @@ int NoWipe;				// [RH] Allow wipe? (Needs to be set each time)
 bool singletics = false;	// debug flag to cancel adaptiveness
 FString startmap;
 bool setmap;
+int setskill = -1;
 bool autostart;
 bool advancedemo;
 FILE *debugfile;
@@ -2166,11 +2167,12 @@ static void CheckCmdLine()
 		startmap = "&wt@01";
 	}
 	autostart = StoredWarp.IsNotEmpty();
-				
+
+	setskill = -1;
 	const char *val = Args->CheckValue ("-skill");
 	if (val)
 	{
-		gameskill = val[0] - '1';
+		setskill = val[0] - '1';
 		autostart = true;
 	}
 
@@ -2257,7 +2259,7 @@ static void CheckCmdLine()
 		StartScreen->AppendStatusLine("Respawning...");
 	if (autostart)
 	{
-		FStringf temp("Warp to map %s, Skill %d ", startmap.GetChars(), gameskill + 1);
+		FStringf temp("Warp to map %s, Skill %d ", startmap.GetChars(), setskill + 1);
 		StartScreen->AppendStatusLine(temp.GetChars());
 	}
 }
@@ -2291,6 +2293,20 @@ static void CheckEpisodeCmd()
 	setmap = true;
 	if (setEpisode)
 		autostart = true;
+}
+
+static void CheckDefaultSkill()
+{
+	// Change skill cvar default to this game's defaultskill
+	UCVarValue val;
+	val.Int = DefaultSkill;
+	gameskill->SetGenericRepDefault(val, CVAR_Int);
+
+	if (setskill >= 0)
+	{
+		// -skill was defined, use that instead.
+		gameskill = setskill;
+	}
 }
 
 static void NewFailure ()
@@ -3385,6 +3401,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	// [RH] Parse through all loaded mapinfo lumps
 	if (!batchrun) Printf ("G_ParseMapInfo: Load map definitions.\n");
 	G_ParseMapInfo (iwad_info->MapInfo);
+	CheckDefaultSkill();
 	CheckEpisodeCmd();
 	MessageBoxClass = gameinfo.MessageBoxClass;
 	endoomName = gameinfo.Endoom;


### PR DESCRIPTION
Changes the following to default to MAPINFO's `defaultskill` setting:
 - Warping to maps
 - Resetting the "skill" cvar

I did this because I have a project that has 4 skills instead of 5, so the hardcoded default of 2 doesn't match. I can manually change the default in an IWAD with DEFCVARS, but I've seen lots of gameplay mods define their own skill lists, so it'd be nice to let these mods define the command line's default skill, too.

# Testing instructions

1. Run any game with any autostart parameter (`-warp`, `-episode`, etc)
2. Check "skill" in console, current skill and the default should both be 2.
3. Close, re-run with this mod: [default-skill-test.zip](https://github.com/user-attachments/files/22918130/default-skill-test.zip)
4. Check "skill" again, should be 1 now.
