### PR TITLE
Fix "CreateTossable" keeping certain items at zero amount

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -782,7 +782,8 @@ class Inventory : Actor
 		{
 			return NULL;
 		}
-		if (Amount == 1 && !bKeepDepleted)
+		amt = clamp(amt, 1, Amount);
+		if (Amount == amt && !bKeepDepleted)
 		{
 			BecomePickup ();
 			DropTime = 30;
@@ -792,8 +793,6 @@ class Inventory : Actor
 		let copy = Inventory(Spawn (GetClass(), Owner.Pos, NO_REPLACE));
 		if (copy != NULL)
 		{
-			amt = clamp(amt, 1, Amount);
-			
 			copy.MaxAmount = MaxAmount;
 			copy.Amount = amt;
 			copy.DropTime = 30;


### PR DESCRIPTION
Fixed a bug in CreateTossable where certain items would be kept even if their amounts where at zero despite not having the bKeepDepletedFlag.

In my [original issue report](https://github.com/UZDoom/UZDoom/issues/128) I erroneously used an ammo item as an example; note that by default ammo is kept at zero for various reasons, thus custom mod items or those from Heretic/Hexen would be more clear testing examples.

With help from Jay.