### PR TITLE
- demote error to warning for `discordappid` and `steamappid`

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -4086,25 +4086,37 @@ static int D_DoomMain_Internal (void)
 		if (GameStartupInfo.DiscordAppId.GetChars())
 		{
 			const char* check = GameStartupInfo.DiscordAppId.GetChars();
-			uint32_t addr = 0;
-			while (check[addr])
+			uint32_t index = 0;
+			bool failedcheck = false;
+			while (!failedcheck && check[index])
 			{
-				if (check[addr] < '0' || check[addr] > '9')
-					I_FatalError("DiscordAppId must be a numerical value!\n");
-				addr++;
+				if (check[index] < '0' || check[index] > '9')
+				{
+					Printf(TEXTCOLOR_RED "DiscordAppId must be a numerical value!\n");
+					failedcheck = true;
+				}
+				index++;
 			}
+			if (failedcheck)
+				GameStartupInfo.DiscordAppId = '\0';
 		}
 
 		if (GameStartupInfo.SteamAppId.GetChars())
 		{
 			const char* check = GameStartupInfo.SteamAppId.GetChars();
-			uint32_t addr = 0;
-			while (check[addr])
+			uint32_t index = 0;
+			bool failedcheck = false;
+			while (!failedcheck && check[index])
 			{
-				if (check[addr] < '0' || check[addr] > '9')
-					I_FatalError("SteamAppId must be a numerical value!\n");
-				addr++;
+				if (check[index] < '0' || check[index] > '9')
+				{
+					Printf(TEXTCOLOR_RED "SteamAppId must be a numerical value!\n");
+					failedcheck = true;
+				}
+				index++;
 			}
+			if (failedcheck)
+				GameStartupInfo.SteamAppId = '\0';
 		}
 
 		int ret = D_InitGame(iwad_info, allwads, pwads);


### PR DESCRIPTION
<img width="3484" height="411" alt="image" src="https://github.com/user-attachments/assets/875988fb-c516-48ca-953c-34fe2ac97242" />
Unfortunately it's buried at the top of the console log, but it's there.