### PR TITLE
Made linked sectors respect the crush mode of their control sector

### DIFF
--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -785,7 +785,7 @@ struct sector_t
 	// Member functions
 
 private:
-	bool MoveAttached(int crush, double move, int floorOrCeiling, bool resetfailed, bool instant = false);
+	bool MoveAttached(int crush, double move, int floorOrCeiling, bool resetfailed, bool instant = false, bool* crushed = nullptr);
 public:
 	EMoveResult MoveFloor(double speed, double dest, int crush, int direction, bool hexencrush, bool instant = false);
 	EMoveResult MoveCeiling(double speed, double dest, int crush, int direction, bool hexencrush);


### PR DESCRIPTION
Previously these would always stop everything when blocked, similar to Hexen.  Also cleans up a few inconsistencies with how attached sector results are handled.

This may or may not need a ZDoom compatibility flag in the future if some maps were relying on this behavior (e.g. they didn't set the mode to Hexen or the damage value to < 0 to force it to stop). As such this will need to be monitored alongside the other consistency fixes potentially introducing breaks.

Fixes #135