### PR TITLE
Add documentation comments

### DIFF
--- a/wadsrc/static/docs/Array.toml
+++ b/wadsrc/static/docs/Array.toml
@@ -1,0 +1,105 @@
+name = "Array"
+doc = """
+The built-in dynamic-size array type. Written as `Array<T>`.
+"""
+
+[[function]]
+def = """
+    /// Returns the number of elements in the array.
+    int Size() const;
+"""
+
+[[function]]
+def = """
+    /// Copies all of the elements of `other` into this array, doing
+    /// nothing to the original array.
+    void Copy(Array<T> other);
+"""
+
+[[function]]
+def = """
+    /// Moves all of the elements of `other` into this array, emptying
+    /// the original array completely.
+    void Move(Array<T> other);
+"""
+
+[[function]]
+def = """
+    /// Appends the elements of `other` to this array, copying them.
+    void Append(Array<T> other);
+"""
+
+[[function]]
+def = """
+    /// Returns the index of the first element matching `item`, or
+    /// [`Size`] if no matches are found.
+    int Find(T item) const;
+"""
+
+[[function]]
+def = """
+    /// Inserts an element at the end of the array, returning the
+    /// index of the new item.
+    int Push(T item);
+"""
+
+[[function]]
+def = """
+    /// Removes the last element in the array. Returns `false` if
+    /// nothing was removed.
+    bool Pop();
+"""
+
+[[function]]
+def = """
+    /// Deletes `deletecount` elements at `index`, moving elements
+    /// back if necessary.
+    void Delete(uint index, int deletecount = 1);
+"""
+
+[[function]]
+def = """
+    /// Inserts an element at `index`. If `index` is beyond the bounds
+    /// of the array, it will initialize the leading elements to their
+    /// null value.
+    void Insert(uint index, T item);
+"""
+
+[[function]]
+def = """
+    /// Shrinks the internal array to the [`Size`] of the array.
+    void ShrinkToFit();
+"""
+
+[[function]]
+def = """
+    /// Grows the internal array's capacity so that it can fit at least
+    /// `amount` more elements.
+    void Grow(uint amount);
+"""
+
+[[function]]
+def = """
+    /// Resizes the array to `amount`, potentially removing or
+    /// initializing elements.
+    void Resize(uint amount);
+"""
+
+[[function]]
+def = """
+    /// Grows the array by exactly `amount` more elements and returns
+    /// the first new index.
+    int Reserve(uint amount);
+"""
+
+[[function]]
+def = """
+    /// Returns the size of the internal array.
+    int Max() const;
+"""
+
+[[function]]
+def = """
+    /// Removes all elements in the array.
+    void Clear();
+"""

--- a/wadsrc/static/docs/Color.toml
+++ b/wadsrc/static/docs/Color.toml
@@ -1,6 +1,6 @@
 name = "Color"
 doc = """
-A builtin type representing a color.
+A built-in type representing a color.
 """
 
 [[member]]

--- a/wadsrc/static/docs/Color.toml
+++ b/wadsrc/static/docs/Color.toml
@@ -1,0 +1,28 @@
+name = "Color"
+doc = """
+A builtin type representing a color.
+"""
+
+[[member]]
+def = """
+    /// The red component. 0-255, inclusive.
+    uint r;
+"""
+
+[[member]]
+def = """
+    /// The green component. 0-255, inclusive.
+    uint g;
+"""
+
+[[member]]
+def = """
+    /// The blue component. 0-255, inclusive.
+    uint b;
+"""
+
+[[member]]
+def = """
+    /// The alpha component. 0-255, inclusive.
+    uint a;
+"""

--- a/wadsrc/static/docs/FixedArray.toml
+++ b/wadsrc/static/docs/FixedArray.toml
@@ -1,0 +1,11 @@
+name = "FixedArray"
+doc = """
+The built-in fixed-size array type. Written as `T[N]`.
+"""
+
+[[function]]
+def = """
+    /// Returns the number of elements in the array. Will always be
+    /// the same value, so this counts as a compile-time constant.
+    int Size() const;
+"""

--- a/wadsrc/static/docs/String.toml
+++ b/wadsrc/static/docs/String.toml
@@ -6,5 +6,6 @@ The built-in string type.
 
 [[function]]
 def = """
+    /// Returns the number of bytes in this string.
     uint Length();
 """

--- a/wadsrc/static/docs/TextureID.toml
+++ b/wadsrc/static/docs/TextureID.toml
@@ -1,0 +1,39 @@
+name = "TextureID"
+doc = """
+A built-in type representing a texture's internal identifier.
+
+Texture IDs can be explicitly converted to integers, but not the other
+way around. You can add and subtract integers with a Texture ID,
+however. (This only works with the integer on the right hand side.)
+"""
+
+[[function]]
+def = """
+    /// Checks if the texture exists within the texture manager at
+    /// all.
+    bool Exists() const;
+"""
+
+[[function]]
+def = """
+    /// Checks if the texture is the null index 0.
+    bool IsNull() const;
+"""
+
+[[function]]
+def = """
+    /// Checks if the texture is not the invalid index -1.
+    bool IsValid() const;
+"""
+
+[[function]]
+def = """
+    /// Sets the texture index to the null index 0.
+    bool SetNull();
+"""
+
+[[function]]
+def = """
+    /// Sets the texture index to the invalid index -1.
+    bool SetInvalid();
+"""

--- a/wadsrc/static/docs/Vector2.toml
+++ b/wadsrc/static/docs/Vector2.toml
@@ -1,6 +1,6 @@
 name = "Vector2"
 doc = """
-A builtin type representing 2D coordinates, either as a point or as a vector.
+A built-in type representing 2D coordinates, either as a point or as a vector.
 """
 
 [[member]]

--- a/wadsrc/static/docs/Vector2.toml
+++ b/wadsrc/static/docs/Vector2.toml
@@ -5,12 +5,25 @@ A built-in type representing 2D coordinates, either as a point or as a vector.
 
 [[member]]
 def = """
-    /// The x coordinate.
+    /// The X coordinate.
     double x;
 """
 
 [[member]]
 def = """
-    /// The y coordinate.
+    /// The Y coordinate.
     double y;
+"""
+
+[[function]]
+def = """
+    /// Returns the length (magnitude) of the vector.
+    double Length() const;
+"""
+
+[[function]]
+def = """
+    /// Returns a normalized vector. Equivalent to `vec /
+    /// vec.Length()`.
+    Vector2 Unit() const;
 """

--- a/wadsrc/static/docs/Vector3.toml
+++ b/wadsrc/static/docs/Vector3.toml
@@ -5,27 +5,40 @@ A built-in type representing 3D coordinates, either as a point or as a vector.
 
 [[member]]
 def = """
-    /// The x coordinate.
+    /// The X coordinate.
     double x;
 """
 
 [[member]]
 def = """
-    /// The y coordinate.
+    /// The Y coordinate.
     double y;
 """
 
 [[member]]
 def = """
-    /// The z coordinate.
+    /// The Z coordinate.
     double z;
 """
 
 [[member]]
 def = """
-    /// The x and y coordinates as a [`Vector2`].
+    /// The X and Y coordinates as a [`Vector2`].
     ///
-    /// This is not a unique piece of data and "overlaps" with [`x`] and [`y`]. Modifying this will
-    /// modify them.
+    /// This is not a unique piece of data and "overlaps" with [`x`]
+    /// and [`y`]. Modifying this will modify them.
     transient Vector2 xy;
+"""
+
+[[function]]
+def = """
+    /// Returns the length (magnitude) of the vector.
+    double Length() const;
+"""
+
+[[function]]
+def = """
+    /// Returns a normalized vector. Equivalent to `vec /
+    /// vec.Length()`.
+    Vector3 Unit() const;
 """

--- a/wadsrc/static/docs/Vector3.toml
+++ b/wadsrc/static/docs/Vector3.toml
@@ -1,6 +1,6 @@
 name = "Vector3"
 doc = """
-A builtin type representing 3D coordinates, either as a point or as a vector.
+A built-in type representing 3D coordinates, either as a point or as a vector.
 """
 
 [[member]]
@@ -24,7 +24,7 @@ def = """
 [[member]]
 def = """
     /// The x and y coordinates as a [`Vector2`].
-    /// 
+    ///
     /// This is not a unique piece of data and "overlaps" with [`x`] and [`y`]. Modifying this will
     /// modify them.
     transient Vector2 xy;

--- a/wadsrc/static/docs/double.toml
+++ b/wadsrc/static/docs/double.toml
@@ -1,6 +1,6 @@
 name = "double"
 doc = """
-The 64-bit floating point builtin type.
+The 64-bit floating point built-in type.
 
 This type can represent decimal values such as `0.5` as opposed to `int` and `uint` which are
 limited to whole numbers.

--- a/wadsrc/static/docs/double.toml
+++ b/wadsrc/static/docs/double.toml
@@ -2,6 +2,85 @@ name = "double"
 doc = """
 The 64-bit floating point built-in type.
 
-This type can represent decimal values such as `0.5` as opposed to `int` and `uint` which are
-limited to whole numbers.
+This type can represent decimal values such as `0.5` as opposed to
+`int` and `uint` which are limited to whole numbers.
+"""
+
+[[constant]]
+def = """
+    /// The lowest value representable by the type.
+    const MIN_NORMAL = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The lowest positive subnormal value of the type.
+    const MIN_DENORMAL = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The highest (non-infinity) value representable by the type.
+    const MAX = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The smallest positive value representable by the type.
+    const EPSILON = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The Not-a-Number value of the type.
+    const NAN = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The infinity value of the type.
+    const INFINITY = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The number of decimal digits guaranteed to be preserved when
+    /// converting between text to this type and back.
+    const DIG = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The minimum negative base 2 exponent that produces a normal
+    /// float.
+    const MIN_EXP = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The maximum positive base-2 exponent that produces a normal
+    /// float.
+    const MAX_EXP = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The number of bits representing the *mantissa* portion of the
+    /// float, i.e. the number of bits that can be represented without
+    /// precision loss.
+    const MANT_DIG = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The minimum negative base-10 exponent that produces a normal
+    /// float.
+    const MIN_10_EXP = 0.0;
+"""
+
+[[constant]]
+def = """
+    /// The maximum positive base-10 exponent that produces a normal
+    /// float.
+    const MAX_10_EXP = 0.0;
 """

--- a/wadsrc/static/docs/int.toml
+++ b/wadsrc/static/docs/int.toml
@@ -1,6 +1,6 @@
 name = "int"
 doc = """
-The 32-bit signed integer builtin type.
+The 32-bit signed integer built-in type.
 
 This type can represent every integer in the range `-2147483648` to `2147483647`.
 """

--- a/wadsrc/static/docs/uint.toml
+++ b/wadsrc/static/docs/uint.toml
@@ -1,6 +1,6 @@
 name = "uint"
 doc = """
-The 32-bit unsigned integer builtin type.
+The 32-bit unsigned integer built-in type.
 
 This type can represent every integer in the range `0` to `4294967295`.
 """

--- a/wadsrc/static/docs/zscdoc.toml
+++ b/wadsrc/static/docs/zscdoc.toml
@@ -4,6 +4,7 @@ builtins = [
     "int.toml", "uint.toml",
     "bool.toml",
     "double.toml",
+    "FixedArray.toml",
     "Array.toml",
     "Vector2.toml", "Vector3.toml",
     "String.toml", "Name.toml",

--- a/wadsrc/static/docs/zscdoc.toml
+++ b/wadsrc/static/docs/zscdoc.toml
@@ -4,6 +4,7 @@ builtins = [
     "int.toml", "uint.toml",
     "bool.toml",
     "double.toml",
+    "Array.toml",
     "Vector2.toml", "Vector3.toml",
     "String.toml", "Name.toml",
     "Color.toml",

--- a/wadsrc/static/docs/zscdoc.toml
+++ b/wadsrc/static/docs/zscdoc.toml
@@ -6,5 +6,6 @@ builtins = [
     "double.toml",
     "Vector2.toml", "Vector3.toml",
     "String.toml", "Name.toml",
+    "Color.toml",
 ]
 document_globals = true

--- a/wadsrc/static/docs/zscdoc.toml
+++ b/wadsrc/static/docs/zscdoc.toml
@@ -9,5 +9,6 @@ builtins = [
     "Vector2.toml", "Vector3.toml",
     "String.toml", "Name.toml",
     "Color.toml",
+    "TextureID.toml",
 ]
 document_globals = true

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -941,9 +941,14 @@ struct Wads	// todo: make FileSystem an alias to 'Wads'
 	native static string GetLumpFullPath(int lump);
 }
 
+/// Identifies whether to keep or skip empty tokens.
+///
+/// Used by [`String.Split`].
 enum EmptyTokenType
 {
+	/// Skips empty tokens.
 	TOK_SKIPEMPTY = 0,
+	/// Keeps empty tokens.
 	TOK_KEEPEMPTY = 1,
 }
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -970,8 +970,8 @@ struct StringStruct native unsafe(internal)
 	native void Truncate(int newlen);
 	/// Removes `remlen` bytes starting at `index` in-place.
 	native void Remove(int index, int remlen);
-	/// Returns the byte at `pos` as a new string. Use [`ByteAt`],
-	/// [`Left`], or [`Mid`] instead.
+	/// Returns the byte at `pos` as a new string. Use [`Left`] or
+	/// [`Mid`] instead.
 	deprecated("4.1", "use Left() or Mid() instead") native String CharAt(int pos) const;
 	/// Deprecated alias of [`ByteAt`]. Use it instead.
 	deprecated("4.1", "use ByteAt() instead") native int CharCodeAt(int pos) const;

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -951,51 +951,112 @@ enum EmptyTokenType
 // All of these methods are available on strings
 struct StringStruct native unsafe(internal)
 {
+	/// Creates a string using a format string and any amount of arguments.
 	native static vararg String Format(String fmt, ...);
+	/// Creates and appends a string using a format string and any
+	/// amount of arguments.
 	native vararg void AppendFormat(String fmt, ...);
 	// native int Length();  // Intrinsic
 	// native bool operator==(String other); // Equality comparison
 	// native bool operator~==(String other);  // Case-insensitive equality comparison
 	// native String operator..(String other);  // Concatenate with another String
+	/// Replaces all instances of `pattern` with `replacement` in-place.
 	native void Replace(String pattern, String replacement);
+	/// Returns the first `len` bytes as a new string.
 	native String Left(int len) const;
+	/// Returns `len` bytes starting at `pos` as a new string.
 	native String Mid(int pos = 0, int len = 2147483647) const;
+	/// Truncates the string to `newlen` bytes in-place.
 	native void Truncate(int newlen);
+	/// Removes `remlen` bytes starting at `index` in-place.
 	native void Remove(int index, int remlen);
+	/// Returns the byte at `pos` as a new string. Use [`ByteAt`],
+	/// [`Left`], or [`Mid`] instead.
 	deprecated("4.1", "use Left() or Mid() instead") native String CharAt(int pos) const;
+	/// Deprecated alias of [`ByteAt`]. Use it instead.
 	deprecated("4.1", "use ByteAt() instead") native int CharCodeAt(int pos) const;
+	/// Returns the byte at `pos` as an integer.
 	native int ByteAt(int pos) const;
+	/// Returns a new string which replaces escape sequences with
+	/// their respective escaped characters.
 	native String Filter();
+	/// Returns the first index of `substr` starting from the left at
+	/// `startIndex`.
 	native int IndexOf(String substr, int startIndex = 0) const;
 	deprecated("3.5.1", "use RightIndexOf() instead") native int LastIndexOf(String substr, int endIndex = 2147483647) const;
+	/// Returns the first index of `substr` starting from the right at
+	/// `endIndex`.
 	native int RightIndexOf(String substr, int endIndex = 2147483647) const;
+	/// Makes all bytes uppercase in-place. Does not account for
+	/// codepoints. Use [`MakeUpper`] instead.
 	deprecated("4.1", "use MakeUpper() instead") native void ToUpper();
+	/// Makes all bytes lowercase in-place. Does not account for
+	/// codepoints. Use [`MakeLower`] instead.
 	deprecated("4.1", "use MakeLower() instead") native void ToLower();
+	/// Returns a new string where all codepoints are uppercase.
 	native String MakeUpper() const;
+	/// Returns a new string where all codepoints are lowercase.
 	native String MakeLower() const;
+	/// Returns the uppercase version of `ch`.
 	native static int CharUpper(int ch);
+	/// Returns the lowercase version of `ch`.
 	native static int CharLower(int ch);
 
+	/// Returns `true` if the string matches the pattern `[whitespace]
+	/// [sign] [0 [{ x | X }]] digits [whitespace]`.
 	native bool IsInt() const;
+	/// Returns `true` if the string matches the pattern `[whitespace]
+	/// [sign] {digits | [digits] . digits} [{d | D | e | E} [sign] digits]
+	/// [whitespace]`.
 	native bool IsDouble() const;
+	/// Interprets the string as a base-`base` integer, guessing the
+	/// base if it is 0.
 	native int ToInt(int base = 0) const;
+	/// Interprets the string as a double precision floating point
+	/// number.
 	native double ToDouble() const;
 
+	/// Splits the string by each `delimiter` into `tokens`.
+	/// `keepEmpty` describes whether the function should keep or
+	/// discard empty strings found while splitting.
 	native void Split(out Array<String> tokens, String delimiter, EmptyTokenType keepEmpty = TOK_KEEPEMPTY) const;
+	/// Appends the codepoint `c` to the end of the string in-place.
 	native void AppendCharacter(int c);
+	/// Removes the last codepoint of the string in-place.
 	native void DeleteLastCharacter();
+	/// Returns the number of codepoints in this string.
 	native int CodePointCount() const;
+	/// Returns the next codepoint from the byte `position` onwards, and the
+	/// byte position of the next codepoint.
 	native int, int GetNextCodePoint(int position) const;
+	/// Alias for [`Replace`].
 	native void Substitute(String str, String replace);
+	/// Strips any byte in `junk` from the left side of the string
+	/// in-place. If `junk` is empty, strips any ASCII whitespace
+	/// character.
 	native void StripLeft(String junk = "");
+	/// Strips any byte in `junk` from the right side of the string
+	/// in-place. If `junk` is empty, strips any ASCII whitespace
+	/// character.
 	native void StripRight(String junk = "");
+	/// Strips any byte in `junk` from the left and right sides of the
+	/// string in-place. If `junk` is empty, strips any ASCII
+	/// whitespace character.
 	native void StripLeftRight(String junk = "");
 
-	native int Compare(String other) const; // strcmp
-	native int CompareNoCase(String other) const; // stricmp
+	/// Compares this string with `other`. Returns lexicographic order,
+	/// i.e. zero for no difference, negative for if this is before
+	/// `other`, positive if it is after.
+	native int Compare(String other) const;
+	/// Compares this string with `other`, ignoring case. Returns
+	/// lexicographic order, i.e. zero for no difference, negative for
+	/// if this is before `other`, positive if it is after.
+	native int CompareNoCase(String other) const;
 
-	native bool IsEmpty() const; // strcmp
-	native bool IsNotEmpty() const; // stricmp
+	/// Returns `true` if [`Length`] is 0.
+	native bool IsEmpty() const;
+	/// Returns `true` if [`Length`] is not 0.
+	native bool IsNotEmpty() const;
 }
 
 struct Translation version("2.4")


### PR DESCRIPTION
Currently only using the documentation available in my ZDoom Docs project, and new documentation by myself, will incorporate wiki items later when we have permission from enough people.

Very early stages right now, only String is commented. Will note when this is more ready to merge.

Tested locally with current zscdoc.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.