### PR TITLE
[Fix] Re-license to GPLv2

### DIFF
--- a/src/common/engine/m_haptics.cpp
+++ b/src/common/engine/m_haptics.cpp
@@ -8,10 +8,10 @@
 ** Copyright 2025 Marcus Minhorst
 ** Copyright 2025 GZDoom Maintainers and Contributors
 **
-** This program is free software: you can redistribute it and/or modify
-** it under the terms of the GNU General Public License as published by
-** the Free Software Foundation, either version 3 of the License, or
-** (at your option) any later version.
+** This program is free software; you can redistribute it and/or
+** modify it under the terms of the GNU General Public License
+** as published by the Free Software Foundation; either version 2
+** of the License, or (at your option) any later version.
 **
 ** This program is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -19,7 +19,7 @@
 ** GNU General Public License for more details.
 **
 ** You should have received a copy of the GNU General Public License
-** along with this program.  If not, see http://www.gnu.org/licenses/
+** along with this program; if not, see https://www.gnu.org/licenses/
 **
 **---------------------------------------------------------------------------
 **


### PR DESCRIPTION
Re-license file to GPLv2, in order to allow Raze to use it