### PR TITLE
Fix flatsprites on reflective flats rendering under/over floor/ceiling.

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -393,6 +393,15 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 		pitch.Normalized180();
 
 		mat.Translate(x, z, y);
+		// Account for zshift in hw_flats.cpp due to flat stencils used to render reflective flats
+		if ((actor->Sector->GetReflect(sector_t::floor) > 0) && (z == actor->floorz))
+		{
+			mat.Translate(0, 0.1f, 0);
+		}
+		else if ((actor->Sector->GetReflect(sector_t::ceiling) > 0) && (z == actor->ceilingz))
+		{
+			mat.Translate(0, -0.1f, 0);
+		}
 		mat.Rotate(0, 1, 0, 270. - Angles.Yaw.Degrees());
 		mat.Rotate(1, 0, 0, pitch.Degrees());
 


### PR DESCRIPTION
Moving to a planar stencil to render reflections in flats needed a zshift for both the flat texture and any flatsprites coplanar with it. I had forgotten about the flatsprites.

Test pk3 (just walk around and look at flatsprites on the ground): 
[flatsprites_reflect.zip](https://github.com/user-attachments/files/22995503/flatsprites_reflect.zip)
