### PR TITLE
Restored Map Light Mode Option

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -148,7 +148,7 @@ CUSTOM_CVAR(Bool, gl_notexturefill, false, CVAR_NOINITCALL)
 	}
 }
 
-CUSTOM_CVAR(Int, gl_maplightmode, -1, CVAR_NOINITCALL | CVAR_CHEAT) // this is just for testing. -1 means 'inactive'
+CUSTOM_CVAR(Int, gl_maplightmode, -1, CVAR_NOINITCALL | CVAR_ARCHIVE) // this is just for testing. -1 means 'inactive'
 {
 	if (self > 4 || self < -1) self = -1;
 }

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2663,6 +2663,16 @@ OptionValue "LightingModes"
 	2, "$OPTVAL_VANILLA"
 }
 
+OptionValue "MapLightModes"
+{
+	-1, "Inactive"
+	0, "$OPTVAL_STANDARD"
+	1, "$OPTVAL_BRIGHT"
+	2, "$OPTVAL_DOOM"
+	3, "$OPTVAL_DARK"
+	4, "$OPTVAL_LEGACY"
+}
+
 OptionValue "Precision"
 {
 	0, "$OPTVAL_SPEED"
@@ -2822,6 +2832,7 @@ OptionMenu "OpenGLOptions" protected
 	Submenu "$GLMNU_POSTPROCESS",				"PostProcessMenu"
 	StaticText " "
 	Option "$GLPREFMNU_SECLIGHTMODE",			gl_lightmode,					"LightingModes"
+	Option "$GLPREFMNU_MAPLIGHTMODE",			gl_maplightmode,				"MapLightModes"
 	Option "$GLPREFMNU_SWLMBANDED",				gl_bandedswlight,				"OnOff"
 	Option "$GLPREFMNU_FOGMODE",				gl_fogmode,						"FogMode"
 	Option "$GLPREFMNU_FOGFORCEFULLBRIGHT",		gl_brightfog,					"YesNo"


### PR DESCRIPTION
This puts the Map Light Mode option back in Display -> Hardware Options.

I set this up to be cherry-pickable in the event persistence isn't desired. However I'm tired of relying on autoexec.cfg.

To everyone else who may want to reformat the map light mode, I understand. But if it's to be overhauled, I say we should have this anyway and it can be removed again at any other point in time, should an overhaul be worked on.

# Reminder, mapinfo still takes priority.

Fixes #4 .