### PR TITLE
Fix DropInventory removing depleted stacks

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -799,6 +799,10 @@ class Inventory : Actor
 			copy.DropTime = 30;
 			copy.bSpecial = copy.bSolid = false;
 			Amount -= amt;
+			if (Amount <= 0)
+			{
+				DepleteOrDestroy();
+			}
 		}
 		return copy;
 	}


### PR DESCRIPTION
## Summary
- ensure Inventory.CreateTossable destroys items that fully deplete when dropping
- leave KeepDepleted inventories intact at zero as expected
- dropping the last of an item now removes it from the player's inventory as described in #128

## Testing
- not run (engine requires runtime scenario)

Closes #128