### PR TITLE
Disable sky clip behavior for skewed mid-textures

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -1472,7 +1472,7 @@ void HWWall::DoMidTexture(HWWallDispatcher *di, seg_t * seg, bool drawfogboundar
 		if (!tex || !tex->isValid())
 		{
 			if (front->GetTexture(sector_t::ceiling) == skyflatnum &&
-				back->GetTexture(sector_t::ceiling) == skyflatnum && !wrap)
+				back->GetTexture(sector_t::ceiling) == skyflatnum && !wrap && skew == 0)
 			{
 				// intra-sky lines do not clip the texture at all if there's no upper texture.
 				topleft = topright = texturetop;


### PR DESCRIPTION
Resolves #40

<img width="1920" height="1080" alt="Screenshot_Doom_20251021_212859" src="https://github.com/user-attachments/assets/9701650f-2827-4d3f-93e4-186ee94104d6" />

It could be argued that this should alter the skew coordinates to keep the clip behavior, but still allow skewing. I couldn't get that to work, though, so I've simply disabled it for skewed textures.

I think this is a reasonable compromise because the clip behavior is just emulating the software renderer, and skewing is only for the hardware renderer. Plus, this is a lot better than this situation being *completely* broken, at least.

# Testing

1. Extract this test file (`skew-test-2.wad`) from this .zip, and load it in Doom II: [skew-test-2.zip](https://github.com/user-attachments/files/19438782/skew-test-2.zip)
2. Load `MAP01`
3. Observe -- the previously bugged mid-textures are in the areas outlined by FIREBLU
