### PR TITLE
Add translucent canvas textures support

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -1715,7 +1715,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, Clear)
 
 void DoDim(F2DDrawer *drawer, PalEntry color, float amount, int x1, int y1, int w, int h, FRenderStyle *style)
 {
-	if (amount <= 0)
+	if (amount < 0 || (amount == 0.f && *style != LegacyRenderStyles[STYLE_Source]))
 	{
 		return;
 	}
@@ -1779,7 +1779,8 @@ DEFINE_ACTION_FUNCTION(FCanvas, Dim)
 	PARAM_INT(w);
 	PARAM_INT(h);
 	PARAM_INT(style);
-	Dim(&self->Drawer, color, float(amount), x1, y1, w, h, &LegacyRenderStyles[style]);
+	PARAM_BOOL(overwritealpha);
+	Dim(&self->Drawer, color, float(amount), x1, y1, w, h, &LegacyRenderStyles[overwritealpha ? STYLE_Source : style]);
 	self->Tex->NeedUpdate();
 	return 0;
 }

--- a/src/common/rendering/gl/gl_renderstate.cpp
+++ b/src/common/rendering/gl/gl_renderstate.cpp
@@ -313,7 +313,7 @@ void FGLRenderState::Apply()
 
 void FGLRenderState::ApplyMaterial(FMaterial *mat, int clampmode, int translation, int overrideshader)
 {
-	if (mat->Source()->isHardwareCanvas())
+	if (mat->Source()->isHardwareCanvas() && !mat->Source()->GetTranslucency())
 	{
 		mTempTM = TM_OPAQUE;
 	}

--- a/src/common/rendering/gles/gles_renderstate.cpp
+++ b/src/common/rendering/gles/gles_renderstate.cpp
@@ -439,7 +439,7 @@ void FGLRenderState::Apply()
 
 void FGLRenderState::ApplyMaterial(FMaterial *mat, int clampmode, int translation, int overrideshader)
 {
-	if (mat->Source()->isHardwareCanvas())
+	if (mat->Source()->isHardwareCanvas() && !mat->Source()->GetTranslucency())
 	{
 		mTempTM = TM_OPAQUE;
 	}

--- a/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
@@ -372,7 +372,7 @@ void VkRenderState::ApplyPushConstants()
 	}
 
 	int tempTM = TM_NORMAL;
-	if (mMaterial.mMaterial && mMaterial.mMaterial->Source()->isHardwareCanvas())
+	if (mMaterial.mMaterial && mMaterial.mMaterial->Source()->isHardwareCanvas() && !mMaterial.mMaterial->Source()->GetTranslucency())
 		tempTM = TM_OPAQUE;
 
 	mPushConstants.uFogEnabled = fogset;

--- a/src/common/textures/hw_material.cpp
+++ b/src/common/textures/hw_material.cpp
@@ -152,7 +152,6 @@ FMaterial::FMaterial(FGameTexture * tx, int scaleflags)
 
 	mTextureLayers.ShrinkToFit();
 	tx->Material[scaleflags] = this;
-	if (tx->isHardwareCanvas()) tx->SetTranslucent(false);
 }
 
 //===========================================================================

--- a/src/common/textures/textures.h
+++ b/src/common/textures/textures.h
@@ -322,6 +322,8 @@ public:
 
 		bHasCanvas = true;
 		aspectRatio = (float)width / height;
+
+		bTranslucent = false;
 	}
 
 	~FCanvasTexture()

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -787,6 +787,18 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 			sc.UnGet();
 		}
 	}
+	if (sc.GetString())
+	{
+		if (sc.Compare("translucent"))
+		{
+			viewer->SetTranslucent(true);
+		}
+		else
+		{
+			sc.UnGet();
+		}
+	}
+
 	canvas->aspectRatio = (float)fitwidth / (float)fitheight;
 	viewer->SetDisplaySize((float)fitwidth, (float)fitheight);
 }

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -550,7 +550,7 @@ class Shape2D : Object native
 class Canvas : Object native abstract
 {
 	native void Clear(int left, int top, int right, int bottom, Color color, int palcolor = -1);
-	native void Dim(Color col, double amount, int x, int y, int w, int h, ERenderStyle style = STYLE_Translucent);
+	native void Dim(Color col, double amount, int x, int y, int w, int h, ERenderStyle style = STYLE_Translucent, bool overwritealpha = false);
 
 	native vararg void DrawTexture(TextureID tex, bool animate, double x, double y, ...);
 	native vararg void DrawShape(TextureID tex, bool animate, Shape2D s, ...);


### PR DESCRIPTION
Adds support for translucent canvas textures.

[map01trans.zip](https://github.com/user-attachments/files/23151354/map01trans.zip)


Example file.

<img width="1522" height="857" alt="image" src="https://github.com/user-attachments/assets/ae7eebda-5c11-473b-bb61-bd65162503b2" />
