### PR TITLE
Don't use SDL_StartTextInput workaround for Wayland on SDL 2.0.18 and later

### DIFF
--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -183,7 +183,7 @@ namespace Priv
 			// Enforce minimum size limit
 			SDL_SetWindowMinimumSize(Priv::window, VID_MIN_WIDTH, VID_MIN_HEIGHT);
 			// Tell SDL to start sending text input on Wayland if it's on affected versions.
-			if (strncasecmp(SDL_GetCurrentVideoDriver(), "wayland", 7) == 0 && !(sdlver.major >= 2 && sdlver.minor >= 0 && sdlver.patch >= 18))
+			if (strncasecmp(SDL_GetCurrentVideoDriver(), "wayland", 7) == 0 && sdlver.major == 2 && sdlver.minor == 0 && sdlver.patch < 18)
 				SDL_StartTextInput();
 		}
 	}


### PR DESCRIPTION
Don't use SDL_StartTextInput workaround for Wayland on SDL 2.0.18 and later versions.

Fixes keyboard input not working on some Wayland setups.