### PR TITLE
Fixed incorrect stat velocity reading

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -714,6 +714,7 @@ public:
 	int			total_monsters;
 	int			killed_monsters;
 
+	double		cur_velocity;
 	double      max_velocity;
 	double      avg_velocity;
 

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -714,9 +714,34 @@ public:
 	int			total_monsters;
 	int			killed_monsters;
 
-	double		cur_velocity;
-	double      max_velocity;
-	double      avg_velocity;
+	struct VelocityMeasurer {
+		int total = 0;
+		double cur_velocity = 0.0;
+		double max_velocity = 0.0;
+		double avg_velocity = 0.0;
+
+		void SetVelocity(double spd)
+		{
+			cur_velocity = spd;
+			if (spd > max_velocity)
+				max_velocity = spd;
+			avg_velocity += (spd - avg_velocity) / ++total;
+		}
+
+		void Clear()
+		{
+			total = 0;
+			cur_velocity = max_velocity = avg_velocity = 0.0;
+		}
+	};
+
+	VelocityMeasurer velocities[MAXPLAYERS] = {};
+
+	void ClearVelocities()
+	{
+		for (auto& vel : velocities)
+			vel.Clear();
+	}
 
 	double		gravity;
 	double		aircontrol;

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -619,8 +619,9 @@ ADD_STAT(velocity)
 {
 	FString compose;
 	if (players[consoleplayer].mo != NULL && gamestate == GS_LEVEL) {
-		compose.AppendFormat("Current velocity: %.2f\n", players[consoleplayer].mo->Vel.Length());
-		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", primaryLevel->MapName.GetChars(), primaryLevel->max_velocity, primaryLevel->avg_velocity);
+		auto level = players[consoleplayer].mo->Level;
+		compose.AppendFormat("Current velocity: %.2f\n", level->cur_velocity);
+		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", level->MapName.GetChars(), level->max_velocity, level->avg_velocity);
 	}
 	return compose;
 }

--- a/src/gamedata/statistics.cpp
+++ b/src/gamedata/statistics.cpp
@@ -618,10 +618,14 @@ ADD_STAT(statistics)
 ADD_STAT(velocity)
 {
 	FString compose;
-	if (players[consoleplayer].mo != NULL && gamestate == GS_LEVEL) {
-		auto level = players[consoleplayer].mo->Level;
-		compose.AppendFormat("Current velocity: %.2f\n", level->cur_velocity);
-		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", level->MapName.GetChars(), level->max_velocity, level->avg_velocity);
+	auto cam = players[consoleplayer].camera;
+	if (cam == nullptr || cam->player == nullptr)
+		cam = players[consoleplayer].mo;
+	if (cam != nullptr && gamestate == GS_LEVEL) {
+		auto level = cam->Level;
+		const auto& vel = level->velocities[cam->player - players];
+		compose.AppendFormat("Current velocity: %.2f\n", vel.cur_velocity);
+		compose.AppendFormat("Level %s - Velocity Max: %.2f, Velocity Average: %.2f\n", level->MapName.GetChars(), vel.max_velocity, vel.avg_velocity);
 	}
 	return compose;
 }

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -306,7 +306,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	total_monsters = total_items = total_secrets =
 	killed_monsters = found_items = found_secrets = 0;
 
-	max_velocity = avg_velocity = 0;
+	cur_velocity = max_velocity = avg_velocity = 0;
 
 	for (int i = 0; i < 4; i++)
 	{

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -306,7 +306,7 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	total_monsters = total_items = total_secrets =
 	killed_monsters = found_items = found_secrets = 0;
 
-	cur_velocity = max_velocity = avg_velocity = 0;
+	ClearVelocities();
 
 	for (int i = 0; i < 4; i++)
 	{

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -277,8 +277,4 @@ void P_Ticker (void)
 		Level->maptime++;
 		Level->totaltime++;
 	}
-	if (players[consoleplayer].mo != NULL) {
-		if (players[consoleplayer].mo->Vel.Length() > primaryLevel->max_velocity) { primaryLevel->max_velocity = players[consoleplayer].mo->Vel.Length(); }
-		primaryLevel->avg_velocity += (players[consoleplayer].mo->Vel.Length() - primaryLevel->avg_velocity) / primaryLevel->maptime;
-	}
 }

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1352,6 +1352,18 @@ void P_PlayerThink (player_t *player)
 		VMValue param = player->mo;
 		VMCall(func, &param, 1, nullptr, 0);
 	}
+
+	// Moved this to directly after player thinking to get more accurate velocity values. Also takes
+	// 3D vs 2D movement into account now.
+	if (!bPredictionGuard && player == &players[consoleplayer] && player->mo != nullptr)
+	{
+		double spd = (player->mo->flags & MF_NOGRAVITY) ? player->mo->Vel.Length() : player->mo->Vel.XY().Length();
+		auto level = player->mo->Level;
+		level->cur_velocity = spd;
+		if (spd > level->max_velocity)
+			level->max_velocity = spd;
+		level->avg_velocity += (spd - level->avg_velocity) / (level->maptime + 1);
+	}
 }
 
 void P_PredictionLerpReset()

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1355,14 +1355,10 @@ void P_PlayerThink (player_t *player)
 
 	// Moved this to directly after player thinking to get more accurate velocity values. Also takes
 	// 3D vs 2D movement into account now.
-	if (!bPredictionGuard && player == &players[consoleplayer] && player->mo != nullptr)
+	if (!bPredictionGuard && player->mo != nullptr)
 	{
 		double spd = (player->mo->flags & MF_NOGRAVITY) ? player->mo->Vel.Length() : player->mo->Vel.XY().Length();
-		auto level = player->mo->Level;
-		level->cur_velocity = spd;
-		if (spd > level->max_velocity)
-			level->max_velocity = spd;
-		level->avg_velocity += (spd - level->avg_velocity) / (level->maptime + 1);
+		player->mo->Level->velocities[player - players].SetVelocity(spd);
 	}
 }
 


### PR DESCRIPTION
Previously this read the player's velocity after friction, but now does so before. Also now takes 3D vs 2D movement into account. Also adds support for multiple players and will change the value based on which one is being viewed.

Fixes #151 