### PR TITLE
Option for automap lines to scale w/ status bar

### DIFF
--- a/src/am_map.h
+++ b/src/am_map.h
@@ -45,6 +45,7 @@ public:
 	virtual void Drawer(int bottom) = 0;
 
 	virtual void NewResolution() = 0;
+	virtual void NewUIScale() = 0;
 	virtual void LevelInit() = 0;
 	virtual void UpdateShowAllLines() = 0;
 	virtual void GoBig() = 0;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3103,6 +3103,9 @@ static void System_HudScaleChanged()
 		StatusBar->SetScale();
 		setsizeneeded = true;
 	}
+
+	if (primaryLevel && primaryLevel->automap)
+		primaryLevel->automap->NewUIScale();
 }
 
 bool  CheckSkipGameOptionBlock(const char* str);


### PR DESCRIPTION
Setting `am_linethickness 0` will scale the automap line thickness based on the rest of the status bar's scaling.

I implemented this just because I would like to keep UI scale in my IWAD consistent and not ask players to adjust options on first boot.
