### PR TITLE
emulate legacy behavior of alpha > 1 treated as fraction of 255

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -736,6 +736,7 @@ CVAR (Flag, compat_nombf21,				compatflags2, COMPATF2_NOMBF21);
 CVAR (Flag, compat_voodoozombies,		compatflags2, COMPATF2_VOODOO_ZOMBIES);
 CVAR (Flag, compat_fdteleport,			compatflags2, COMPATF2_FDTELEPORT);
 CVAR (Flag, compat_novdolllockmsg,		compatflags2, COMPATF2_NOVDOLLLOCKMSG);
+CVAR (Flag, compat_alphawraparound,		compatflags2, COMPATF2_ALPHAWRAPAROUND);
 
 CVAR(Bool, vid_activeinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -240,6 +240,7 @@ enum : unsigned int
 	COMPATF2_FDTELEPORT		= 1 << 16,	// Emulate Final Doom's teleporter z glitch.
 	COMPATF2_NOACSARGCHECK	= 1 << 17,	// Disable arg count checking for ACS
 	COMPATF2_NOVDOLLLOCKMSG = 1 << 18,	// Voodoo dolls no longer trigger lock messages
+	COMPATF2_ALPHAWRAPAROUND = 1 << 19,	// Alpha values > 1 are treated as a fraction of 255
 };
 
 // Emulate old bugs for select maps. These are not exposed by a cvar

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1944,6 +1944,7 @@ MapFlagHandlers[] =
 	{ "compat_voodoozombies",			MITYPE_COMPATFLAG, 0, COMPATF2_VOODOO_ZOMBIES },
 	{ "compat_noacsargcheck",			MITYPE_COMPATFLAG, 0, COMPATF2_NOACSARGCHECK },
 	{ "compat_novdolllockmsg",			MITYPE_COMPATFLAG, 0, COMPATF2_NOVDOLLLOCKMSG },
+	{ "compat_alphawraparound",			MITYPE_COMPATFLAG, 0, COMPATF2_ALPHAWRAPAROUND },
 
 	{ "cd_start_track",					MITYPE_EATNEXT,	0, 0 },
 	{ "cd_end1_track",					MITYPE_EATNEXT,	0, 0 },

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -821,7 +821,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 
 	//compat trick: some old WADs put alpha values in decorate from 0-255 (ex: Pirate Doom). This accidentally "worked" in certain versions of GZDoom.
 	//only the harware renderer is reported to have this issue, so it is patched here.
-	if (alpha > 1.0)
+	if (alpha > 1.0 && di->Level->i_compatflags2 & COMPATF2_ALPHAWRAPAROUND)
 	{
 		alpha /= 255.;
 	}

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -817,7 +817,15 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	const auto &vp = di->Viewpoint;
 	AActor *camera = vp.camera;
 
-	const double alpha = thing->InterpolatedAlpha(vp.TicFrac);
+	double alpha = thing->InterpolatedAlpha(vp.TicFrac);
+
+	//compat trick: some old WADs put alpha values in decorate from 0-255 (ex: Pirate Doom). This accidentally "worked" in certain versions of GZDoom.
+	//only the harware renderer is reported to have this issue, so it is patched here.
+	if (alpha > 1.0)
+	{
+		alpha /= 255.;
+	}
+
 	if (thing->renderflags & RF_INVISIBLE || !thing->RenderStyle.IsVisible(alpha))
 	{
 		if (!(thing->flags & MF_STEALTH) || !di->isStealthVision() || thing == camera)


### PR DESCRIPTION
In response to https://github.com/UZDoom/UZDoom/issues/100, this does the "treat alpha > 1.0 as a fraction of 255" behavior for the hardware sprite rendering.

- [ ] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.