### PR TITLE
Fix the music used in Strife's mediocre/sad ending.

### DIFF
--- a/wadsrc/static/mapinfo/strife.txt
+++ b/wadsrc/static/mapinfo/strife.txt
@@ -419,7 +419,7 @@ Intermission Inter_Strife_Sad
 {
 	Image
 	{
-		Music = "D_SAD"
+		Music = "D_END"
 		Background = "SS6F1"
 		Sound = "svox/ss601a"
 		Subtitle = "$TXT_SUB_SAD1"


### PR DESCRIPTION
This fixes an oversight regarding Strife's MAPINFO that has existed since the original ZDoom. The Inter_Strife_Sad ending sequence plays the music D_SAD. However, this is incorrect and not what vanilla Strife does. In vanilla Strife, the music D_END actually plays during this ending.

See this line of code from Chocolate Strife, which specifies "mus_end" to play in this same ending: https://github.com/chocolate-doom/chocolate-doom/blob/efecec6963cbd48be54136f7eefd8bf286480bab/src/strife/f_finale.c#L392

I suspect this oversight may have happened because the two songs sound quite similar, and you could mistakenly think it was D_SAD playing if you were just going off of what you hear in the ending rather than the code.