### PR TITLE
Indicate shader compilation phase during startup when possible

### DIFF
--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -709,6 +709,7 @@ void FStartScreen::Render(bool force)
 		if (ShaderComp && NewConsoleFont)
 		{
 			FString compStr = GStrings.localize("$SHADERCOMPILING");
+			compStr.Truncate(compStr.Len() - (3 - ShaderComp));
 			auto strWidth = NewConsoleFont->StringWidth(compStr);
 			if (ShaderComp == 3)
 				compStr.AppendFormat("..");

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -708,18 +708,15 @@ void FStartScreen::Render(bool force)
 
 		if (ShaderComp && NewConsoleFont)
 		{
-			FString compStr("Compiling shaders.");
-			if (GStrings.CheckString("SHADERCOMPILING"))
-			{
-				compStr = GStrings.localize("$SHADERCOMPILING");
-			}
+			FString compStr = GStrings.localize("$SHADERCOMPILING");
+			auto strWidth = NewConsoleFont->StringWidth(compStr);
 			if (ShaderComp == 3)
 				compStr.AppendFormat("..");
 			else if (ShaderComp == 2)
 				compStr.AppendFormat(".");
 
 			Dim(twod, PalEntry(0, 0, 0, 255), 0.5, 0, 0, screen->GetWidth(), screen->GetHeight());
-			DrawText(twod, NewConsoleFont, CR_WHITE, (CleanWidth / 2) - (NewConsoleFont->StringWidth(compStr) / 2), (CleanHeight - (NewConsoleFont->GetHeight() * 2)), compStr.GetChars(), DTA_VirtualWidth, CleanWidth, DTA_VirtualHeight, CleanHeight, TAG_DONE);
+			DrawText(twod, NewConsoleFont, CR_WHITE, (CleanWidth / 2) - (strWidth / 2), (CleanHeight - (NewConsoleFont->GetHeight() * 2)), compStr.GetChars(), DTA_VirtualWidth, CleanWidth, DTA_VirtualHeight, CleanHeight, TAG_DONE);
 		}
 
 		twod->End();

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -711,10 +711,6 @@ void FStartScreen::Render(bool force)
 			FString compStr = GStrings.localize("$SHADERCOMPILING");
 			compStr.Truncate(compStr.Len() - (3 - ShaderComp));
 			auto strWidth = NewConsoleFont->StringWidth(compStr);
-			if (ShaderComp == 3)
-				compStr.AppendFormat("..");
-			else if (ShaderComp == 2)
-				compStr.AppendFormat(".");
 
 			Dim(twod, PalEntry(0, 0, 0, 255), 0.5, 0, 0, screen->GetWidth(), screen->GetHeight());
 			DrawText(twod, NewConsoleFont, CR_WHITE, (CleanWidth / 2) - (strWidth / 2), (CleanHeight - (NewConsoleFont->GetHeight() * 2)), compStr.GetChars(), DTA_VirtualWidth, CleanWidth, DTA_VirtualHeight, CleanHeight, TAG_DONE);

--- a/src/common/startscreen/startscreen.cpp
+++ b/src/common/startscreen/startscreen.cpp
@@ -706,6 +706,22 @@ void FStartScreen::Render(bool force)
 			DrawTexture(twod, StartupTexture, 0, 0, DTA_VirtualWidthF, displaywidth, DTA_VirtualHeightF, displayheight, TAG_END);
 		}
 
+		if (ShaderComp && NewConsoleFont)
+		{
+			FString compStr("Compiling shaders.");
+			if (GStrings.CheckString("SHADERCOMPILING"))
+			{
+				compStr = GStrings.localize("$SHADERCOMPILING");
+			}
+			if (ShaderComp == 3)
+				compStr.AppendFormat("..");
+			else if (ShaderComp == 2)
+				compStr.AppendFormat(".");
+
+			Dim(twod, PalEntry(0, 0, 0, 255), 0.5, 0, 0, screen->GetWidth(), screen->GetHeight());
+			DrawText(twod, NewConsoleFont, CR_WHITE, (CleanWidth / 2) - (NewConsoleFont->StringWidth(compStr) / 2), (CleanHeight - (NewConsoleFont->GetHeight() * 2)), compStr.GetChars(), DTA_VirtualWidth, CleanWidth, DTA_VirtualHeight, CleanHeight, TAG_DONE);
+		}
+
 		twod->End();
 		screen->Update();
 		twod->OnFrameDone();

--- a/src/common/startscreen/startscreen.h
+++ b/src/common/startscreen/startscreen.h
@@ -61,6 +61,8 @@ protected:
 	int Scale = 1;
 	int NetMaxPos = -1;
 	int NetCurPos = 0;
+	int ShaderComp = 0;
+	int strLocalized = -1;
 	FBitmap StartupBitmap;
 	FBitmap HeaderBitmap;
 	FBitmap NetBitmap;
@@ -72,6 +74,7 @@ public:
 	FStartScreen(int maxp) { MaxPos = maxp; }
 	virtual ~FStartScreen();
 	void Render(bool force = false);
+	void SetShaderComp(int comp) { ShaderComp = comp; }
 	bool Progress(int);
 	void NetProgress(int count);
 	virtual void LoadingStatus(const char *message, int colors) {}

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3790,6 +3790,8 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	{
 		// start the apropriate game based on parms
 		auto v = Args->CheckValue (FArg_record);
+		auto startTime = I_msTime();
+		auto shaderDispRotate = 2;
 
 		if (v)
 		{
@@ -3803,17 +3805,33 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 		StartWindow->Progress(max_progress);
 		if (StartScreen)
 		{
+			StartScreen->SetShaderComp(3);
 			StartScreen->Progress(max_progress);	// advance progress bar to the end.
 			StartScreen->Render(true);
 			StartScreen->Progress(max_progress);	// do this again because Progress advances the counter after redrawing.
 			StartScreen->Render(true);
-			delete StartScreen;
-			StartScreen = NULL;
 		}
 
 		while(!screen->CompileNextShader())
 		{
 			// here we can do some visual updates later
+			if (StartScreen)
+			{
+				if ((I_msTime() - startTime) >= 1000)
+				{
+					startTime = I_msTime();
+					shaderDispRotate++;
+					StartScreen->SetShaderComp(1 + (shaderDispRotate % 3));
+					StartScreen->Render(true);
+				}
+			}
+		}
+		if (StartScreen)
+		{
+			StartScreen->SetShaderComp(false);
+			StartScreen->Render(true);
+			delete StartScreen;
+			StartScreen = NULL;
 		}
 		twod->fullscreenautoaspect = gameinfo.fullscreenautoaspect;
 		// Initialize the size of the 2D drawer so that an attempt to access it outside the draw code won't crash.


### PR DESCRIPTION
This PR indicates shader compilation phase during startup when possible, especially if start screens are displayed.

https://github.com/user-attachments/assets/02a76124-6a84-4e97-ad5b-e2b8475ec1ec

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.