### PR TITLE
Allow MoviePlayer instances to use different texture targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1061,6 +1061,7 @@ set (PCH_SOURCES
 	common/cutscenes/playmve.cpp
 	common/cutscenes/movieplayer.cpp
 	common/cutscenes/screenjob.cpp
+	common/cutscenes/vidtexmanager.cpp
 	common/utility/engineerrors.cpp
 
 	common/utility/gitinfo.cpp

--- a/src/common/cutscenes/movieplayer.cpp
+++ b/src/common/cutscenes/movieplayer.cpp
@@ -52,26 +52,7 @@
 #include <zmusic.h>
 #include "filereadermusicinterface.h"
 #include "texturemanager.h"
-
-class MoviePlayer
-{
-protected:
-	enum EMovieFlags
-	{
-		NOSOUNDCUTOFF = 1,
-		FIXEDVIEWPORT = 2,	// Forces fixed 640x480 screen size like for Blood's intros.
-		NOMUSICCUTOFF = 4,
-	};
-
-	int flags;
-public:
-	virtual void Start() {}
-	virtual bool Frame(uint64_t clock) = 0;
-	virtual void Stop() {}
-	virtual ~MoviePlayer() = default;
-	virtual FTextureID GetTexture() = 0;
-	virtual void SetTarget(FTextureID first) = 0;
-};
+#include "movieplayer.h"
 
 //---------------------------------------------------------------------------
 //
@@ -170,6 +151,7 @@ public:
 	AnmPlayer(FileReader& fr, TArray<int>& ans, const int *frameticks, int flags_)
 		: animSnd(std::move(ans))
 	{
+		if (!frameticks) return;
 		memcpy(frameTicks, frameticks, 3 * sizeof(int));
 		flags = flags_;
 		buffer = fr.ReadPadded(1);
@@ -238,7 +220,7 @@ public:
 
 	~AnmPlayer()
 	{
-		animtex.Clean();
+		animtex.Clean(true);
 	}
 
 	FTextureID GetTexture() override
@@ -635,7 +617,7 @@ public:
 			ZMusic_Close(MusicStream);
 		}
 		vpx_codec_destroy(&codec);
-		animtex.Clean();
+		animtex.Clean(true);
 	}
 
 	FTextureID GetTexture() override
@@ -838,7 +820,7 @@ public:
 	{
 		AudioTrack.Finish();
 		Smacker_Close(hSMK);
-		animtex.Clean();
+		animtex.Clean(true);
 	}
 
 	FTextureID GetTexture() override

--- a/src/common/cutscenes/movieplayer.cpp
+++ b/src/common/cutscenes/movieplayer.cpp
@@ -51,6 +51,7 @@
 #include <cmath>
 #include <zmusic.h>
 #include "filereadermusicinterface.h"
+#include "texturemanager.h"
 
 class MoviePlayer
 {
@@ -69,6 +70,7 @@ public:
 	virtual void Stop() {}
 	virtual ~MoviePlayer() = default;
 	virtual FTextureID GetTexture() = 0;
+	virtual void SetTargets(FTextureID first, FTextureID second) = 0;
 };
 
 //---------------------------------------------------------------------------
@@ -229,6 +231,10 @@ public:
 		if (!nostopsound) soundEngine->StopAllChannels();
 	}
 
+	void SetTargets(FTextureID first, FTextureID second)
+	{
+		animtex.SetTargets(first, second);
+	}
 
 	~AnmPlayer()
 	{
@@ -295,6 +301,11 @@ public:
 		audioTrack.Finish();
 
 		decoder.Close();
+	}
+
+	void SetTargets(FTextureID first, FTextureID second)
+	{
+		decoder.animTex().SetTargets(first, second);
 	}
 
 	FTextureID GetTexture() override
@@ -631,6 +642,11 @@ public:
 	{
 		return animtex.GetFrameID();
 	}
+
+	void SetTargets(FTextureID first, FTextureID second)
+	{
+		animtex.SetTargets(first, second);
+	}
 };
 
 //---------------------------------------------------------------------------
@@ -830,6 +846,10 @@ public:
 		return animtex.GetFrameID();
 	}
 
+	void SetTargets(FTextureID first, FTextureID second)
+	{
+		animtex.SetTargets(first, second);
+	}
 };
 
 //---------------------------------------------------------------------------
@@ -981,4 +1001,15 @@ DEFINE_ACTION_FUNCTION(_MoviePlayer, GetTexture)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(MoviePlayer);
 	ACTION_RETURN_INT(self->GetTexture().GetIndex());
+}
+
+DEFINE_ACTION_FUNCTION(_MoviePlayer, SetTargets)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(MoviePlayer);
+	PARAM_INT(first);
+	PARAM_INT(second);
+
+	self->SetTargets(TexMan.GameByIndex(first)->GetID(), TexMan.GameByIndex(second)->GetID());
+
+	return 0;
 }

--- a/src/common/cutscenes/movieplayer.cpp
+++ b/src/common/cutscenes/movieplayer.cpp
@@ -70,7 +70,7 @@ public:
 	virtual void Stop() {}
 	virtual ~MoviePlayer() = default;
 	virtual FTextureID GetTexture() = 0;
-	virtual void SetTargets(FTextureID first, FTextureID second) = 0;
+	virtual void SetTarget(FTextureID first) = 0;
 };
 
 //---------------------------------------------------------------------------
@@ -231,9 +231,9 @@ public:
 		if (!nostopsound) soundEngine->StopAllChannels();
 	}
 
-	void SetTargets(FTextureID first, FTextureID second)
+	void SetTarget(FTextureID first)
 	{
-		animtex.SetTargets(first, second);
+		animtex.SetTarget(first);
 	}
 
 	~AnmPlayer()
@@ -303,9 +303,9 @@ public:
 		decoder.Close();
 	}
 
-	void SetTargets(FTextureID first, FTextureID second)
+	void SetTarget(FTextureID first)
 	{
-		decoder.animTex().SetTargets(first, second);
+		decoder.animTex().SetTarget(first);
 	}
 
 	FTextureID GetTexture() override
@@ -643,9 +643,9 @@ public:
 		return animtex.GetFrameID();
 	}
 
-	void SetTargets(FTextureID first, FTextureID second)
+	void SetTarget(FTextureID first)
 	{
-		animtex.SetTargets(first, second);
+		animtex.SetTarget(first);
 	}
 };
 
@@ -846,9 +846,9 @@ public:
 		return animtex.GetFrameID();
 	}
 
-	void SetTargets(FTextureID first, FTextureID second)
+	void SetTarget(FTextureID first)
 	{
-		animtex.SetTargets(first, second);
+		animtex.SetTarget(first);
 	}
 };
 
@@ -1003,13 +1003,12 @@ DEFINE_ACTION_FUNCTION(_MoviePlayer, GetTexture)
 	ACTION_RETURN_INT(self->GetTexture().GetIndex());
 }
 
-DEFINE_ACTION_FUNCTION(_MoviePlayer, SetTargets)
+DEFINE_ACTION_FUNCTION(_MoviePlayer, SetTarget)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(MoviePlayer);
 	PARAM_INT(first);
-	PARAM_INT(second);
 
-	self->SetTargets(TexMan.GameByIndex(first)->GetID(), TexMan.GameByIndex(second)->GetID());
+	self->SetTarget(TexMan.GameByIndex(first)->GetID());
 
 	return 0;
 }

--- a/src/common/cutscenes/movieplayer.h
+++ b/src/common/cutscenes/movieplayer.h
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include "animtexture.h"
+#include "texturemanager.h"
+
+class MoviePlayer
+{
+protected:
+	int flags;
+public:
+	// public because it's needed for the video manager.
+	enum EMovieFlags
+	{
+		NOSOUNDCUTOFF = 1,
+		FIXEDVIEWPORT = 2,	// Forces fixed 640x480 screen size like for Blood's intros.
+		NOMUSICCUTOFF = 4,
+	};
+
+	virtual void Start() {}
+	virtual bool Frame(uint64_t clock) = 0;
+	virtual void Stop() {}
+	virtual ~MoviePlayer() { Stop(); };
+	virtual FTextureID GetTexture() = 0;
+	virtual void SetTarget(FTextureID first) = 0;
+};
+
+MoviePlayer* OpenMovie(const char* filename, TArray<int>& ans, const int* frameticks, int flags, FString& error);

--- a/src/common/cutscenes/playmve.cpp
+++ b/src/common/cutscenes/playmve.cpp
@@ -511,6 +511,7 @@ void InterplayDecoder::Close()
         pVideoBuffers[1] = nullptr;
     }
 
+	animTex().Clean(true);
 }
 
 bool InterplayDecoder::Open(FileReader &fr_)

--- a/src/common/cutscenes/vidtexmanager.cpp
+++ b/src/common/cutscenes/vidtexmanager.cpp
@@ -1,0 +1,130 @@
+#include "vidtexmanager.h"
+#include "printf.h"
+#include "i_time.h"
+#include "animtexture.h"
+#include "s_music.h"
+#include "vm.h"
+
+FVideoManager VidMan;
+
+void FVideoManager::DeleteAll()
+{
+	for (int i = 0; i < videos.size(); i++)
+	{
+		auto& curvid = videos[i];
+		if (curvid.videostate != VIDSTATE_Stopped)
+		{
+			curvid.player->Stop();
+			static_cast<AnimTexture*>(TexMan.GetGameTexture(curvid.target_tex)->GetTexture())->ClearFrame();
+			TexMan.GetGameTexture(curvid.target_tex)->CleanHardwareData();
+		}
+	}
+	videos.Clear();
+}
+
+void FVideoManager::StopVideo(int vid)
+{
+	for (int i = 0; i < videos.size(); i++)
+	{
+		auto& curvid = videos[i];
+		if (curvid.id == vid)
+		{
+			curvid.player->Stop();
+			videos.Delete(i);
+			return;
+		}
+	}
+}
+
+void FVideoManager::TickAll()
+{
+	auto curMs = I_msTime();
+	for (int i = 0; i < videos.size(); i++)
+	{
+		auto& curvid = videos[i];
+		if (curvid.videostate == VIDSTATE_Starting)
+		{
+			curvid.startTicksMs = curMs;
+			curvid.player->Start();
+			curvid.player->Frame(0);
+			curvid.videostate = VIDSTATE_Running;
+		}
+		else if (curvid.videostate == VIDSTATE_Running)
+		{
+			if (!curvid.player->Frame((curMs - curvid.startTicksMs) * 1000000))
+			{
+				curvid.player->Stop();
+				videos.Delete(i);
+			}
+		}
+	}
+}
+
+int FVideoManager::AddVideo(const FString& filename, FTextureID target, TArray<int>& ans, int firstframetime, int lastframetime, int frametime, int flags)
+{
+	FString error;
+	if (!target.Exists())
+	{
+		return -1;
+	}
+	videos.Resize(videos.Size() + 1);
+	auto& lastVid = videos[videos.Size() - 1];
+
+	lastVid.videostate = VIDSTATE_Stopped;
+	if (firstframetime == -1) firstframetime = frametime;
+	if (lastframetime == -1) lastframetime = frametime;
+	int frametimes[] = { firstframetime, frametime, lastframetime };
+	lastVid.player.reset(OpenMovie(filename.GetChars(), ans, frametime == -1 ? nullptr : frametimes, flags, error));
+	if (!lastVid.player)
+	{
+		Printf(TEXTCOLOR_YELLOW "%s", error.GetChars());
+		videos.Pop();
+		return -1;
+	}
+	lastVid.player->SetTarget(target);
+	lastVid.startTicksMs = I_msTime();
+	lastVid.videostate = VIDSTATE_Starting;
+	internalid++;
+	lastVid.id = internalid;
+	if (!(flags & MoviePlayer::NOMUSICCUTOFF))
+	{
+		S_StopMusic(true);
+	}
+	return internalid;
+}
+
+DEFINE_ACTION_FUNCTION(_VidMan, AddVideo)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(filename);
+	PARAM_INT(target);
+	PARAM_POINTER(sndinf, TArray<int>);
+	PARAM_INT(frametime);
+	PARAM_INT(firstframetime);
+	PARAM_INT(lastframetime);
+	PARAM_INT(flags);
+	ACTION_RETURN_INT(VidMan.AddVideo(filename, FSetTextureID(target), *sndinf, firstframetime, lastframetime, frametime, flags));
+}
+
+DEFINE_ACTION_FUNCTION(_VidMan, GetVideoTime)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(vid);
+	ACTION_RETURN_INT(VidMan.GetVideoTime(vid));
+}
+
+DEFINE_ACTION_FUNCTION(_VidMan, GetVideoStatus)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(vid);
+	ACTION_RETURN_INT(VidMan.GetVideoStatus(vid));
+}
+
+DEFINE_ACTION_FUNCTION(_VidMan, StopVideo)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(vid);
+
+	VidMan.StopVideo(vid);
+	return 0;
+}

--- a/src/common/cutscenes/vidtexmanager.h
+++ b/src/common/cutscenes/vidtexmanager.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "movieplayer.h"
+#include "tarray.h"
+#include "i_time.h"
+
+enum EVideoState
+{
+	VIDSTATE_Starting,
+	VIDSTATE_Running,
+	VIDSTATE_Stopped
+};
+
+class FVideoTexture
+{
+public:
+	std::unique_ptr<MoviePlayer> player;
+	FTextureID target_tex;
+
+	int videostate;
+	uint64_t startTicksMs;
+
+	int id;
+};
+
+class FVideoManager
+{
+	TArray<FVideoTexture> videos;
+	int internalid;
+
+public:
+	int AddVideo(const FString& filename, FTextureID target, TArray<int>& ans, int firstframetime, int lastframetime, int frametime, int flags);
+	void StopVideo(int vid);
+	void DeleteAll();
+	
+	void TickAll();
+
+	int GetVideoStatus(int vid)
+	{
+		if (vid == -1)
+			return VIDSTATE_Stopped;
+
+		auto it = std::find_if(videos.begin(), videos.end(), [vid](const FVideoTexture& target) { return target.id == vid; });
+
+		if (it == videos.end())
+			return VIDSTATE_Stopped;
+
+		return (*it).videostate;
+	}
+
+	int GetVideoTime(int vid)
+	{
+		if (vid == -1)
+			return 0;
+
+		auto it = std::find_if(videos.begin(), videos.end(), [vid](const FVideoTexture& target) { return target.id == vid; });
+
+		if (it == videos.end())
+			return 0;
+
+		return I_msTime() - (*it).startTicksMs;
+	}
+};
+
+extern FVideoManager VidMan;

--- a/src/common/textures/animtexture.cpp
+++ b/src/common/textures/animtexture.cpp
@@ -34,6 +34,7 @@
 #include "animtexture.h"
 #include "bitmap.h"
 #include "texturemanager.h"
+#include "engineerrors.h"
 
 #include "vpx/vpx_image.h"
 
@@ -224,6 +225,23 @@ AnimTextures::AnimTextures()
 AnimTextures::~AnimTextures()
 {
 	Clean();
+}
+
+void AnimTextures::SetTargets(FTextureID first, FTextureID second)
+{
+	Clean();
+
+	active = 1;
+	tex[0] = TexMan.GetGameTexture(first);
+	tex[1] = TexMan.GetGameTexture(second);
+
+	if (!tex[0] || !tex[1])
+		I_Error("AnimTextures not found.");
+
+	if (tex[0]->GetTexture()->IsAnimTex() == false || tex[1]->GetTexture()->IsAnimTex() == false)
+	{
+		I_Error("Invalid textures for AnimTextures specified.");
+	}
 }
 
 void AnimTextures::Clean()

--- a/src/common/textures/animtexture.cpp
+++ b/src/common/textures/animtexture.cpp
@@ -49,7 +49,7 @@ void AnimTexture::SetFrameSize(int  format, int width, int height)
 {
 	pixelformat = format;
 	FTexture::SetSize(width, height);
-	Image.Resize(width * height * 4);
+	Image.Resize(width * height * 4 * 2);
 	memset(Image.Data(), 0, Image.Size());
 }
 
@@ -73,7 +73,8 @@ void AnimTexture::SetFrame(const uint8_t* Palette, const void* data_)
 {
 	if (data_)
 	{
-		auto dpix = Image.Data();
+		active ^= 1;
+		auto dpix = Image.Data() + (active ? (Image.Size() / 2) : 0);
 
 		if (pixelformat == YUV)
 		{
@@ -206,7 +207,7 @@ void AnimTexture::SetFrame(const uint8_t* Palette, const void* data_)
 
 FBitmap AnimTexture::GetBgraBitmap(const PalEntry* remap, int* trans)
 {
-	return FBitmap(Image.Data(), Width * 4, Width, Height);
+	return FBitmap(Image.Data() + (active ? (Image.Size() / 2) : 0), Width * 4, Width, Height);
 }
 
 //==========================================================================
@@ -218,8 +219,7 @@ FBitmap AnimTexture::GetBgraBitmap(const PalEntry* remap, int* trans)
 AnimTextures::AnimTextures()
 {
 	active = 1;
-	tex[0] = TexMan.FindGameTexture("AnimTextureFrame1", ETextureType::Override);
-	tex[1] = TexMan.FindGameTexture("AnimTextureFrame2", ETextureType::Override);
+	tex = TexMan.FindGameTexture("AnimTextureFrame1", ETextureType::Override);
 }
 
 AnimTextures::~AnimTextures()
@@ -227,18 +227,17 @@ AnimTextures::~AnimTextures()
 	Clean();
 }
 
-void AnimTextures::SetTargets(FTextureID first, FTextureID second)
+void AnimTextures::SetTarget(FTextureID first)
 {
 	Clean();
 
 	active = 1;
-	tex[0] = TexMan.GetGameTexture(first);
-	tex[1] = TexMan.GetGameTexture(second);
+	tex = TexMan.GetGameTexture(first);
 
-	if (!tex[0] || !tex[1])
-		I_Error("AnimTextures not found.");
+	if (!tex)
+		I_Error("AnimTexture not found.");
 
-	if (tex[0]->GetTexture()->IsAnimTex() == false || tex[1]->GetTexture()->IsAnimTex() == false)
+	if (tex->GetTexture()->IsAnimTex() == false)
 	{
 		I_Error("Invalid textures for AnimTextures specified.");
 	}
@@ -246,24 +245,19 @@ void AnimTextures::SetTargets(FTextureID first, FTextureID second)
 
 void AnimTextures::Clean()
 {
-	if (tex[0]) tex[0]->CleanHardwareData(true);
-	if (tex[1]) tex[1]->CleanHardwareData(true);
-	tex[0] = tex[1] = nullptr;
+	if (tex) tex->CleanHardwareData(true);
+	tex = nullptr;
 }
 
 void AnimTextures::SetSize(int format, int width, int height)
 {
-	static_cast<AnimTexture*>(tex[0]->GetTexture())->SetFrameSize(format, width, height);
-	static_cast<AnimTexture*>(tex[1]->GetTexture())->SetFrameSize(format, width, height);
-	tex[0]->SetSize(width, height);
-	tex[1]->SetSize(width, height);
-	tex[0]->CleanHardwareData();
-	tex[1]->CleanHardwareData();
+	static_cast<AnimTexture*>(tex->GetTexture())->SetFrameSize(format, width, height);
+	tex->SetSize(width, height);
+	tex->CleanHardwareData();
 }
 
 void AnimTextures::SetFrame(const uint8_t* palette, const void* data)
 {
-	active ^= 1;
-	static_cast<AnimTexture*>(tex[active]->GetTexture())->SetFrame(palette, data);
-	tex[active]->CleanHardwareData();
+	static_cast<AnimTexture*>(tex->GetTexture())->SetFrame(palette, data);
+	tex->CleanHardwareData();
 }

--- a/src/common/textures/animtexture.cpp
+++ b/src/common/textures/animtexture.cpp
@@ -69,6 +69,20 @@ static inline void YUVtoRGB(uint8_t yi, uint8_t ui, uint8_t vi, uint8_t * rgb)
 	(rgb)[3] = 255;
 }
 
+void AnimTexture::ClearFrame()
+{
+	auto dpix = Image.Data();
+	for (int i = 0; i < Width * Height * 2; i++)
+	{
+		dpix[0] = 0;
+		dpix[1] = 0;
+		dpix[2] = 0;
+		dpix[3] = 255;
+
+		dpix += 4;
+	}
+}
+
 void AnimTexture::SetFrame(const uint8_t* Palette, const void* data_)
 {
 	if (data_)
@@ -224,6 +238,7 @@ AnimTextures::AnimTextures()
 
 AnimTextures::~AnimTextures()
 {
+	ClearFrame();
 	Clean();
 }
 
@@ -243,9 +258,14 @@ void AnimTextures::SetTarget(FTextureID first)
 	}
 }
 
-void AnimTextures::Clean()
+void AnimTextures::Clean(bool clearframe)
 {
-	if (tex) tex->CleanHardwareData(true);
+	if (tex)
+	{
+		if (clearframe)
+			ClearFrame();
+		tex->CleanHardwareData(true);
+	}
 	tex = nullptr;
 }
 
@@ -253,6 +273,14 @@ void AnimTextures::SetSize(int format, int width, int height)
 {
 	static_cast<AnimTexture*>(tex->GetTexture())->SetFrameSize(format, width, height);
 	tex->SetSize(width, height);
+	tex->CleanHardwareData();
+}
+
+void AnimTextures::ClearFrame()
+{
+	if (!tex)
+		return;
+	static_cast<AnimTexture*>(tex->GetTexture())->ClearFrame();
 	tex->CleanHardwareData();
 }
 

--- a/src/common/textures/animtexture.h
+++ b/src/common/textures/animtexture.h
@@ -16,10 +16,12 @@ public:
 		YUV = 2,
 		VPX = 3
 	};
-	AnimTexture() = default;
 	void SetFrameSize(int format, int width, int height);
+	// Changed to at least initialize the texture size to sane values.
+	AnimTexture() { SetFrameSize(RGB, 128, 128); };
 	void SetFrame(const uint8_t* palette, const void* data);
 	virtual FBitmap GetBgraBitmap(const PalEntry* remap, int* trans) override;
+	void ClearFrame();
 
 	bool IsAnimTex() override { return true; }
 };
@@ -32,7 +34,8 @@ class AnimTextures
 public:
 	AnimTextures();
 	~AnimTextures();
-	void Clean();
+	void Clean(bool clearframe = false);
+	void ClearFrame();
 	void SetSize(int format, int width, int height);
 	void SetFrame(const uint8_t* palette, const void* data);
 	void SetTarget(FTextureID first);

--- a/src/common/textures/animtexture.h
+++ b/src/common/textures/animtexture.h
@@ -7,6 +7,7 @@ class AnimTexture : public FTexture
 {
 	TArray<uint8_t> Image;
 	int pixelformat;
+	int active = 0;
 public:
 	enum
 	{
@@ -26,7 +27,7 @@ public:
 class AnimTextures
 {
 	int active;
-	FGameTexture* tex[2] = { nullptr, nullptr };
+	FGameTexture* tex = nullptr;
 
 public:
 	AnimTextures();
@@ -34,14 +35,14 @@ public:
 	void Clean();
 	void SetSize(int format, int width, int height);
 	void SetFrame(const uint8_t* palette, const void* data);
-	void SetTargets(FTextureID first, FTextureID second);
+	void SetTarget(FTextureID first);
 	FGameTexture* GetFrame()
 	{
-		return tex[active];
+		return tex;
 	}
 
 	FTextureID GetFrameID()
 	{
-		return tex[active]->GetID();
+		return tex->GetID();
 	}
 };

--- a/src/common/textures/animtexture.h
+++ b/src/common/textures/animtexture.h
@@ -19,12 +19,14 @@ public:
 	void SetFrameSize(int format, int width, int height);
 	void SetFrame(const uint8_t* palette, const void* data);
 	virtual FBitmap GetBgraBitmap(const PalEntry* remap, int* trans) override;
+
+	bool IsAnimTex() override { return true; }
 };
 
 class AnimTextures
 {
 	int active;
-	FGameTexture* tex[2];
+	FGameTexture* tex[2] = { nullptr, nullptr };
 
 public:
 	AnimTextures();
@@ -32,6 +34,7 @@ public:
 	void Clean();
 	void SetSize(int format, int width, int height);
 	void SetFrame(const uint8_t* palette, const void* data);
+	void SetTargets(FTextureID first, FTextureID second);
 	FGameTexture* GetFrame()
 	{
 		return tex[active];

--- a/src/common/textures/textures.h
+++ b/src/common/textures/textures.h
@@ -286,6 +286,7 @@ public:
 
 
 	virtual void ResolvePatches() {}
+	virtual bool IsAnimTex() { return false; }
 
 
 	FTexture (int lumpnum = -1);

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -115,6 +115,7 @@
 #include "v_palette.h"
 #include "v_text.h"
 #include "v_video.h"
+#include "vidtexmanager.h"
 #include "version.h"
 #include "vm.h"
 #include "wi_stuff.h"
@@ -1014,6 +1015,7 @@ void D_Display ()
 	
 	screen->FrameTime = I_msTimeFS();
 	TexAnim.UpdateAnimations(screen->FrameTime);
+	VidMan.TickAll();
 	R_UpdateSky(screen->FrameTime);
 	screen->BeginFrame();
 	twod->ClearClipRect();
@@ -4058,6 +4060,7 @@ void D_Cleanup()
 	savegameManager.ClearSaveGames();
 	LightDefaults.DeleteAndClear();			// this can leak heap memory if it isn't cleared.
 	TexAnim.DeleteAll();
+	VidMan.DeleteAll();
 	TexMan.DeleteAll();
 	
 	// delete GameStartupInfo data

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -44,6 +44,7 @@
 #include "animations.h"
 #include "texturemanager.h"
 #include "image.h"
+#include "animtexture.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -342,6 +343,10 @@ void FTextureAnimator::InitAnimDefs ()
 			else if (sc.Compare ("animatedDoor"))
 			{
 				ParseAnimatedDoor (sc);
+			}
+			else if (sc.Compare ("animtexture"))
+			{
+				ParseAnimatedTexture (sc);
 			}
 			else if (sc.Compare("skyoffset"))
 			{
@@ -904,6 +909,31 @@ void FTextureAnimator::FixAnimations ()
 			}
 		}
 	}
+}
+
+void FTextureAnimator::ParseAnimatedTexture(FScanner &sc)
+{
+	sc.MustGetString();
+	FString firstname = sc.String;
+	sc.MustGetString();
+	FString secondname = sc.String;
+
+	FTextureID picnum1 = TexMan.CheckForTexture(firstname.GetChars(), ETextureType::Wall, TexMan.TEXMAN_TryAny);
+	FTextureID picnum2 = TexMan.CheckForTexture(firstname.GetChars(), ETextureType::Wall, TexMan.TEXMAN_TryAny);
+
+	auto mt = MakeGameTexture(new AnimTexture(), firstname.GetChars(), ETextureType::Override);
+	mt->SetUpscaleFlag(false, true);
+	if (picnum1.Exists())
+		TexMan.ReplaceTexture(picnum1, mt, true);
+	else
+		TexMan.AddGameTexture(mt);
+
+	mt = MakeGameTexture(new AnimTexture(), secondname.GetChars(), ETextureType::Override);
+	mt->SetUpscaleFlag(false, true);
+	if (picnum2.Exists())
+		TexMan.ReplaceTexture(picnum2, mt, true);
+	else
+		TexMan.AddGameTexture(mt);
 }
 
 //==========================================================================

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -915,23 +915,13 @@ void FTextureAnimator::ParseAnimatedTexture(FScanner &sc)
 {
 	sc.MustGetString();
 	FString firstname = sc.String;
-	sc.MustGetString();
-	FString secondname = sc.String;
 
 	FTextureID picnum1 = TexMan.CheckForTexture(firstname.GetChars(), ETextureType::Wall, TexMan.TEXMAN_TryAny);
-	FTextureID picnum2 = TexMan.CheckForTexture(firstname.GetChars(), ETextureType::Wall, TexMan.TEXMAN_TryAny);
 
 	auto mt = MakeGameTexture(new AnimTexture(), firstname.GetChars(), ETextureType::Override);
 	mt->SetUpscaleFlag(false, true);
 	if (picnum1.Exists())
 		TexMan.ReplaceTexture(picnum1, mt, true);
-	else
-		TexMan.AddGameTexture(mt);
-
-	mt = MakeGameTexture(new AnimTexture(), secondname.GetChars(), ETextureType::Override);
-	mt->SetUpscaleFlag(false, true);
-	if (picnum2.Exists())
-		TexMan.ReplaceTexture(picnum2, mt, true);
 	else
 		TexMan.AddGameTexture(mt);
 }

--- a/src/gamedata/textures/animations.h
+++ b/src/gamedata/textures/animations.h
@@ -105,6 +105,7 @@ class FTextureAnimator
 	FSwitchDef* ParseSwitchDef(FScanner& sc, bool ignoreBad);
 	void AddSwitchPair(FSwitchDef* def1, FSwitchDef* def2);
 	void ParseAnimatedDoor(FScanner& sc);
+	void ParseAnimatedTexture(FScanner& sc);
 
 public:
 

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -78,6 +78,7 @@
 #include "types.h"
 #include "v_video.h"
 #include "version.h"
+#include "vidtexmanager.h"
 
 	// P-codes for ACS scripts
 	enum
@@ -469,6 +470,8 @@
 		PCD_LSPEC5EXRESULT,
 		PCD_TRANSLATIONRANGE4,
 		PCD_TRANSLATIONRANGE5,
+		PCD_VIDEOWAIT,
+		PCD_VIDEOWAITDIRECT,
 
 /*385*/	PCODE_COMMAND_COUNT
 	};
@@ -697,6 +700,7 @@ public:
 		SCRIPT_Delayed,
 		SCRIPT_TagWait,
 		SCRIPT_PolyWait,
+		SCRIPT_VideoWait,
 		SCRIPT_ScriptWaitPre,
 		SCRIPT_ScriptWait,
 		SCRIPT_PleaseRemove,
@@ -4864,6 +4868,8 @@ enum EACSFunctions
 	ACSF_SetSubtitleNumber,
 	ACSF_GetNetID,
 	ACSF_SetActivatorByNetID,
+	ACSF_PlayVideoOnTexture,
+	ACSF_StopVideo,
 
 		// Eternity's
 	ACSF_GetLineX = 300,
@@ -6869,6 +6875,33 @@ doplaysound:			if (funcIndex == ACSF_PlayActorSound)
 			return DoubleToACS(result);
 		}
 
+		case ACSF_PlayVideoOnTexture:
+			MIN_ARG_COUNT(2);
+		{
+			auto lumpname = Level->Behaviors.LookupString(args[0]);
+			auto texname = Level->Behaviors.LookupString(args[1]);
+			FSoundID sid = NO_SOUND;
+
+			const char* lookup = argCount >= 3 ? Level->Behaviors.LookupString(args[2]) : nullptr;
+			if (lookup != nullptr)
+			{
+				sid = S_FindSound(lookup);
+			}
+			TArray<int> mus;
+
+			if (sid != NO_SOUND)
+				mus.Push(sid.index());
+
+			return VidMan.AddVideo(lumpname, TexMan.CheckForTexture(texname, ETextureType::Override), mus, -1, -1, argCount >= 4 ? args[3] : -1, argCount >= 5 ? args[4] : 0);
+		}
+
+		case ACSF_StopVideo:
+			MIN_ARG_COUNT(1);
+		{
+			VidMan.StopVideo(args[0]);
+			return 0;
+		}
+
 		case ACSF_SetSubtitleNumber:
 			MIN_ARG_COUNT(2);
 			// only players allowed as activator
@@ -7002,6 +7035,21 @@ int DLevelScript::RunScript()
 		}
 
 		// If we got here, none of the tagged sectors were busy
+		state = SCRIPT_Running;
+	}
+	break;
+
+	case SCRIPT_VideoWait:
+		// Wait for the video to finish playing, then enter
+		// state running
+	{
+		int videoid = statedata;
+		if (VidMan.GetVideoStatus(videoid) != VIDSTATE_Stopped)
+		{
+			return resultValue;
+		}
+
+		// If we got here, the video was not playing
 		state = SCRIPT_Running;
 	}
 	break;
@@ -8386,6 +8434,18 @@ int DLevelScript::RunScript()
 
 		case PCD_TAGWAITDIRECT:
 			state = SCRIPT_TagWait;
+			statedata = uallong(pc[0]);
+			pc++;
+			break;
+
+		case PCD_VIDEOWAIT:
+			state = SCRIPT_VideoWait;
+			statedata = STACK(1);
+			sp--;
+			break;
+
+		case PCD_VIDEOWAITDIRECT:
+			state = SCRIPT_VideoWait;
 			statedata = uallong(pc[0]);
 			pc++;
 			break;
@@ -10733,6 +10793,7 @@ void DACSThinker::DumpScriptStatus ()
 		"Delayed",
 		"TagWait",
 		"PolyWait",
+		"VideoWait",
 		"ScriptWaitPre",
 		"ScriptWait",
 		"PleaseRemove"

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -354,6 +354,21 @@ struct TexMan
 	native static Canvas GetCanvas(String texture);
 }
 
+struct VidMan
+{
+	enum EVideoState
+	{
+		VIDSTATE_Starting,
+		VIDSTATE_Running,
+		VIDSTATE_Stopped
+	};
+	// Uses same flags as MoviePlayer
+	native static int AddVideo(String filename, TextureID target, Array<int> soundinfo, int firstframetime, int lastframetime, int frametime, int flags);
+	native static int GetVideoTime(int vid);
+	native static int GetVideoStatus(int vid);
+	native static int StopVideo(int vid);
+}
+
 /*
 // Intrinsic TextureID methods
 // This isn't really a class, and can be used as an integer

--- a/wadsrc/static/zscript/engine/screenjob.zs
+++ b/wadsrc/static/zscript/engine/screenjob.zs
@@ -212,7 +212,7 @@ struct MoviePlayer native
 	native bool Frame(double clock);
 	native void Destroy();
 	native TextureID GetTexture();
-	native void SetTargets(TextureID first, TextureID second);
+	native void SetTarget(TextureID first);
 }
 
 //---------------------------------------------------------------------------

--- a/wadsrc/static/zscript/engine/screenjob.zs
+++ b/wadsrc/static/zscript/engine/screenjob.zs
@@ -212,6 +212,7 @@ struct MoviePlayer native
 	native bool Frame(double clock);
 	native void Destroy();
 	native TextureID GetTexture();
+	native void SetTargets(TextureID first, TextureID second);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows MoviePlayer instances to use different texture targets instead of the default one.