### PR TITLE
Modernization pass on Automap

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -929,72 +929,72 @@ class DAutomap :public DAutomapBase
 	//FLevelLocals *Level;
 	// scale on entry
 	// used by MTOF to scale from map-to-frame-buffer coords
-	double scale_mtof = .2;
+	double scale_mtof;
 	// used by FTOM to scale from frame-buffer-to-map coords (=1/scale_mtof)
-	double scale_ftom = 1.0/scale_mtof;
+	double scale_ftom;
 
-	bool bigstate = false;
-	int MapPortalGroup = 0;
+	bool bigstate;
+	int MapPortalGroup;
 
 	// Disable the ML_DONTDRAW line flag if x% of all lines in a map are flagged with it
 	// (To counter annoying mappers who think they are smart by making the automap unusable)
-	bool am_showallenabled = false;
+	bool am_showallenabled;
 
 	// location of window on screen
-	int	f_x = 0;
-	int	f_y = 0;
+	int	f_x;
+	int	f_y;
 
 	// size of window on screen
-	int	f_w = 0;
-	int	f_h = 0;
+	int	f_w;
+	int	f_h;
 
-	int	amclock = 0;
+	int	amclock;
 
-	mpoint_t	m_paninc = { 0.0, 0.0 };		// how far the window pans each tic (map coords)
-	double	mtof_zoommul = 0.0;	// how far the window zooms in each tic (map coords)
+	mpoint_t	m_paninc;		// how far the window pans each tic (map coords)
+	double	mtof_zoommul;	// how far the window zooms in each tic (map coords)
 
-	double m_x = 0.0;
-	double m_y = 0.0;		// LL x,y where the window is on the map (map coords)
-	double m_x2 = 0.0;
-	double m_y2 = 0.0;		// UR x,y where the window is on the map (map coords)
+	double m_x;
+	double m_y;		// LL x,y where the window is on the map (map coords)
+	double m_x2;
+	double m_y2;		// UR x,y where the window is on the map (map coords)
 
 	//
 	// width/height of window on map (map coords)
 	//
-	double	m_w = 0.0;
-	double	m_h = 0.0;
+	double	m_w;
+	double	m_h;
 
 	// based on level size
-	double	min_x = 0.0, min_y = 0.0, max_x = 0.0, max_y = 0.0;
+	double	min_x, min_y, max_x, max_y;
 
-	double	max_w = 0.0; // max_x-min_x,
-	double	max_h = 0.0; // max_y-min_y
+	double	max_w; // max_x-min_x,
+	double	max_h; // max_y-min_y
 
 	// based on player size
-	double	min_w = 0.0;
-	double	min_h = 0.0;
+	double	min_w;
+	double	min_h;
 
 
-	double	min_scale_mtof = 0.0; // used to tell when to stop zooming out
-	double	max_scale_mtof = 0.0; // used to tell when to stop zooming in
+	double	min_scale_mtof; // used to tell when to stop zooming out
+	double	max_scale_mtof; // used to tell when to stop zooming in
 
 	// old stuff for recovery later
-	double old_m_w = 0.0, old_m_h = 0.0;
-	double old_m_x = 0.0, old_m_y = 0.0;
+	double old_m_w, old_m_h;
+	double old_m_x, old_m_y;
 
 	// old location used by the Follower routine
-	mpoint_t f_oldloc = { 0.0, 0.0 };
+	mpoint_t f_oldloc;
 
-	std::array<mpoint_t, AutoMap::Defaults::num_mark_points> markpoints = {}; // where the points are
-	int markpointnum = 0; // next point to be assigned
+	std::array<mpoint_t, AutoMap::Defaults::num_mark_points> markpoints; // where the points are
+	int markpointnum; // next point to be assigned
 
-	FTextureID mapback = nullptr;	// the automap background
-	double mapystart = 0; // y-value for the start of the map bitmap...used in the parallax stuff.
-	double mapxstart = 0; //x-value for the bitmap.
+	FTextureID mapback;	// the automap background
+	double mapystart; // y-value for the start of the map bitmap...used in the parallax stuff.
+	double mapxstart; //x-value for the bitmap.
 
 	TArray<FVector2> points;
 
-	int line_thickness_scaled = 1; // line thickness scaled to resolution
+	int line_thickness_scaled; // line thickness scaled to resolution
 
 	// translates between frame-buffer and map distances
 	double FTOM(double x)

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -63,19 +63,17 @@
 //
 //=============================================================================
 
-enum
+namespace AutoMap::Defaults
 {
-	AM_NUMMARKPOINTS = 10,
-};
+	static inline constexpr double PLAYERRADIUS = 16.; // player radius for automap checking
+	static inline constexpr double M_ZOOMIN = 2; // how much zoom-in per second
+	static inline constexpr double M_ZOOMOUT = 0.2; // how much zoom-out per second
+	static inline constexpr double M_OLDZOOMIN = (1.02); // for am_zoom
+	static inline constexpr double M_OLDZOOMOUT = (1 / 1.02);
+	static inline constexpr uint8_t num_mark_points = 10;
+}
 
-// C++ cannot do static const floats in a class, so these need to be global...
-static const double PLAYERRADIUS = 16.;	// player radius for automap checking
-static const double M_ZOOMIN = 2; // how much zoom-in per second
-static const double M_ZOOMOUT = 0.2; // how much zoom-out per second
-static const double M_OLDZOOMIN = (1.02); // for am_zoom
-static const double M_OLDZOOMOUT = (1 / 1.02);
-
-static FTextureID marknums[AM_NUMMARKPOINTS]; // numbers used for marking by the automap
+static FTextureID marknums[AutoMap::Defaults::num_mark_points]; // numbers used for marking by the automap
 bool automapactive = false;
 
 //=============================================================================
@@ -123,7 +121,7 @@ CVAR(Bool, am_thingrenderstyles, true, CVAR_ARCHIVE)
 CVAR(Int, am_showsubsector, -1, 0);
 
 
-CUSTOM_CVAR(Int, am_showalllines, -1, CVAR_NOINITCALL)	// This is a cheat so don't save it.
+CUSTOM_CVAR(Int, am_showalllines, -1, CVAR_NOINITCALL) // This is a cheat so don't save it.
 {
 	if (primaryLevel && primaryLevel->automap)
 		primaryLevel->automap->UpdateShowAllLines();
@@ -266,56 +264,57 @@ CCMD(am_zoom)
 //
 //=============================================================================
 
-CVAR (Color, am_backcolor,			0x6c5440,	CVAR_ARCHIVE);
-CVAR (Color, am_yourcolor,			0xfce8d8,	CVAR_ARCHIVE);
-CVAR (Color, am_wallcolor,			0x2c1808,	CVAR_ARCHIVE);
-CVAR (Color, am_secretwallcolor,	0x000000,	CVAR_ARCHIVE);
-CVAR (Color, am_specialwallcolor,	0xffffff,	CVAR_ARCHIVE);
-CVAR (Color, am_tswallcolor,		0x888888,	CVAR_ARCHIVE);
-CVAR (Color, am_fdwallcolor,		0x887058,	CVAR_ARCHIVE);
-CVAR (Color, am_cdwallcolor,		0x4c3820,	CVAR_ARCHIVE);
-CVAR (Color, am_efwallcolor,		0x665555,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor,			0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_gridcolor,			0x8b5a2b,	CVAR_ARCHIVE);
-CVAR (Color, am_xhaircolor,			0x808080,	CVAR_ARCHIVE);
-CVAR (Color, am_notseencolor,		0x6c6c6c,	CVAR_ARCHIVE);
-CVAR (Color, am_lockedcolor,		0x007800,	CVAR_ARCHIVE);
-CVAR (Color, am_intralevelcolor,	0x0000ff,	CVAR_ARCHIVE);
-CVAR (Color, am_interlevelcolor,	0xff0000,	CVAR_ARCHIVE);
-CVAR (Color, am_secretsectorcolor,	0xff00ff,	CVAR_ARCHIVE);
-CVAR (Color, am_unexploredsecretcolor,	0xff00ff,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor_friend,	0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor_monster,	0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor_ncmonster,	0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor_item,	0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_thingcolor_citem,	0xfcfcfc,	CVAR_ARCHIVE);
-CVAR (Color, am_sectorfillcolor,	0x4e3621,	CVAR_ARCHIVE);
-CVAR (Float, am_sectorfillalpha,	0.0f,		CVAR_ARCHIVE);
-CVAR (Color, am_portalcolor,		0x404040,	CVAR_ARCHIVE);
+CVAR (Float, am_sectorfillalpha,           0.0f, CVAR_ARCHIVE);
+CVAR (Color, am_backcolor,             0x6c5440, CVAR_ARCHIVE);
+CVAR (Color, am_yourcolor,             0xfce8d8, CVAR_ARCHIVE);
+CVAR (Color, am_wallcolor,             0x2c1808, CVAR_ARCHIVE);
+CVAR (Color, am_secretwallcolor,       0x000000, CVAR_ARCHIVE);
+CVAR (Color, am_specialwallcolor,      0xffffff, CVAR_ARCHIVE);
+CVAR (Color, am_tswallcolor,           0x888888, CVAR_ARCHIVE);
+CVAR (Color, am_fdwallcolor,           0x887058, CVAR_ARCHIVE);
+CVAR (Color, am_cdwallcolor,           0x4c3820, CVAR_ARCHIVE);
+CVAR (Color, am_efwallcolor,           0x665555, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor,            0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_gridcolor,             0x8b5a2b, CVAR_ARCHIVE);
+CVAR (Color, am_xhaircolor,            0x808080, CVAR_ARCHIVE);
+CVAR (Color, am_notseencolor,          0x6c6c6c, CVAR_ARCHIVE);
+CVAR (Color, am_lockedcolor,           0x007800, CVAR_ARCHIVE);
+CVAR (Color, am_intralevelcolor,       0x0000ff, CVAR_ARCHIVE);
+CVAR (Color, am_interlevelcolor,       0xff0000, CVAR_ARCHIVE);
+CVAR (Color, am_secretsectorcolor,     0xff00ff, CVAR_ARCHIVE);
+CVAR (Color, am_unexploredsecretcolor, 0xff00ff, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor_friend,     0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor_monster,    0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor_ncmonster,  0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor_item,       0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_thingcolor_citem,      0xfcfcfc, CVAR_ARCHIVE);
+CVAR (Color, am_sectorfillcolor,       0x4e3621, CVAR_ARCHIVE);
+CVAR (Color, am_portalcolor,           0x404040, CVAR_ARCHIVE);
 
-CVAR (Color, am_ovyourcolor,		0xfce8d8,	CVAR_ARCHIVE);
-CVAR (Color, am_ovwallcolor,		0x00ff00,	CVAR_ARCHIVE);
-CVAR (Color, am_ovsecretwallcolor,	0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovspecialwallcolor,	0xffffff,	CVAR_ARCHIVE);
-CVAR (Color, am_ovotherwallscolor,	0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovlockedcolor,		0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovefwallcolor,		0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovfdwallcolor,		0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovcdwallcolor,		0x008844,	CVAR_ARCHIVE);
-CVAR (Color, am_ovunseencolor,		0x00226e,	CVAR_ARCHIVE);
-CVAR (Color, am_ovtelecolor,		0xffff00,	CVAR_ARCHIVE);
-CVAR (Color, am_ovinterlevelcolor,	0xffff00,	CVAR_ARCHIVE);
-CVAR (Color, am_ovsecretsectorcolor,0x00ffff,	CVAR_ARCHIVE);
-CVAR (Color, am_ovunexploredsecretcolor,0x00ffff,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor,		0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor_friend,	0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor_monster,	0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor_ncmonster,	0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor_item,		0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovthingcolor_citem,		0xe88800,	CVAR_ARCHIVE);
-CVAR (Color, am_ovsectorfillcolor,		0x000000,	CVAR_ARCHIVE);
-CVAR (Float, am_ovsectorfillalpha,		0.0f,		CVAR_ARCHIVE);
-CVAR (Color, am_ovportalcolor,			0x004022,	CVAR_ARCHIVE);
+
+CVAR (Float, am_ovsectorfillalpha,           0.0f, CVAR_ARCHIVE);
+CVAR (Color, am_ovyourcolor,             0xfce8d8, CVAR_ARCHIVE);
+CVAR (Color, am_ovwallcolor,             0x00ff00, CVAR_ARCHIVE);
+CVAR (Color, am_ovsecretwallcolor,       0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovspecialwallcolor,      0xffffff, CVAR_ARCHIVE);
+CVAR (Color, am_ovotherwallscolor,       0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovlockedcolor,           0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovefwallcolor,           0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovfdwallcolor,           0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovcdwallcolor,           0x008844, CVAR_ARCHIVE);
+CVAR (Color, am_ovunseencolor,           0x00226e, CVAR_ARCHIVE);
+CVAR (Color, am_ovtelecolor,             0xffff00, CVAR_ARCHIVE);
+CVAR (Color, am_ovinterlevelcolor,       0xffff00, CVAR_ARCHIVE);
+CVAR (Color, am_ovsecretsectorcolor,     0x00ffff, CVAR_ARCHIVE);
+CVAR (Color, am_ovunexploredsecretcolor, 0x00ffff, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor,            0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor_friend,     0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor_monster,    0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor_ncmonster,  0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor_item,       0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovthingcolor_citem,      0xe88800, CVAR_ARCHIVE);
+CVAR (Color, am_ovsectorfillcolor,       0x000000, CVAR_ARCHIVE);
+CVAR (Color, am_ovportalcolor,           0x004022, CVAR_ARCHIVE);
 
 //=============================================================================
 //
@@ -325,24 +324,43 @@ CVAR (Color, am_ovportalcolor,			0x004022,	CVAR_ARCHIVE);
 
 struct AMColor
 {
-	uint32_t RGB;
+	uint32_t RGB = 0;
+
+	constexpr AMColor(uint32_t rgb) noexcept
+	{
+		RGB = 0xff000000|rgb;
+	}
+
+	constexpr AMColor(int r, int g, int b) noexcept
+	{
+		RGB = MAKEARGB(255, r, g, b);
+	}
+
+	constexpr AMColor() = default;
+	constexpr AMColor(AMColor&& rhs) = default;
+	constexpr AMColor(const AMColor& rhs) = default;
+	constexpr AMColor(AMColor& rhs) = default;
+	~AMColor() = default;
+
+	AMColor& operator=(const AMColor&) = default;
+	AMColor& operator=(AMColor&) = default;
 
 	void FromCVar(FColorCVar & cv)
 	{
 		RGB = uint32_t(cv) | MAKEARGB(255, 0, 0, 0);
 	}
 
-	void FromRGB(int r,int g, int b)
+	constexpr void FromRGB(int r,int g, int b)
 	{
 		RGB = MAKEARGB(255, r, g, b);
 	}
 
-	void setInvalid()
+	constexpr void setInvalid()
 	{
 		RGB = 0;
 	}
 
-	bool isValid() const
+	constexpr bool isValid() const
 	{
 		return RGB != 0;
 	}
@@ -386,7 +404,7 @@ static const char *ColorNames[] = {
 
 struct AMColorset
 {
-	enum
+	enum EAMColor
 	{
 		Background,
 		YourColor,
@@ -417,11 +435,20 @@ struct AMColorset
 		AM_NUM_COLORS
 	};
 
-	AMColor c[AM_NUM_COLORS];
+	std::array<AMColor, AM_NUM_COLORS> c;
 	double fillAlpha;
-	bool displayLocks;
-	bool forcebackground;
-	bool defined;	// only for mod specific colorsets: must be true to be usable
+	bool displayLocks = false;
+	bool forcebackground = false;
+	bool defined = false; // only for mod specific colorsets: must be true to be usable
+
+	AMColorset() = default;
+	AMColorset(AMColorset&& rhs) = delete;
+	AMColorset(AMColorset& rhs) = default;
+	AMColorset(const AMColorset& rhs) = default;
+	~AMColorset() = default;
+
+	AMColorset& operator=(const AMColorset&) = default;
+	AMColorset& operator=(AMColorset&) = default;
 
 	void initFromCVars(FColorCVarRef **values, FFloatCVarRef &fill_alpha_cv)
 	{
@@ -450,21 +477,9 @@ struct AMColorset
 		forcebackground = false;
 	}
 
-	void initFromColors(const unsigned char *colors, bool showlocks)
+	void initFromColors(const std::array<AMColor, AM_NUM_COLORS> colors, bool showlocks)
 	{
-		for(int i=0, j=0; i<AM_NUM_COLORS; i++, j+=3)
-		{
-			if (colors[j] == 1 && colors[j+1] == 0 && colors[j+2] == 0)
-			{
-				c[i].setInvalid();
-			}
-			else
-			{
-				c[i].FromRGB(colors[j], colors[j+1], colors[j+2]);
-			}
-		}
-
-		fillAlpha = 0.0f;
+		c = colors;
 		displayLocks = showlocks;
 		forcebackground = false;
 	}
@@ -478,7 +493,7 @@ struct AMColorset
 		}
 	}
 
-	const AMColor &operator[](int index) const
+	const AMColor& operator[](int index) const
 	{
 		return c[index];
 	}
@@ -497,20 +512,20 @@ struct AMColorset
 
 static const int AUTOMAP_LINE_COLORS[AMLS_COUNT] =
 {
-	-1, 								// AMLS_Default (unused)
-	AMColorset::WallColor, 				// AMLS_OneSided,
-	AMColorset::TSWallColor, 			// AMLS_TwoSided
-	AMColorset::FDWallColor, 			// AMLS_FloorDiff
-	AMColorset::CDWallColor, 			// AMLS_CeilingDiff
-	AMColorset::EFWallColor, 			// AMLS_ExtraFloor
-	AMColorset::SpecialWallColor, 		// AMLS_Special
-	AMColorset::SecretWallColor, 		// AMLS_Secret
-	AMColorset::NotSeenColor, 			// AMLS_NotSeen
-	AMColorset::LockedColor, 			// AMLS_Locked
-	AMColorset::IntraTeleportColor, 	// AMLS_IntraTeleport
-	AMColorset::InterTeleportColor, 	// AMLS_InterTeleport
-	AMColorset::UnexploredSecretColor, 	// AMLS_UnexploredSecret
-	AMColorset::PortalColor, 			// AMLS_Portal
+	-1,                                // AMLS_Default (unused)
+	AMColorset::WallColor,             // AMLS_OneSided,
+	AMColorset::TSWallColor,           // AMLS_TwoSided
+	AMColorset::FDWallColor,           // AMLS_FloorDiff
+	AMColorset::CDWallColor,           // AMLS_CeilingDiff
+	AMColorset::EFWallColor,           // AMLS_ExtraFloor
+	AMColorset::SpecialWallColor,      // AMLS_Special
+	AMColorset::SecretWallColor,       // AMLS_Secret
+	AMColorset::NotSeenColor,          // AMLS_NotSeen
+	AMColorset::LockedColor,           // AMLS_Locked
+	AMColorset::IntraTeleportColor,    // AMLS_IntraTeleport
+	AMColorset::InterTeleportColor,    // AMLS_InterTeleport
+	AMColorset::UnexploredSecretColor, // AMLS_UnexploredSecret
+	AMColorset::PortalColor,           // AMLS_Portal
 };
 
 //=============================================================================
@@ -548,7 +563,7 @@ static FColorCVarRef *cv_standard[] = {
 };
 
 static FColorCVarRef *cv_overlay[] = {
-	&am_backcolor,	// this will not be used in overlay mode
+	&am_backcolor, // this will not be used in overlay mode
 	&am_ovyourcolor,
 	&am_ovwallcolor,
 	&am_ovotherwallscolor,
@@ -563,8 +578,8 @@ static FColorCVarRef *cv_overlay[] = {
 	&am_ovthingcolor_friend,
 	&am_ovspecialwallcolor,
 	&am_ovsecretwallcolor,
-	&am_gridcolor,	// this will not be used in overlay mode
-	&am_xhaircolor,	// this will not be used in overlay mode
+	&am_gridcolor, // this will not be used in overlay mode
+	&am_xhaircolor, // this will not be used in overlay mode
 	&am_ovunseencolor,
 	&am_ovlockedcolor,
 	&am_ovtelecolor,
@@ -593,102 +608,98 @@ CCMD(am_restorecolors)
 }
 
 
+namespace AutoMap::Colors 
+{
+	static inline const AMColor not_used = AMColor(0x010000);
 
-#define NOT_USED 1,0,0	// use almost black as indicator for an unused color
+	static inline const std::array<AMColor,AMColorset::EAMColor::AM_NUM_COLORS> DoomColors = {
+		AMColor(0x000000), // background
+		AMColor(0xffffff), // yourcolor
+		AMColor(0xfc0000), // wallcolor
+		AMColor(0x808080), // tswallcolor
+		AMColor(0xbc7848), // fdwallcolor
+		AMColor(0xfcfc00), // cdwallcolor
+		AMColor(0xbc7848), // efwallcolor
+		AMColor(0x74fc6c), // thingcolor
+		AMColor(0x74fc6c), // thingcolor_item
+		AMColor(0x74fc6c), // thingcolor_citem
+		AMColor(0x74fc6c), // thingcolor_monster
+		AMColor(0x74fc6c), // thingcolor_ncmonster
+		AMColor(0x74fc6c), // thingcolor_friend
+		not_used,          // specialwallcolor
+		not_used,          // secretwallcolor
+		AMColor(0x4c4c4c), // gridcolor
+		AMColor(0x808080), // xhaircolor
+		AMColor(0x6c6c6c), // notseencolor
+		AMColor(0xfcfc00), // lockedcolor
+		not_used,          // intrateleport
+		not_used,          // interteleport
+		not_used,          // secretsector
+		not_used,          // unexploredsecretsector
+		AMColor(0x101010), // almostbackground
+		AMColor(0x404040)  // portal
+	};
 
-static unsigned char DoomColors[]= {
-	0x00,0x00,0x00, // background
-	0xff,0xff,0xff, // yourcolor
-	0xfc,0x00,0x00, // wallcolor
-	0x80,0x80,0x80, // tswallcolor
-	0xbc,0x78,0x48,	// fdwallcolor
-	0xfc,0xfc,0x00, // cdwallcolor
-	0xbc,0x78,0x48,	// efwallcolor
-	0x74,0xfc,0x6c, // thingcolor
-	0x74,0xfc,0x6c, // thingcolor_item
-	0x74,0xfc,0x6c, // thingcolor_citem
-	0x74,0xfc,0x6c, // thingcolor_monster
-	0x74,0xfc,0x6c, // thingcolor_ncmonster
-	0x74,0xfc,0x6c, // thingcolor_friend
-	NOT_USED,		// specialwallcolor
-	NOT_USED,		// secretwallcolor
-	0x4c,0x4c,0x4c,	// gridcolor
-	0x80,0x80,0x80, // xhaircolor
-	0x6c,0x6c,0x6c,	// notseencolor
-	0xfc,0xfc,0x00, // lockedcolor
-	NOT_USED,		// intrateleport
-	NOT_USED,		// interteleport
-	NOT_USED,		// secretsector
-	NOT_USED,		// unexploredsecretsector
-	NOT_USED,		// sectorfillcolor
-	0x10,0x10,0x10,	// almostbackground
-	0x40,0x40,0x40	// portal
-};
+	static inline const std::array<AMColor, AMColorset::EAMColor::AM_NUM_COLORS> StrifeColors = {
+		AMColor(0x000000), // background
+		AMColor(0xefef00), // yourcolor
+		AMColor(0xc7c3c3), // wallcolor
+		AMColor(0x777373), // tswallcolor
+		AMColor(0x373b9b), // fdwallcolor
+		AMColor(0x777373), // cdwallcolor
+		AMColor(0x373b9b), // efwallcolor
+		AMColor(0xbb3b00), // thingcolor
+		AMColor(0xdbab00), // thingcolor_item
+		AMColor(0xdbab00), // thingcolor_citem
+		AMColor(0xfc0000), // thingcolor_monster
+		AMColor(0xfc0000), // thingcolor_ncmonster
+		AMColor(0xfc0000), // thingcolor_friend
+		not_used,          // specialwallcolor
+		not_used,          // secretwallcolor
+		AMColor(0x4c4c4c), // gridcolor
+		AMColor(0x808080), // xhaircolor
+		AMColor(0x6c6c6c), // notseencolor
+		AMColor(0x777373), // lockedcolor
+		not_used,          // intrateleport
+		not_used,          // interteleport
+		not_used,          // secretsector
+		not_used,          // unexploredsecretsector
+		AMColor(0x101010), // almostbackground
+		AMColor(0x404040)  // portal
+	};
 
-static unsigned char StrifeColors[]= {
-	0x00,0x00,0x00, // background
-	239, 239,   0,	// yourcolor
-	199, 195, 195,	// wallcolor
-	119, 115, 115,	// tswallcolor
-	 55,  59,  91,	// fdwallcolor
-	119, 115, 115,	// cdwallcolor
-	 55,  59,  91,	// efwallcolor
-	187,  59,   0,	// thingcolor
-	219, 171,   0,	// thingcolor_item
-	219, 171,   0,	// thingcolor_citem
-	0xfc,0x00,0x00,	// thingcolor_monster
-	0xfc,0x00,0x00,	// thingcolor_ncmonster
-	0xfc,0x00,0x00, // thingcolor_friend
-	NOT_USED,		// specialwallcolor
-	NOT_USED,		// secretwallcolor
-	0x4c,0x4c,0x4c,	// gridcolor
-	0x80,0x80,0x80, // xhaircolor
-	0x6c,0x6c,0x6c,	// notseencolor
-	119, 115, 115,	// lockedcolor
-	NOT_USED,		// intrateleport
-	NOT_USED,		// interteleport
-	NOT_USED,		// secretsector
-	NOT_USED,		// unexploredsecretsector
-	NOT_USED,		// sectorfillcolor
-	0x10,0x10,0x10,	// almostbackground
-	0x40,0x40,0x40	// portal
-};
-
-static unsigned char RavenColors[]= {
-	0x6c,0x54,0x40, // background
-	0xff,0xff,0xff, // yourcolor
-	 75,  50,  16,	// wallcolor
-	 88,  93,  86,	// tswallcolor
-	208, 176, 133,  // fdwallcolor
-	103,  59,  31,	// cdwallcolor
-	208, 176, 133,  // efwallcolor
-	236, 236, 236,	// thingcolor
-	236, 236, 236,	// thingcolor_item
-	236, 236, 236,	// thingcolor_citem
-	236, 236, 236,	// thingcolor_monster
-	236, 236, 236,	// thingcolor_ncmonster
-	236, 236, 236,	// thingcolor_friend
-	NOT_USED,		// specialwallcolor
-	NOT_USED,		// secretwallcolor
-	 75,  50,  16,	// gridcolor
-	0x00,0x00,0x00, // xhaircolor
-	0x00,0x00,0x00,	// notseencolor
-	103,  59,  31,	// lockedcolor
-	NOT_USED,		// intrateleport
-	NOT_USED,		// interteleport
-	NOT_USED,		// secretsector
-	NOT_USED,		// unexploredsecretsector
-	NOT_USED,		// sectorfillcolor
-	0x10,0x10,0x10,	// almostbackground
-	0x50,0x50,0x50	// portal
-};
-
-#undef NOT_USED
+	static inline const std::array<AMColor, AMColorset::EAMColor::AM_NUM_COLORS> RavenColors = {
+		AMColor(0x6c5440), // background
+		AMColor(0xffffff), // yourcolor
+		AMColor(0x4b3210), // wallcolor
+		AMColor(0x585d56), // tswallcolor
+		AMColor(0xd0b085), // fdwallcolor
+		AMColor(0x673b1f), // cdwallcolor
+		AMColor(0xd0b085), // efwallcolor
+		AMColor(0xececec), // thingcolor
+		AMColor(0xececec), // thingcolor_item
+		AMColor(0xececec), // thingcolor_citem
+		AMColor(0xececec), // thingcolor_monster
+		AMColor(0xececec), // thingcolor_ncmonster
+		AMColor(0xececec), // thingcolor_friend
+		not_used,          // specialwallcolor
+		not_used,          // secretwallcolor
+		AMColor(0x4b3210), // gridcolor
+		AMColor(0x000000), // xhaircolor
+		AMColor(0x000000), // notseencolor
+		AMColor(0x673b1f), // lockedcolor
+		not_used,          // intrateleport
+		not_used,          // interteleport
+		not_used,          // secretsector
+		not_used,          // unexploredsecretsector
+		AMColor(0x101010), // almostbackground
+		AMColor(0x505050)  // portal
+	};
+}
 
 static AMColorset AMColors;
 static AMColorset AMMod;
 static AMColorset AMModOverlay;
-
 
 void AM_ClearColorsets()
 {
@@ -708,7 +719,7 @@ static void AM_initColors(bool overlayed)
 	{
 		if (am_customcolors && AMModOverlay.defined)
 		{
-			AMColors = AMModOverlay;
+			AMColors = (AMModOverlay);
 		}
 		else
 		{
@@ -739,19 +750,19 @@ static void AM_initColors(bool overlayed)
 			AMColors.initFromCVars(cv_standard, am_sectorfillalpha);
 			break;
 
-		case 1:	// Doom
+		case 1: // Doom
 			// Use colors corresponding to the original Doom's
-			AMColors.initFromColors(DoomColors, false);
+			AMColors.initFromColors(AutoMap::Colors::DoomColors, false);
 			break;
 
-		case 2:	// Strife
+		case 2: // Strife
 			// Use colors corresponding to the original Strife's
-			AMColors.initFromColors(StrifeColors, false);
+			AMColors.initFromColors(AutoMap::Colors::StrifeColors, false);
 			break;
 
-		case 3:	// Raven
+		case 3: // Raven
 			// Use colors corresponding to the original Raven's
-			AMColors.initFromColors(RavenColors, true);
+			AMColors.initFromColors(AutoMap::Colors::RavenColors, true);
 			break;
 
 		}
@@ -787,15 +798,15 @@ void FMapInfoParser::ParseAMColors(bool overlay)
 			sc.MustGetToken(TK_StringConst);
 			if (sc.Compare("doom"))
 			{
-				cset.initFromColors(DoomColors, false);
+				cset.initFromColors(AutoMap::Colors::DoomColors, false);
 			}
 			else if (sc.Compare("raven"))
 			{
-				cset.initFromColors(RavenColors, true);
+				cset.initFromColors(AutoMap::Colors::RavenColors, true);
 			}
 			else if (sc.Compare("strife"))
 			{
-				cset.initFromColors(StrifeColors, false);
+				cset.initFromColors(AutoMap::Colors::StrifeColors, false);
 			}
 			else
 			{
@@ -869,7 +880,7 @@ static std::array<mline_t, 3> thintriangle_guy = { {
 
 static void AM_ParseArrow(TArray<mline_t> &Arrow, const char *lumpname)
 {
-	const int R = int((8 * PLAYERRADIUS) / 7);
+	const int R = int((8 * AutoMap::Defaults::PLAYERRADIUS) / 7);
 	FScanner sc;
 	int lump = fileSystem.CheckNumForFullName(lumpname, true);
 	if (lump >= 0)
@@ -914,7 +925,7 @@ void AM_StaticInit()
 
 	char namebuf[9];
 
-	for (int i = 0; i < AM_NUMMARKPOINTS; i++)
+	for (int i = 0; i < AutoMap::Defaults::num_mark_points; i++)
 	{
 		mysnprintf(namebuf, countof(namebuf), "AMMNUM%d", i);
 		marknums[i] = TexMan.CheckForTexture(namebuf, ETextureType::MiscPatch);
@@ -934,78 +945,77 @@ class DAutomap :public DAutomapBase
 {
 	DECLARE_CLASS(DAutomap, DAutomapBase)
 
-	enum
-	{
-		F_PANINC = 140 / TICRATE,	// how much the automap moves window per tic in frame-buffer coordinates moves 140 pixels at 320x200 in 1 second
-	};
+	static inline constexpr int F_PANINC = 140 / TICRATE; // how much the automap moves window per tic in frame-buffer coordinates moves 140 pixels at 320x200 in 1 second
 
 	//FLevelLocals *Level;
 	// scale on entry
 	// used by MTOF to scale from map-to-frame-buffer coords
 	double scale_mtof = .2;
 	// used by FTOM to scale from frame-buffer-to-map coords (=1/scale_mtof)
-	double scale_ftom;
+	double scale_ftom = 0.2;
 
-	int bigstate;
-	int MapPortalGroup;
+	bool bigstate = false;
+	int MapPortalGroup = 0;
 
 	// Disable the ML_DONTDRAW line flag if x% of all lines in a map are flagged with it
 	// (To counter annoying mappers who think they are smart by making the automap unusable)
-	bool am_showallenabled;
+	bool am_showallenabled = false;
 
 	// location of window on screen
-	int	f_x;
-	int	f_y;
+	int f_x = 0;
+	int f_y = 0;
 
 	// size of window on screen
-	int	f_w;
-	int	f_h;
+	int f_w = 0;
+	int f_h = 0;
 
-	int	amclock;
+	int amclock = 0;
 
-	mpoint_t	m_paninc;		// how far the window pans each tic (map coords)
-	double	mtof_zoommul;	// how far the window zooms in each tic (map coords)
+	mpoint_t m_paninc = { 0.0, 0.0 }; // how far the window pans each tic (map coords)
+	double mtof_zoommul = 0.0; // how far the window zooms in each tic (map coords)
 
-	double	m_x, m_y;		// LL x,y where the window is on the map (map coords)
-	double	m_x2, m_y2;		// UR x,y where the window is on the map (map coords)
+	double m_x = 0.0;
+	double m_y = 0.0; // LL x,y where the window is on the map (map coords)
+	double m_x2 = 0.0;
+	double m_y2 = 0.0; // UR x,y where the window is on the map (map coords)
 
 	//
 	// width/height of window on map (map coords)
 	//
-	double	m_w;
-	double	m_h;
+	double m_w = 0.0;
+	double m_h = 0.0;
 
 	// based on level size
-	double	min_x, min_y, max_x, max_y;
+	double min_x = 0.0, min_y = 0.0, max_x = 0.0, max_y = 0.0;
 
-	double	max_w; // max_x-min_x,
-	double	max_h; // max_y-min_y
+	double max_w = 0.0; // max_x-min_x,
+	double max_h = 0.0; // max_y-min_y
 
 	// based on player size
-	double	min_w;
-	double	min_h;
+	double min_w = 0.0;
+	double min_h = 0.0;
 
 
-	double	min_scale_mtof; // used to tell when to stop zooming out
-	double	max_scale_mtof; // used to tell when to stop zooming in
+	double min_scale_mtof = 0.0; // used to tell when to stop zooming out
+	double max_scale_mtof = 0.0; // used to tell when to stop zooming in
 
 	// old stuff for recovery later
-	double old_m_w, old_m_h;
-	double old_m_x, old_m_y;
+	double old_m_w = 0.0, old_m_h = 0.0;
+	double old_m_x = 0.0, old_m_y = 0.0;
 
 	// old location used by the Follower routine
-	mpoint_t f_oldloc;
+	mpoint_t f_oldloc = { 0.0, 0.0 };
 
-	mpoint_t markpoints[AM_NUMMARKPOINTS]; // where the points are
+	std::array<mpoint_t, AutoMap::Defaults::num_mark_points> markpoints = {}; // where the points are
 	int markpointnum = 0; // next point to be assigned
 
-	FTextureID mapback;	// the automap background
+	FTextureID mapback = nullptr; // the automap background
 	double mapystart = 0; // y-value for the start of the map bitmap...used in the parallax stuff.
 	double mapxstart = 0; //x-value for the bitmap.
 
 	TArray<FVector2> points;
 
-	int line_thickness_scaled; // line thickness scaled to resolution
+	int line_thickness_scaled = 1; // line thickness scaled to resolution
 
 	// translates between frame-buffer and map distances
 	double FTOM(double x)
@@ -1032,7 +1042,7 @@ class DAutomap :public DAutomapBase
 	void calcMinMaxMtoF();
 
 	void DrawMarker(FGameTexture *tex, double x, double y, int yadjust,
-		INTBOOL flip, double xscale, double yscale, FTranslationID translation, double alpha, uint32_t fillcolor, FRenderStyle renderstyle);
+		bool flip, double xscale, double yscale, FTranslationID translation, double alpha, uint32_t fillcolor, FRenderStyle renderstyle);
 
 	void rotatePoint(double *x, double *y);
 	void rotate(double *x, double *y, DAngle an);
@@ -1182,7 +1192,7 @@ int DAutomap::addMark ()
 		auto m = markpointnum;
 		markpoints[markpointnum].x = m_x + m_w/2;
 		markpoints[markpointnum].y = m_y + m_h/2;
-		markpointnum = (markpointnum + 1) % AM_NUMMARKPOINTS;
+		markpointnum = (markpointnum + 1) % AutoMap::Defaults::num_mark_points;
 		return m;
 	}
 	return -1;
@@ -1216,8 +1226,8 @@ void DAutomap::findMinMaxBoundaries ()
 	max_w = max_x - min_x;
 	max_h = max_y - min_y;
 
-	min_w = 2*PLAYERRADIUS; // const? never changed?
-	min_h = 2*PLAYERRADIUS;
+	min_w = 2*AutoMap::Defaults::PLAYERRADIUS; // const? never changed?
+	min_h = 2*AutoMap::Defaults::PLAYERRADIUS;
 
 	calcMinMaxMtoF();
 }
@@ -1235,7 +1245,7 @@ void DAutomap::calcMinMaxMtoF()
 	double b = safe_frame * (StatusBar->GetTopOfStatusbar() / max_h);
 
 	min_scale_mtof = a < b ? a : b;
-	max_scale_mtof = twod->GetHeight() / (2*PLAYERRADIUS);
+	max_scale_mtof = twod->GetHeight() / (2*AutoMap::Defaults::PLAYERRADIUS);
 }
 
 //=============================================================================
@@ -1379,7 +1389,7 @@ void DAutomap::startDisplay()
 
 bool DAutomap::clearMarks ()
 {
-	for (int i = AM_NUMMARKPOINTS-1; i >= 0; i--)
+	for (int i = AutoMap::Defaults::num_mark_points -1; i >= 0; i--)
 		markpoints[i].x = -1; // means empty
 	markpointnum = 0;
 	return marknums[0].isValid();
@@ -1532,19 +1542,19 @@ void DAutomap::changeWindowScale (double delta)
 
 	if (am_zoomdir > 0)
 	{
-		mtof_zoommul = M_OLDZOOMIN * am_zoomdir;
+		mtof_zoommul = AutoMap::Defaults::M_OLDZOOMIN * am_zoomdir;
 	}
 	else if (am_zoomdir < 0)
 	{
-		mtof_zoommul = M_OLDZOOMOUT / -am_zoomdir;
+		mtof_zoommul = AutoMap::Defaults::M_OLDZOOMOUT / -am_zoomdir;
 	}
 	else if (buttonMap.ButtonDown(Button_AM_ZoomIn))
 	{
-		mtof_zoommul = (1 + (M_ZOOMIN - 1) * delta);
+		mtof_zoommul = (1 + (AutoMap::Defaults::M_ZOOMIN - 1) * delta);
 	}
 	else if (buttonMap.ButtonDown(Button_AM_ZoomOut))
 	{
-		mtof_zoommul = (1 + (M_ZOOMOUT - 1) * delta);
+		mtof_zoommul = (1 + (AutoMap::Defaults::M_ZOOMOUT - 1) * delta);
 	}
 	else
 	{
@@ -1671,10 +1681,10 @@ void DAutomap::clearFB (const AMColor &color)
 bool DAutomap::clipMline (mline_t *ml, fline_t *fl)
 {
 	enum {
-		LEFT	=1,
-		RIGHT	=2,
-		BOTTOM	=4,
-		TOP		=8
+		LEFT   = 1,
+		RIGHT  = 2,
+		BOTTOM = 4,
+		TOP    = 8
 	};
 
 	int outcode1 = 0;
@@ -1881,8 +1891,8 @@ void DAutomap::drawMline (mline_t *ml, int colorindex)
 
 void DAutomap::drawGrid (int color)
 {
-	double x, y;
-	double start, end;
+	uint64_t x, y;
+	uint64_t start, end;
 	mline_t ml;
 	double minlen, extx, exty;
 	double minx, miny;
@@ -2454,7 +2464,7 @@ bool AM_Check3DFloors(line_t *line)
 	for(unsigned i=0;i<ff_front.Size();i++)
 	{
 		F3DFloor *rover = ff_front[i];
-		if (rover->flags & FF_THISINSIDE) continue;	// only relevant for software rendering.
+		if (rover->flags & FF_THISINSIDE) continue; // only relevant for software rendering.
 		if (!(rover->flags & FF_EXISTS)) continue;
 		if (rover->alpha == 0) continue;
 
@@ -2462,7 +2472,7 @@ bool AM_Check3DFloors(line_t *line)
 		for(unsigned j=0;j<ff_back.Size();j++)
 		{
 			F3DFloor *rover2 = ff_back[j];
-			if (rover2->flags & FF_THISINSIDE) continue;	// only relevant for software rendering.
+			if (rover2->flags & FF_THISINSIDE) continue; // only relevant for software rendering.
 			if (!(rover2->flags & FF_EXISTS)) continue;
 			if (rover2->alpha == 0) continue;
 			if (rover->model == rover2->model && rover->flags == rover2->flags)
@@ -2734,7 +2744,7 @@ void DAutomap::drawWalls (bool allmap)
 
 						AMColor c;
 
-						if (color >= 0)	c.FromRGB(RPART(color), GPART(color), BPART(color));
+						if (color >= 0) c.FromRGB(RPART(color), GPART(color), BPART(color));
 						else c = AMColors[AMColors.LockedColor];
 
 						drawMline(&l, c);
@@ -2748,11 +2758,11 @@ void DAutomap::drawWalls (bool allmap)
 					&& AMColors.isValid(AMColors.SpecialWallColor)
 					&& AM_isTriggerBoundary(line))
 				{
-					drawMline(&l, AMColors.SpecialWallColor);	// wall with special non-door action the player can do
+					drawMline(&l, AMColors.SpecialWallColor); // wall with special non-door action the player can do
 				}
 				else if (line.backsector == nullptr)
 				{
-					drawMline(&l, AMColors.WallColor);	// one-sided wall
+					drawMline(&l, AMColors.WallColor); // one-sided wall
 				}
 				else if (line.backsector->floorplane
 					!= line.frontsector->floorplane)
@@ -2843,7 +2853,7 @@ void DAutomap::rotatePoint (double *x, double *y)
 
 void DAutomap::drawLineCharacter(const mline_t *lineguy, size_t lineguylines, double scale, DAngle angle, const AMColor &color, double x, double y)
 {
-	mline_t	l;
+	mline_t l;
 
 	for (size_t i=0;i<lineguylines;i++)
 	{
@@ -2901,10 +2911,9 @@ void DAutomap::drawPlayers ()
 
 	if (!multiplayer)
 	{
-		mline_t *arrow;
-		int numarrowlines;
+		mline_t* arrow = nullptr;
+		uint8_t numarrowlines = 0;
 
-		double vh = players[consoleplayer].viewheight;
 		DVector2 pos = players[consoleplayer].mo->InterpolatedPosition(r_viewpoint.TicFrac).XY();
 		pt.x = pos.X;
 		pt.y = pos.Y;
@@ -2997,7 +3006,7 @@ void DAutomap::drawKeys ()
 {
 	AMColor color;
 	mpoint_t p;
-	DAngle	 angle;
+	DAngle  angle;
 
 	auto it = Level->GetThinkerIterator<AActor>(NAME_Inventory);
 	AActor *key;
@@ -3030,7 +3039,7 @@ void DAutomap::drawKeys ()
 			// That is the case for all default keys, however.
 			int c = P_GetMapColorForKey(key);
 
-			if (c >= 0)	color.FromRGB(RPART(c), GPART(c), BPART(c));
+			if (c >= 0) color.FromRGB(RPART(c), GPART(c), BPART(c));
 			else color = AMColors[AMColors.ThingColor_CountItem];
 			drawLineCharacter(&EasyKey[0], EasyKey.Size(), 0, nullAngle, color, p.x, p.y);
 		}
@@ -3045,9 +3054,9 @@ void DAutomap::drawKeys ()
 void DAutomap::drawThings ()
 {
 	AMColor color;
-	AActor*	 t;
+	AActor*  t;
 	mpoint_t p;
-	DAngle	 angle;
+	DAngle  angle;
 
 	for (auto &sec : Level->sectors)
 	{
@@ -3087,7 +3096,7 @@ void DAutomap::drawThings ()
 						texture = TexMan.GetGameTexture(textureID, true);
 					}
 
-					if (texture == nullptr) goto drawTriangle;	// fall back to standard display if no sprite can be found.
+					if (texture == nullptr) goto drawTriangle; // fall back to standard display if no sprite can be found.
 
 					const DVector2 scale = t->InterpolatedScale(r_viewpoint.TicFrac);
 					const double spriteXScale = (scale.X * (10. / 16.) * scale_mtof);
@@ -3134,7 +3143,7 @@ void DAutomap::drawThings ()
 							{
 								int c = P_GetMapColorForKey(t);
 
-								if (c >= 0)	color.FromRGB(RPART(c), GPART(c), BPART(c));
+								if (c >= 0) color.FromRGB(RPART(c), GPART(c), BPART(c));
 								else color = AMColors[AMColors.ThingColor_CountItem];
 								drawLineCharacter(&CheatKey[0], CheatKey.Size(), 0, nullAngle, color, p.x, p.y);
 								color.RGB = 0;
@@ -3181,7 +3190,7 @@ void DAutomap::drawThings ()
 //=============================================================================
 
 void DAutomap::DrawMarker (FGameTexture *tex, double x, double y, int yadjust,
-	INTBOOL flip, double xscale, double yscale, FTranslationID translation, double alpha, uint32_t fillcolor, FRenderStyle renderstyle)
+	bool flip, double xscale, double yscale, FTranslationID translation, double alpha, uint32_t fillcolor, FRenderStyle renderstyle)
 {
 	if (tex == nullptr || !tex->isValid())
 	{
@@ -3219,10 +3228,10 @@ void DAutomap::DrawMarker (FGameTexture *tex, double x, double y, int yadjust,
 
 void DAutomap::drawMarks ()
 {
-	FFont* font;
+	FFont* font = nullptr;
 	bool fontloaded = false;
 
-	for (int i = 0; i < AM_NUMMARKPOINTS; i++)
+	for (int i = 0; i < AutoMap::Defaults::num_mark_points; i++)
 	{
 		if (markpoints[i].x != -1)
 		{
@@ -3239,7 +3248,7 @@ void DAutomap::drawMarks ()
 			}
 			else
 			{
-				char numstr[2] = { char('0' + i), 0 };
+				std::string numstr = { char('0' + i), 0 };
 				double x = markpoints[i].x;
 				double y = markpoints[i].y;
 
@@ -3248,7 +3257,7 @@ void DAutomap::drawMarks ()
 					rotatePoint (&x, &y);
 				}
 
-				DrawText(twod, font, am_markcolor, CXMTOF(x), CYMTOF(y), numstr, TAG_DONE);
+				DrawText(twod, font, am_markcolor, CXMTOF(x), CYMTOF(y), numstr.c_str(), TAG_DONE);
 			}
 		}
 	}
@@ -3266,7 +3275,7 @@ void DAutomap::drawAuthorMarkers ()
 	// If args[0] is 0, then the actor's sprite is drawn at its own location.
 	// Otherwise, its sprite is drawn at the location of any actors whose TIDs match args[0].
 	auto it = Level->GetThinkerIterator<AActor>(NAME_MapMarker, STAT_MAPMARKER);
-	AActor *mark;
+	AActor* mark = nullptr;
 
 	while ((mark = it.Next()) != nullptr)
 	{
@@ -3275,9 +3284,9 @@ void DAutomap::drawAuthorMarkers ()
 			continue;
 		}
 
-		FTextureID picnum;
-		FGameTexture *tex;
-		uint16_t flip = 0;
+		FTextureID picnum = nullptr;
+		FGameTexture* tex = nullptr;
+		bool flip = false;
 
 		if (mark->picnum.isValid())
 		{
@@ -3306,7 +3315,7 @@ void DAutomap::drawAuthorMarkers ()
 			}
 		}
 		auto it = Level->GetActorIterator(mark->args[0]);
-		AActor *marked = mark->args[0] == 0 ? mark : it.Next();
+		AActor* marked = mark->args[0] == 0 ? mark : it.Next();
 
         DVector2 markscale = mark->InterpolatedScale(r_viewpoint.TicFrac);
 		double xscale = markscale.X;
@@ -3450,7 +3459,7 @@ void DAutomap::Serialize(FSerializer &arc)
 	// This only stores those variables which do not get set each time the automap is either activated or drawn.
 	// Especially the screen coordinates can not be brought over because the display settings may have changed.
 	arc("markpointnum", markpointnum)
-		.Array("markpoints", &markpoints[0].x, AM_NUMMARKPOINTS * 2)	// write as a double array.
+		.Array("markpoints", &markpoints[0].x, AutoMap::Defaults::num_mark_points * 2) // write as a double array.
 		("scale_mtof", scale_mtof)
 		("scale_ftom", scale_ftom)
 		("bigstate", bigstate)
@@ -3497,7 +3506,7 @@ void DAutomap::UpdateShowAllLines()
 			total++;
 			if (line.flags & ML_DONTDRAW) flagged++;
 		}
-		am_showallenabled = (flagged * 100 / total >= val);
+		am_showallenabled = ((flagged * 100 / total) >= val);
 	}
 	else if (val == 0)
 	{
@@ -3518,7 +3527,9 @@ void DAutomap::GoBig()
 		minOutWindowScale();
 	}
 	else
+	{
 		restoreScaleAndLoc();
+	}
 }
 
 void DAutomap::ResetFollowLocation()

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -952,7 +952,7 @@ class DAutomap :public DAutomapBase
 	// used by MTOF to scale from map-to-frame-buffer coords
 	double scale_mtof = .2;
 	// used by FTOM to scale from frame-buffer-to-map coords (=1/scale_mtof)
-	double scale_ftom = 0.2;
+	double scale_ftom = 1.0/scale_mtof;
 
 	bool bigstate = false;
 	int MapPortalGroup = 0;
@@ -1074,7 +1074,6 @@ class DAutomap :public DAutomapBase
 	void drawMarks();
 	void drawAuthorMarkers();
 	void drawCrosshair(const AMColor &color);
-	void CalculateLineThicknessScaled();
 
 public:
 	bool Responder(event_t* ev, bool last) override;
@@ -1174,7 +1173,7 @@ void DAutomap::restoreScaleAndLoc ()
 
 	// Change the scaling multipliers
 	scale_mtof = f_w / m_w;
-	scale_ftom = 1. / scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 }
 
 //=============================================================================
@@ -1418,7 +1417,7 @@ void DAutomap::LevelInit ()
 	scale_mtof = min_scale_mtof / 0.7;
 	if (scale_mtof > max_scale_mtof)
 		scale_mtof = min_scale_mtof;
-	scale_ftom = 1 / scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 
 	UpdateShowAllLines();
 }
@@ -1432,7 +1431,7 @@ void DAutomap::LevelInit ()
 void DAutomap::minOutWindowScale ()
 {
 	scale_mtof = min_scale_mtof;
-	scale_ftom = 1/ scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 }
 
 //=============================================================================
@@ -1444,7 +1443,7 @@ void DAutomap::minOutWindowScale ()
 void DAutomap::maxOutWindowScale ()
 {
 	scale_mtof = max_scale_mtof;
-	scale_ftom = 1 / scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 }
 
 //=============================================================================
@@ -1486,7 +1485,7 @@ void DAutomap::NewResolution()
 	}
 	calcMinMaxMtoF();
 	scale_mtof = scale_mtof * min_scale_mtof / oldmin;
-	scale_ftom = 1 / scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 	if (scale_mtof < min_scale_mtof)
 		minOutWindowScale();
 	else if (scale_mtof > max_scale_mtof)
@@ -1564,7 +1563,7 @@ void DAutomap::changeWindowScale (double delta)
 
 	// Change the scaling multipliers
 	scale_mtof = scale_mtof * mtof_zoommul;
-	scale_ftom = 1 / scale_mtof;
+	scale_ftom = 1.0 / scale_mtof;
 
 	if (scale_mtof < min_scale_mtof)
 		minOutWindowScale();
@@ -1891,8 +1890,8 @@ void DAutomap::drawMline (mline_t *ml, int colorindex)
 
 void DAutomap::drawGrid (int color)
 {
-	uint64_t x, y;
-	uint64_t start, end;
+	double x, y;
+	double start, end;
 	mline_t ml;
 	double minlen, extx, exty;
 	double minx, miny;
@@ -1909,14 +1908,17 @@ void DAutomap::drawGrid (int color)
 	miny = m_y;
 
 	// Figure out start of vertical gridlines
-	start = minx - extx;
+	start = (minx - extx);
 	start = ceil((start - bmaporgx) / FBlockmap::MAPBLOCKUNITS) * FBlockmap::MAPBLOCKUNITS + bmaporgx;
 
 	end = minx + minlen - extx;
 
 	// draw vertical gridlines
-	for (x = start; x < end; x += FBlockmap::MAPBLOCKUNITS)
+	uint16_t xLineCount = ceil(abs(end - start) /(double)FBlockmap::MAPBLOCKUNITS );
+	x = start;
+	for (uint16_t i = 0; i < xLineCount; ++i)
 	{
+		x += FBlockmap::MAPBLOCKUNITS;
 		ml.a.x = x;
 		ml.b.x = x;
 		ml.a.y = miny - exty;
@@ -1933,10 +1935,13 @@ void DAutomap::drawGrid (int color)
 	start = miny - exty;
 	start = ceil((start - bmaporgy) / FBlockmap::MAPBLOCKUNITS) * FBlockmap::MAPBLOCKUNITS + bmaporgy;
 	end = miny + minlen - exty;
-
+	
 	// draw horizontal gridlines
-	for (y=start; y<end; y+=FBlockmap::MAPBLOCKUNITS)
+	uint16_t yLineCount = ceil(abs(end - start) / (double)FBlockmap::MAPBLOCKUNITS);
+	y = start;
+	for (uint16_t i = 0; i < yLineCount; ++i)
 	{
+		y += FBlockmap::MAPBLOCKUNITS;
 		ml.a.x = minx - extx;
 		ml.b.x = ml.a.x + minlen;
 		ml.a.y = y;

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -950,72 +950,72 @@ class DAutomap :public DAutomapBase
 	//FLevelLocals *Level;
 	// scale on entry
 	// used by MTOF to scale from map-to-frame-buffer coords
-	double scale_mtof = .2;
+	double scale_mtof;
 	// used by FTOM to scale from frame-buffer-to-map coords (=1/scale_mtof)
-	double scale_ftom = 1.0/scale_mtof;
+	double scale_ftom;
 
-	bool bigstate = false;
-	int MapPortalGroup = 0;
+	bool bigstate;
+	int MapPortalGroup;
 
 	// Disable the ML_DONTDRAW line flag if x% of all lines in a map are flagged with it
 	// (To counter annoying mappers who think they are smart by making the automap unusable)
-	bool am_showallenabled = false;
+	bool am_showallenabled;
 
 	// location of window on screen
-	int f_x = 0;
-	int f_y = 0;
+	int f_x;
+	int f_y;
 
 	// size of window on screen
-	int f_w = 0;
-	int f_h = 0;
+	int f_w;
+	int f_h;
 
-	int amclock = 0;
+	int amclock;
 
-	mpoint_t m_paninc = { 0.0, 0.0 }; // how far the window pans each tic (map coords)
-	double mtof_zoommul = 0.0; // how far the window zooms in each tic (map coords)
+	mpoint_t m_paninc; // how far the window pans each tic (map coords)
+	double mtof_zoommul; // how far the window zooms in each tic (map coords)
 
-	double m_x = 0.0;
-	double m_y = 0.0; // LL x,y where the window is on the map (map coords)
-	double m_x2 = 0.0;
-	double m_y2 = 0.0; // UR x,y where the window is on the map (map coords)
+	double m_x;
+	double m_y; // LL x,y where the window is on the map (map coords)
+	double m_x2;
+	double m_y2; // UR x,y where the window is on the map (map coords)
 
 	//
 	// width/height of window on map (map coords)
 	//
-	double m_w = 0.0;
-	double m_h = 0.0;
+	double m_w;
+	double m_h;
 
 	// based on level size
-	double min_x = 0.0, min_y = 0.0, max_x = 0.0, max_y = 0.0;
+	double min_x, min_y, max_x, max_y;
 
-	double max_w = 0.0; // max_x-min_x,
-	double max_h = 0.0; // max_y-min_y
+	double max_w; // max_x-min_x,
+	double max_h; // max_y-min_y
 
 	// based on player size
-	double min_w = 0.0;
-	double min_h = 0.0;
+	double min_w;
+	double min_h;
 
 
-	double min_scale_mtof = 0.0; // used to tell when to stop zooming out
-	double max_scale_mtof = 0.0; // used to tell when to stop zooming in
+	double min_scale_mtof; // used to tell when to stop zooming out
+	double max_scale_mtof; // used to tell when to stop zooming in
 
 	// old stuff for recovery later
-	double old_m_w = 0.0, old_m_h = 0.0;
-	double old_m_x = 0.0, old_m_y = 0.0;
+	double old_m_w, old_m_h;
+	double old_m_x, old_m_y;
 
 	// old location used by the Follower routine
-	mpoint_t f_oldloc = { 0.0, 0.0 };
+	mpoint_t f_oldloc;
 
-	std::array<mpoint_t, AutoMap::Defaults::num_mark_points> markpoints = {}; // where the points are
-	int markpointnum = 0; // next point to be assigned
+	std::array<mpoint_t, AutoMap::Defaults::num_mark_points> markpoints; // where the points are
+	int markpointnum; // next point to be assigned
 
-	FTextureID mapback = nullptr; // the automap background
-	double mapystart = 0; // y-value for the start of the map bitmap...used in the parallax stuff.
-	double mapxstart = 0; //x-value for the bitmap.
+	FTextureID mapback; // the automap background
+	double mapystart; // y-value for the start of the map bitmap...used in the parallax stuff.
+	double mapxstart; //x-value for the bitmap.
 
 	TArray<FVector2> points;
 
-	int line_thickness_scaled = 1; // line thickness scaled to resolution
+	int line_thickness_scaled; // line thickness scaled to resolution
 
 	// translates between frame-buffer and map distances
 	double FTOM(double x)

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -32,7 +32,7 @@ class DAutomapBase : public DObject
 {
 	DECLARE_ABSTRACT_CLASS(DAutomapBase, DObject);
 public:
-	FLevelLocals *Level;	// temporary location so that it can be set from the outside.
+	FLevelLocals* Level = nullptr;	// temporary location so that it can be set from the outside.
 
 	// Called by main loop.
 	virtual bool Responder(event_t* ev, bool last) = 0;

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -32,7 +32,7 @@ class DAutomapBase : public DObject
 {
 	DECLARE_ABSTRACT_CLASS(DAutomapBase, DObject);
 public:
-	FLevelLocals* Level = nullptr;	// temporary location so that it can be set from the outside.
+	FLevelLocals* Level;	// temporary location so that it can be set from the outside.
 
 	// Called by main loop.
 	virtual bool Responder(event_t* ev, bool last) = 0;

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -30,7 +30,7 @@ class DAutomapBase : public DObject
 {
 	DECLARE_ABSTRACT_CLASS(DAutomapBase, DObject);
 public:
-	FLevelLocals *Level;	// temporary location so that it can be set from the outside.
+	FLevelLocals* Level = nullptr;	// temporary location so that it can be set from the outside.
 
 	// Called by main loop.
 	virtual bool Responder(event_t* ev, bool last) = 0;

--- a/src/am_map.h
+++ b/src/am_map.h
@@ -30,7 +30,7 @@ class DAutomapBase : public DObject
 {
 	DECLARE_ABSTRACT_CLASS(DAutomapBase, DObject);
 public:
-	FLevelLocals* Level = nullptr;	// temporary location so that it can be set from the outside.
+	FLevelLocals* Level;	// temporary location so that it can be set from the outside.
 
 	// Called by main loop.
 	virtual bool Responder(event_t* ev, bool last) = 0;

--- a/src/gamedata/p_blockmap.h
+++ b/src/gamedata/p_blockmap.h
@@ -43,7 +43,7 @@ struct FBlockmap
 
 	// mapblocks are used to check movement
 	// against lines and things
-	static constexpr int MAPBLOCKUNITS = 128;
+	static constexpr uint32_t MAPBLOCKUNITS = 128;
 
 	inline int GetBlockX(double xpos)
 	{

--- a/src/gamedata/p_blockmap.h
+++ b/src/gamedata/p_blockmap.h
@@ -66,7 +66,7 @@ struct FBlockmap
 
 	// mapblocks are used to check movement
 	// against lines and things
-	static constexpr int MAPBLOCKUNITS = 128;
+	static constexpr uint32_t MAPBLOCKUNITS = 128;
 
 	inline int GetBlockX(double xpos)
 	{


### PR DESCRIPTION
-constexpr where relevant
-using std::array
-initializing uninitialized variables
-addressing using double as loop counter (static analysis believes this is a security issue)
-bool instead of ints-pretending-to-be-bools
-fixed a potential divide by zero (parens were coercing a comparison into a bool and then dividing by it)
-moved default values (including the default game color tables) into const statics.
-Removed arcane per-element assignment behavior to initialize the default game color tables, and just have an array of static AMColors.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.