### PR TITLE
Add Actions for Pages deployments of docs

### DIFF
--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -1,0 +1,107 @@
+name: Pages Deployment
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build_matrix:
+    runs-on: ubuntu-latest
+    name: Build matrix of refs to document
+    outputs:
+      json_refs: ${{ steps.generate-matrix.outputs.json_refs }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Generate Matrix
+        id: generate-matrix
+        run: |
+          echo "json_refs=$(jq -c . documentation_ref_info.json)" >> $GITHUB_OUTPUT
+
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+    needs:
+      - build_matrix
+    strategy:
+      matrix:
+        ref_info: ${{ fromJSON(needs.build_matrix.outputs.json_refs) }}
+    steps:
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-shared-key: pages-rust-cache
+          cache-workspaces: ""
+          cache-all-crates: true
+      - name: Display Cargo version
+        run: |
+          cargo --version
+      - name: Install zscdoc
+        run: |
+          cargo install --git https://github.com/UZDoom/zscdoc --rev 7d4c0dac2ba487b8afd3a1166553e8324af81f58
+      - name: Display zscdoc version
+        run: |
+          zscdoc --version
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ matrix.ref_info.ref }}
+      - name: Document ref
+        run: |
+          zscdoc -f ./wadsrc/static -o ./output --delete-without-confirm --base-url "/UZDoom/docs/<version>" --target-version '${{ matrix.ref_info.url_part }}' --versions '${{ needs.build_matrix.outputs.json_refs }}' --canonical-domain "https://${{ github.repository_owner }}.github.io"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.ref_info.url_part }}
+          path: output
+
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    environment:
+      name: github-pages
+      url : ${{ steps.deployment.outputs.page_url }}
+    needs:
+      - build_matrix
+      - build
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/configure-pages@v5
+      - run: gh run download ${{ vars.GITHUB_RUN_ID }} --dir refs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bundle together
+        run: |
+          mkdir public
+          echo '${{ needs.build_matrix.outputs.json_refs }}' | jq -c '.[]' | while read ref_info; do
+            ref=$(echo $ref_info | jq -r .ref)
+            url_part=$(echo $ref_info | jq -r .url_part)
+            robots_index=$(echo $ref_info | jq -r .robots_index)
+
+            mkdir -p -- public/docs/$url_part
+            mv refs/$url_part/* public/docs/$url_part
+
+            if [[ "$robots_index" != "true" ]]; then
+              echo "User-agent: *" >> public/robots.txt
+              echo "Disallow: /UZDoom/docs/$url_part/" >> public/robots.txt
+              echo >> public/robots.txt
+            fi
+          done
+      - name: List public
+        run: |
+          ls -lR public/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public/
+      - name: Deploy to GitHub pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/trigger_pages.yml
+++ b/.github/workflows/trigger_pages.yml
@@ -1,0 +1,22 @@
+name: Trigger Pages
+
+on:
+  push:
+    branches:
+      - trunk
+    tags:
+      - '**'
+
+jobs:
+  trigger_pages:
+    # i assume that random UZDoom forks probably don't want pages made for them by default
+    if: ${{ github.repository == 'UZDoom/UZDoom' || github.repository == 'Gutawer/UZDoom' }}
+    runs-on: ubuntu-latest
+    name: Trigger a Pages deployment
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - run: gh workflow run pages_deploy.yml --ref trunk

--- a/documentation_ref_info.json
+++ b/documentation_ref_info.json
@@ -1,0 +1,3 @@
+[
+    { "ref": "trunk", "url_part": "trunk", "nice_name": "Git Trunk", "latest": true, "robots_index": false }
+]

--- a/wadsrc/static/docs/Name.toml
+++ b/wadsrc/static/docs/Name.toml
@@ -1,0 +1,10 @@
+name = "Name"
+doc = """
+The built-in name type.
+
+This type can be seen as a case-insensitive version of [`String`], and is represented internally as
+an index into a name table, making it small and fast to check equality with.
+
+A `Name` can be assigned to a [`String`] type, which will implicitly cast it, allowing string
+operations to be used.
+"""

--- a/wadsrc/static/docs/String.toml
+++ b/wadsrc/static/docs/String.toml
@@ -1,0 +1,10 @@
+name = "String"
+uses_things_from = "StringStruct"
+doc = """
+The built-in string type.
+"""
+
+[[function]]
+def = """
+    uint Length();
+"""

--- a/wadsrc/static/docs/Vector2.toml
+++ b/wadsrc/static/docs/Vector2.toml
@@ -1,0 +1,16 @@
+name = "Vector2"
+doc = """
+A builtin type representing 2D coordinates, either as a point or as a vector.
+"""
+
+[[member]]
+def = """
+    /// The x coordinate.
+    double x;
+"""
+
+[[member]]
+def = """
+    /// The y coordinate.
+    double y;
+"""

--- a/wadsrc/static/docs/Vector3.toml
+++ b/wadsrc/static/docs/Vector3.toml
@@ -1,0 +1,31 @@
+name = "Vector3"
+doc = """
+A builtin type representing 3D coordinates, either as a point or as a vector.
+"""
+
+[[member]]
+def = """
+    /// The x coordinate.
+    double x;
+"""
+
+[[member]]
+def = """
+    /// The y coordinate.
+    double y;
+"""
+
+[[member]]
+def = """
+    /// The z coordinate.
+    double z;
+"""
+
+[[member]]
+def = """
+    /// The x and y coordinates as a [`Vector2`].
+    /// 
+    /// This is not a unique piece of data and "overlaps" with [`x`] and [`y`]. Modifying this will
+    /// modify them.
+    transient Vector2 xy;
+"""

--- a/wadsrc/static/docs/bool.toml
+++ b/wadsrc/static/docs/bool.toml
@@ -1,0 +1,6 @@
+name = "bool"
+doc = """
+The built-in boolean type, representing logical truth values.
+
+This type can take on two values, `true` and `false`.
+"""

--- a/wadsrc/static/docs/double.toml
+++ b/wadsrc/static/docs/double.toml
@@ -1,0 +1,7 @@
+name = "double"
+doc = """
+The 64-bit floating point builtin type.
+
+This type can represent decimal values such as `0.5` as opposed to `int` and `uint` which are
+limited to whole numbers.
+"""

--- a/wadsrc/static/docs/int.toml
+++ b/wadsrc/static/docs/int.toml
@@ -1,0 +1,18 @@
+name = "int"
+doc = """
+The 32-bit signed integer builtin type.
+
+This type can represent every integer in the range `-2147483648` to `2147483647`.
+"""
+
+[[constant]]
+def = """
+    /// The maximum value this datatype can hold. Equal to 2^31 - 1.
+    const MAX = 2147483647;
+"""
+
+[[constant]]
+def = """
+    /// The minimum value this datatype can hold. Equal to -(2^31).
+    const MIN = -2147483648;
+"""

--- a/wadsrc/static/docs/summary.md
+++ b/wadsrc/static/docs/summary.md
@@ -1,0 +1,40 @@
+# UZDoom ZScript Source Code Documentation
+
+This is the documentation for the internal ZScript code within the UZDoom
+engine, distributed with the engine via `uzdoom.pk3` - that's the stuff that
+you, as a modder, need to interact with!
+
+These pages therefore serve as a reference for all of the API surface in the
+entire engine, or at least the ZScript bits.
+
+Make sure to check the search bar up at the top of the page as it's often the
+most efficient way of finding what you need!
+
+Here's a couple of particularly important items:
+
+- The **[Builtin Types](#builtins)** - Types that are built in to the ZScript
+  language, representing the basic building blocks of the rest of the code
+- **[`Actor`]** - The base class for practically anything visually in-world
+- **[`Thinker`]** - The base class of `Actor`, representing things that tick in
+  the game loop
+- **[`Inventory`]** - The base class for `Actor`s that can be in another's
+  inventory
+- **[`EventHandler`]** - A flexible system for registering your own code so
+  that it can react to "events" in the game engine
+
+## Other Documentation
+
+This site is API documentation for ZScript itself, and does not necessarily
+comprise everything you might need to know about the engine. You will still
+want to use the [ZDoom Wiki](https://zdoom.org/wiki/Main_Page), especially for
+tutorials and stuff outside the scope of ZScript.
+
+## Contributing
+
+This site doesn't work like a wiki - it's totally generated from the UZDoom
+GitHub repository with a tool called `zscdoc`. As such, contributing here
+requires contributing to the repository, by adding "doc-comments" into the
+source code.
+
+We haven't set up a guide yet, but in the future one should be available on the
+GitHub wiki or some other more developer-facing documentation location.

--- a/wadsrc/static/docs/uint.toml
+++ b/wadsrc/static/docs/uint.toml
@@ -1,0 +1,6 @@
+name = "uint"
+doc = """
+The 32-bit unsigned integer builtin type.
+
+This type can represent every integer in the range `0` to `4294967295`.
+"""

--- a/wadsrc/static/docs/zscdoc.toml
+++ b/wadsrc/static/docs/zscdoc.toml
@@ -1,0 +1,10 @@
+[archive]
+nice_name = "uzdoom.pk3"
+builtins = [
+    "int.toml", "uint.toml",
+    "bool.toml",
+    "double.toml",
+    "Vector2.toml", "Vector3.toml",
+    "String.toml", "Name.toml",
+]
+document_globals = true


### PR DESCRIPTION
Best to go commit-by-commit when reviewing here! This is the initial step for https://github.com/UZDoom/UZDoom/issues/91

List of changes:

- Adds a folder to `wadsrc/static/docs` that `zscdoc` needs, including some basic builtin type docs I wrote a while ago (needs updating - for later PR)
- Adds a workflow that deploys to Pages by checking out multiple branches, documenting them, then collating the results - the input to this is a JSON file in the repository, which currently only has data for git `trunk` as we haven't released yet. This workflow will only be allowed to work properly if run on `trunk`.
- Adds a workflow which triggers the above workflow on `trunk` pushes and tag events. This workflow also won't run its only job if the repository isn't UZDoom/UZDoom or Gutawer/UZDoom to avoid people with forks accidentally hosting docs (they can do this if they want, I just don't want to make it possible to do not-on-purpose)
- Adds a `summary.md` which gets displayed on the `index.html` explaining how the new docs work