### PR TITLE
Expose polyobjects to ZScript.

### DIFF
--- a/src/playsim/po_man.cpp
+++ b/src/playsim/po_man.cpp
@@ -40,6 +40,7 @@
 #include "g_levellocals.h"
 #include "actorinlines.h"
 #include "v_text.h"
+#include "vm.h"
 
 // TYPES -------------------------------------------------------------------
 
@@ -61,6 +62,8 @@ public:
 	void Construct(FPolyObj *polyNum);
 	void Serialize(FSerializer &arc);
 	void Tick ();
+	DVector2 GetSpeedV() const { return m_Speedv; }
+	DAngle GetAngle() const { return m_Angle; }
 protected:
 	DAngle m_Angle;
 	DVector2 m_Speedv;
@@ -75,6 +78,8 @@ public:
 	void Construct(FPolyObj *polyNum);
 	void Serialize(FSerializer &arc);
 	void Tick();
+	DVector2 GetSpeed() const { return m_Speedv; }
+	DVector2 GetTarget() const { return m_Target; }
 protected:
 	DVector2 m_Speedv;
 	DVector2 m_Target;
@@ -90,6 +95,12 @@ public:
 	void Construct(FPolyObj *polyNum, podoortype_t type);
 	void Serialize(FSerializer &arc);
 	void Tick ();
+	DAngle GetDirection() const { return m_Direction; }
+	double GetTotalDist() const { return m_TotalDist; }
+	int GetTics() const { return m_Tics; }
+	int GetWaitTics() const { return m_WaitTics; }
+	podoortype_t GetType() const { return m_Type; }
+	bool IsClose() const { return m_Close; }
 protected:
 	DAngle m_Direction;
 	double m_TotalDist;
@@ -137,7 +148,7 @@ static FPolyNode *FreePolyNodes;
 
 //==========================================================================
 //
-//
+// Generic polyobject action
 //
 //==========================================================================
 
@@ -195,9 +206,27 @@ void DPolyAction::StopInterpolation ()
 	}
 }
 
+DEFINE_ACTION_FUNCTION(DPolyAction, GetSpeed)
+{
+	PARAM_SELF_PROLOGUE(DPolyAction);
+	ACTION_RETURN_FLOAT(self->GetSpeed());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyAction, GetDistance)
+{
+	PARAM_SELF_PROLOGUE(DPolyAction);
+	ACTION_RETURN_FLOAT(self->GetDistance());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyAction, GetPolyObj)
+{
+	PARAM_SELF_PROLOGUE(DPolyAction);
+	ACTION_RETURN_POINTER(self->GetPolyObj());
+}
+
 //==========================================================================
 //
-//
+// Rotating polyobject
 //
 //==========================================================================
 
@@ -210,7 +239,7 @@ void DRotatePoly::Construct(FPolyObj *polyNum)
 
 //==========================================================================
 //
-//
+// Moving polyobject
 //
 //==========================================================================
 
@@ -230,10 +259,22 @@ void DMovePoly::Construct(FPolyObj *polyNum)
 	m_Speedv = { 0,0 };
 }
 
+DEFINE_ACTION_FUNCTION(DMovePoly, GetSpeedV)
+{
+	PARAM_SELF_PROLOGUE(DMovePoly);
+	ACTION_RETURN_VEC2(self->GetSpeedV());
+}
+
+DEFINE_ACTION_FUNCTION(DMovePoly, GetAngle)
+{
+	PARAM_SELF_PROLOGUE(DMovePoly);
+	ACTION_RETURN_FLOAT(self->GetAngle().Degrees());
+}
+
 //==========================================================================
 //
 //
-//
+//	Moving polyobject to a specific point
 //
 //==========================================================================
 
@@ -252,9 +293,21 @@ void DMovePolyTo::Construct(FPolyObj *polyNum)
 	m_Speedv = m_Target = { 0,0 };
 }
 
+DEFINE_ACTION_FUNCTION(DMovePolyTo, GetSpeed)
+{
+	PARAM_SELF_PROLOGUE(DMovePolyTo);
+	ACTION_RETURN_VEC2(self->GetSpeed());
+}
+
+DEFINE_ACTION_FUNCTION(DMovePolyTo, GetTarget)
+{
+	PARAM_SELF_PROLOGUE(DMovePolyTo);
+	ACTION_RETURN_VEC2(self->GetTarget());
+}
+
 //==========================================================================
 //
-//
+// Polyobject doors
 //
 //==========================================================================
 
@@ -280,6 +333,42 @@ void DPolyDoor::Construct (FPolyObj * polyNum, podoortype_t type)
 	m_Tics = 0;
 	m_WaitTics = 0;
 	m_Close = false;
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, GetDirection)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_FLOAT(self->GetDirection().Degrees());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, GetTotalDist)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_FLOAT(self->GetTotalDist());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, GetTics)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_INT(self->GetTics());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, GetWaitTics)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_INT(self->GetWaitTics());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, GetType)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_INT(self->GetType());
+}
+
+DEFINE_ACTION_FUNCTION(DPolyDoor, IsClose)
+{
+	PARAM_SELF_PROLOGUE(DPolyDoor);
+	ACTION_RETURN_BOOL(self->IsClose());
 }
 
 // ===== Polyobj Event Code =====

--- a/src/playsim/po_man.h
+++ b/src/playsim/po_man.h
@@ -18,6 +18,8 @@ public:
 	void OnDestroy() override;
 	void Stop();
 	double GetSpeed() const { return m_Speed; }
+	double GetDistance() const { return m_Dist; }
+	FPolyObj* GetPolyObj() const { return m_PolyObj; }
 
 	void StopInterpolation();
 protected:

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -756,6 +756,21 @@ void InitThingdef()
 	lineportalstruct->Size = sizeof(FLinePortal);
 	lineportalstruct->Align = alignof(FLinePortal);
 
+	auto polyobjstruct = NewStruct("Polyobj", nullptr, true);
+	polyobjstruct->Size = sizeof(FPolyObj);
+	polyobjstruct->Align = alignof(FPolyObj);
+	NewPointer(polyobjstruct, false)->InstallHandlers(
+		[](FSerializer& ar, const char* key, const void* addr)
+		{
+			ar(key, *(FPolyObj**)addr);
+		},
+		[](FSerializer& ar, const char* key, void* addr)
+		{
+			Serialize<FPolyObj>(ar, key, *(FPolyObj**)addr, nullptr);
+			return true;
+		}
+	);
+
 	auto playerclassstruct = NewStruct("PlayerClass", nullptr, true);
 	playerclassstruct->Size = sizeof(FPlayerClass);
 	playerclassstruct->Align = alignof(FPlayerClass);

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2116,6 +2116,34 @@ DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, GetMirror, GetMirror)
 	ACTION_RETURN_INT(self->GetMirror());
 }
 
+static void ClosestPoint(FPolyObj* self, double x, double y, DVector2& out, side_t** side)
+{
+	self->ClosestPoint(DVector2(x, y), out, side);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, ClosestPoint, ClosestPoint)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
+	PARAM_FLOAT(x);
+	PARAM_FLOAT(y);
+	DVector2 out;
+	side_t* side = nullptr;
+	ClosestPoint(self, x, y, out, &side);
+	if (numret > 1) ret[1].SetPointer(side);
+	if (numret > 0) ret[0].SetVector2(out);
+	return numret;
+}
+
+DEFINE_ACTION_FUNCTION(FPolyObj, GetBounds)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
+	double x = self->Bounds.Top();
+	double y = self->Bounds.Bottom();
+	double z = self->Bounds.Left();
+	double w = self->Bounds.Right();
+	ACTION_RETURN_VEC4(DVector4(x, y, z, w));
+}
+
 static FPolyObj* GetPolyobj(FLevelLocals* self, int polyNum)
 {
 	return self->GetPolyobj(polyNum);

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -1696,7 +1696,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
 
  //=====================================================================================
 //
-// TexMan exports
+//
 //
 //=====================================================================================
 
@@ -2084,6 +2084,48 @@ DEFINE_ACTION_FUNCTION_NATIVE(DSpotState, GetRandomSpot, GetRandomSpot)
 	PARAM_CLASS(type, AActor);
 	PARAM_BOOL(onlyonce);
 	ACTION_RETURN_POINTER(self->GetRandomSpot(type, onlyonce));
+}
+
+//=====================================================================================
+//
+// PolyObj functions
+//
+//=====================================================================================
+
+// [inkoalawetrust] So we don't need to expose FPolyVertex just for the pos.
+DEFINE_ACTION_FUNCTION(FPolyObj, GetStartSpot)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
+	ACTION_RETURN_VEC2(self->StartSpot.pos);
+}
+
+DEFINE_ACTION_FUNCTION(FPolyObj, GetCenterSpot)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
+	ACTION_RETURN_VEC2(self->CenterSpot.pos);
+}
+
+static int GetMirror(FPolyObj *self)
+{
+	return self->GetMirror();
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, GetMirror, GetMirror)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
+	ACTION_RETURN_INT(self->GetMirror());
+}
+
+static FPolyObj* GetPolyobj(FLevelLocals* self, int polyNum)
+{
+	return self->GetPolyobj(polyNum);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE (FLevelLocals, GetPolyobj, GetPolyobj)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_INT(polyNum);
+	ACTION_RETURN_POINTER(self->GetPolyobj(polyNum));
 }
 
 //=====================================================================================
@@ -2915,6 +2957,7 @@ DEFINE_FIELD(FLevelLocals, sides)
 DEFINE_FIELD(FLevelLocals, vertexes)
 DEFINE_FIELD(FLevelLocals, linePortals)
 DEFINE_FIELD(FLevelLocals, sectorPortals)
+DEFINE_FIELD(FLevelLocals, Polyobjects)
 DEFINE_FIELD(FLevelLocals, time)
 DEFINE_FIELD(FLevelLocals, maptime)
 DEFINE_FIELD(FLevelLocals, totaltime)
@@ -3067,6 +3110,18 @@ DEFINE_FIELD_X(F3DFloor, F3DFloor, master);
 DEFINE_FIELD_X(F3DFloor, F3DFloor, model);
 DEFINE_FIELD_X(F3DFloor, F3DFloor, target);
 DEFINE_FIELD_X(F3DFloor, F3DFloor, alpha);
+
+DEFINE_FIELD_X(Polyobj, FPolyObj, Sidedefs)
+DEFINE_FIELD_X(Polyobj, FPolyObj, Linedefs)
+DEFINE_FIELD_X(Polyobj, FPolyObj, Vertices)
+DEFINE_FIELD_X(Polyobj, FPolyObj, Angle)
+DEFINE_FIELD_X(Polyobj, FPolyObj, tag)
+DEFINE_FIELD_X(Polyobj, FPolyObj, crush)
+DEFINE_FIELD_X(Polyobj, FPolyObj, bHurtOnTouch)
+DEFINE_FIELD_X(Polyobj, FPolyObj, bBlocked)
+DEFINE_FIELD_X(Polyobj, FPolyObj, bHasPortals)
+DEFINE_FIELD_X(Polyobj, FPolyObj, seqType)
+DEFINE_FIELD_X(Polyobj, FPolyObj, specialdata)
 
 DEFINE_FIELD_X(Vertex, vertex_t, p)
 

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2134,19 +2134,6 @@ DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, ClosestPoint, ClosestPoint)
 	return numret;
 }
 
-static void GetBounds(FPolyObj* self, DVector4* out)
-{
-	*out = DVector4(self->Bounds.Top(), self->Bounds.Bottom(), self->Bounds.Left(), self->Bounds.Right());
-}
-
-DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, GetBounds, GetBounds)
-{
-	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
-	DVector4 res = { 0.0, 0.0, 0.0, 0.0 };
-	GetBounds(self, &res);
-	ACTION_RETURN_VEC4(res);
-}
-
 static FPolyObj* GetPolyobj(FLevelLocals* self, int polyNum)
 {
 	return self->GetPolyobj(polyNum);
@@ -3147,6 +3134,7 @@ DEFINE_FIELD_X(Polyobj, FPolyObj, Linedefs)
 DEFINE_FIELD_X(Polyobj, FPolyObj, Vertices)
 DEFINE_FIELD_X(Polyobj, FPolyObj, Angle)
 DEFINE_FIELD_X(Polyobj, FPolyObj, tag)
+DEFINE_FIELD_X(Polyobj, FPolyObj, bbox)
 DEFINE_FIELD_X(Polyobj, FPolyObj, crush)
 DEFINE_FIELD_X(Polyobj, FPolyObj, bHurtOnTouch)
 DEFINE_FIELD_X(Polyobj, FPolyObj, bBlocked)

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2134,14 +2134,17 @@ DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, ClosestPoint, ClosestPoint)
 	return numret;
 }
 
-DEFINE_ACTION_FUNCTION(FPolyObj, GetBounds)
+static void GetBounds(FPolyObj* self, DVector4* out)
+{
+	*out = DVector4(self->Bounds.Top(), self->Bounds.Bottom(), self->Bounds.Left(), self->Bounds.Right());
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FPolyObj, GetBounds, GetBounds)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FPolyObj);
-	double x = self->Bounds.Top();
-	double y = self->Bounds.Bottom();
-	double z = self->Bounds.Left();
-	double w = self->Bounds.Right();
-	ACTION_RETURN_VEC4(DVector4(x, y, z, w));
+	DVector4 res = { 0.0, 0.0, 0.0, 0.0 };
+	GetBounds(self, &res);
+	ACTION_RETURN_VEC4(res);
 }
 
 static FPolyObj* GetPolyobj(FLevelLocals* self, int polyNum)

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -986,7 +986,7 @@ class Ceiling : MovingCeiling native
 	
 }
 
-class PolyAction : Thinker native
+class PolyAction : Thinker native Sealed (RotatePoly, MovePoly, MovePolyTo, PolyDoor)
 {
 	native double GetSpeed() const;
 	native double GetDistance() const;

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -986,6 +986,44 @@ class Ceiling : MovingCeiling native
 	
 }
 
+class PolyAction : Thinker native
+{
+	native double GetSpeed() const;
+	native double GetDistance() const;
+	native PolyObj GetPolyobj() const;
+}
+
+class RotatePoly : PolyAction native{}
+
+class MovePoly : PolyAction native
+{
+	native Vector2 GetSpeedV() const;
+	native double GetAngle() const;
+}
+
+class MovePolyTo : PolyAction native
+{
+	native Vector2 GetSpeed() const;
+	native Vector2 GetTarget() const;
+}
+
+class PolyDoor : MovePoly native
+{
+	enum PODoorType
+	{
+		PODOOR_NONE,
+		PODOOR_SLIDE,
+		PODOOR_SWING,
+	};
+
+	native double GetDirection() const;
+	native double GetTotalDist() const;
+	native int GetTics() const;
+	native int GetWaitTics() const;
+	native PODoorType GetType() const;
+	native bool IsClose() const;
+}
+
 struct LookExParams
 {
 	double Fov;

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -498,6 +498,7 @@ struct LevelLocals native
 	native readonly Array<@Vertex> Vertexes;
 	native readonly Array<@LinePortal> LinePortals;
 	native internal readonly Array<@SectorPortal> SectorPortals;
+	native Array<@Polyobj> Polyobjects;
 	
 	native readonly int time;
 	native readonly int maptime;
@@ -616,6 +617,7 @@ struct LevelLocals native
 	native clearscope int PlayerNum(PlayerInfo player) const;
 
 	native String GetChecksum() const;
+	native Polyobj GetPolyobj(int polyNum) const;
 
 	native void ChangeSky(TextureID sky1, TextureID sky2 );
 	native void ChangeSkyMist(TextureID skymist, bool usemist = true);

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -345,7 +345,7 @@ struct Polyobj native play
 	native readonly bool bBlocked;
 	native readonly uint8 bHasPortals;
 	native readonly int seqType;
-	native readonly voidptr specialdata;
+	native readonly PolyAction specialdata;
 
 	native clearscope int GetMirror() const;
 	native clearscope vector2 GetStartSpot() const;

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -350,6 +350,8 @@ struct Polyobj native play
 	native clearscope int GetMirror() const;
 	native clearscope vector2 GetStartSpot() const;
 	native clearscope vector2 GetCenterSpot() const;
+	native clearscope vector2, Side ClosestPoint(Vector2 pos) const;
+	native clearscope vector4 GetBounds() const;
 }
 
 // This encapsulates all info Doom's original 'special' field contained - for saving and transferring.

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -327,6 +327,31 @@ struct F3DFloor native play
 	native clearscope TextureID GetTexture(int pos) const;
 }
 
+struct Polyobj native play
+{
+	enum PolyObjPortalType
+	{
+		POLYPORT_NONE = 0,
+		POLYPORT_PORTAL = 1,
+		POLYPORT_LINKED = 2, //Also prevents polyobject from rotating.
+	};
+	native readonly Array<Side> Sidedefs;
+	native readonly Array<Line> Linedefs;
+	native readonly Array<Vertex> Vertices;
+	native readonly double Angle;
+	native readonly int tag;
+	native readonly int crush;
+	native readonly bool bHurtOnTouch;
+	native readonly bool bBlocked;
+	native readonly uint8 bHasPortals;
+	native readonly int seqType;
+	native readonly voidptr specialdata;
+
+	native clearscope int GetMirror() const;
+	native clearscope vector2 GetStartSpot() const;
+	native clearscope vector2 GetCenterSpot() const;
+}
+
 // This encapsulates all info Doom's original 'special' field contained - for saving and transferring.
 struct SecSpecial play
 {

--- a/wadsrc/static/zscript/mapdata.zs
+++ b/wadsrc/static/zscript/mapdata.zs
@@ -340,6 +340,7 @@ struct Polyobj native play
 	native readonly Array<Vertex> Vertices;
 	native readonly double Angle;
 	native readonly int tag;
+	native readonly int bbox[4];
 	native readonly int crush;
 	native readonly bool bHurtOnTouch;
 	native readonly bool bBlocked;
@@ -351,7 +352,6 @@ struct Polyobj native play
 	native clearscope vector2 GetStartSpot() const;
 	native clearscope vector2 GetCenterSpot() const;
 	native clearscope vector2, Side ClosestPoint(Vector2 pos) const;
-	native clearscope vector4 GetBounds() const;
 }
 
 // This encapsulates all info Doom's original 'special' field contained - for saving and transferring.


### PR DESCRIPTION
> [!NOTE]
> This is a reupload of [the PR I had initially made for GZDoom](https://github.com/ZDoom/gzdoom/pull/3095). However it also includes the changes that Jay had suggested, like sealing PolyAction and directly exposing FPolyObj's bbox array.

This PR aims to expose polyobjects to ZScript as read only data. Allowing mods to be able to get info such as if a polyobject is present, if it does crushing damage, is a portal, etc.

So far it consists of the following:
- Exposing the polyobjects[] array in LevelLocals (After @MrRaveYard fixed it with 51a069a to not include malformed polyobjects) so that mods can access all polyobjects on any given map.
- Exposing FLevelLocals::GetPolyobj(). For finding polyobjects by ID.
- Exposing the FPolyObj struct itself. With all of its' exposed data set as readonly. And also exposing FPolyObj::GetMirror() instead of MirrorNum itself.
- Making ZScript-side GetStartSpot() and GetCenterSpot() methods for PolyObj. To not need to expose FPolyVertex just for their own vector2 member variable.
- Adding a simple PolyObjPortalType enum to PolyObj for making bHasPortals more readable.
- Exporting ClosestPoint(), for, well, getting the closest point to the polyobject from the specified position. Which is a function that doesn't seem to be used anywhere else anyways.
- Exposing DPolyAction and all its' children. Which are what all the polyobject action specials like doors, rotators, and movers are under the hood (i.e specials like Polyobj_MoveToSpot). The DPolyAction-derived classes all use new (And pre-existing getters), none of the variables themselves are exposed (Since they are all protected and I decided to keep them that way), and PolyAction itself is sealed.

In addition, here is a simple example mod that reads a lot of this exposed data and prints it to the console from a custom weapon. Just spawn the "PolyPistol" class and fire it at a polyobject. It will print a ton of info, and also spawn a Doom candlestick at the nearest point to the polyobject your shot, relative to your position. Try it on something like Hexen's first map.
[PolyFinderPistol.zip](https://github.com/user-attachments/files/20402405/PolyFinderPistol.zip)

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.