### PR TITLE
Fix CI perms for the trigger_pages workflow

### DIFF
--- a/.github/workflows/trigger_pages.yml
+++ b/.github/workflows/trigger_pages.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - '**'
 
+permissions:
+  actions: write
+
 jobs:
   trigger_pages:
     # i assume that random UZDoom forks probably don't want pages made for them by default


### PR DESCRIPTION
This fixes a bug with the new Actions stuff I didn't notice because GitHub defaulted to my fork being more permissive - tested on my fork