### PR TITLE
Removed net mode selection and set packet-server as the default

### DIFF
--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -70,7 +70,6 @@ CVAR(String, defaultnetargs, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, defaultnetplayers, 8, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, defaultnethostport, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, defaultnetticdup, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
-CVAR(Int, defaultnetmode, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, defaultnetgamemode, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, defaultnetaltdm, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(String, defaultnetaddress, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
@@ -134,7 +133,6 @@ FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs
 	DefaultNetPlayers = defaultnetplayers;
 	DefaultNetHostPort = defaultnethostport;
 	DefaultNetTicDup = defaultnetticdup;
-	DefaultNetMode = defaultnetmode;
 	DefaultNetGameMode = defaultnetgamemode;
 	DefaultNetAltDM = defaultnetaltdm;
 	DefaultNetHostTeam = defaultnethostteam;
@@ -178,7 +176,6 @@ int FStartupSelectionInfo::SaveInfo()
 			defaultnetplayers = DefaultNetPlayers;
 			defaultnethostport = DefaultNetHostPort;
 			defaultnetticdup = DefaultNetTicDup;
-			defaultnetmode = DefaultNetMode;
 			defaultnetgamemode = DefaultNetGameMode;
 			defaultnetaltdm = DefaultNetAltDM;
 			defaultnethostteam = DefaultNetHostTeam;

--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -94,7 +94,6 @@ struct FStartupSelectionInfo
 	int DefaultNetHostPort = 0;
 	int DefaultNetTicDup = 0;
 	bool DefaultNetExtraTic = false;
-	int DefaultNetMode = 0;
 	int DefaultNetGameMode = 0;
 	bool DefaultNetAltDM = false;
 

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -33,16 +33,10 @@ enum ENetFlags
 	NCMD_RETRANSMIT = 0x40,		// 
 	NCMD_SETUP = 0x20,		// Guest is letting the host know who it is
 	NCMD_LEVELREADY = 0x10,		// After loading a level, guests send this over to the host who then sends it back after all are received
-	NCMD_QUITTERS = 0x08,		// Client is getting info about one or more players quitting (packet server only)
+	NCMD_QUITTERS = 0x08,		// Client is getting info about one or more players quitting
 	NCMD_COMPRESSED = 0x04,		// Remainder of packet is compressed
 	NCMD_LATENCYACK = 0x02,		// A latency packet was just read, so let the sender know.
 	NCMD_LATENCY = 0x01,		// Latency packet, used for measuring RTT.		
-};
-
-enum ENetMode
-{
-	NET_PeerToPeer,
-	NET_PacketServer
 };
 
 struct FClientStack : public TArray<int>
@@ -65,7 +59,6 @@ extern bool netgame, multiplayer;
 extern int consoleplayer;
 extern int Net_Arbitrator;
 extern FClientStack NetworkClients;
-extern ENetMode NetMode;
 extern uint8_t NetBuffer[MAX_MSGLEN];
 extern size_t NetBufferLength;
 extern uint8_t TicDup;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -4098,7 +4098,7 @@ static int D_DoomMain_Internal (void)
 				index++;
 			}
 			if (failedcheck)
-				GameStartupInfo.DiscordAppId = '\0';
+				GameStartupInfo.DiscordAppId = "";
 		}
 
 		if (GameStartupInfo.SteamAppId.GetChars())
@@ -4116,7 +4116,7 @@ static int D_DoomMain_Internal (void)
 				index++;
 			}
 			if (failedcheck)
-				GameStartupInfo.SteamAppId = '\0';
+				GameStartupInfo.SteamAppId = "";
 		}
 
 		int ret = D_InitGame(iwad_info, allwads, pwads);

--- a/src/d_net.h
+++ b/src/d_net.h
@@ -47,7 +47,7 @@ enum EChatType
 enum EClientFlags
 {
 	CF_NONE = 0,
-	CF_QUIT = 1,		// If in packet server mode, this client sent an exit command and needs to be disconnected.
+	CF_QUIT = 1,		// If set, this client sent an exit command and needs to be disconnected.
 	CF_MISSING_SEQ = 1 << 1,	// If a sequence was missed/out of order, ask this client to send back over their info.
 	CF_RETRANSMIT_SEQ = 1 << 2,	// If set, this client needs command data resent to them.
 	CF_MISSING_CON = 1 << 3,	// If a consistency was missed/out of order, ask this client to send back over their info.
@@ -78,16 +78,16 @@ private:
 //  One byte for the net command flags.
 //  Four bytes for the last sequence we got from that client.
 //  Four bytes for the last consistency we got from that client.
-//  If NCMD_QUITTERS set, one byte for the number of players followed by one byte for each player's consolenum. Packet server mode only.
+//  If NCMD_QUITTERS set, one byte for the number of players followed by one byte for each player's consolenum.
 //  One byte for the number of players.
 //  One byte for the number of tics.
 //   If > 0, four bytes for the base sequence being worked from.
 //  One byte for the number of world tics ran.
 //   If > 0, four bytes for the base consistency being worked from.
-//  If in packet server mode and from the host, one byte for how far ahead of the host we are.
+//  If from the host, one byte for how far ahead of the host we are.
 //  For each player:
 //   One byte for the player number.
-//	 If in packet server mode and from the host, two bytes for the latency to the host.
+//	 If from the host, two bytes for the latency to the host.
 //   For each consistency:
 //    One byte for the delta from the base consistency.
 //    Two bytes for each consistency.
@@ -107,11 +107,11 @@ struct FClientNetState
 	bool		bNewLatency = true;			// If the sequence was bumped, the next latency packet sent out should record the send time.
 	uint16_t	AverageLatency = 0u;		// Calculate the average latency every second or so, that way it doesn't give huge variance in the scoreboard.
 	uint64_t	SentTime[MAXSENDTICS] = {};	// Timestamp for when we sent out the packet to this client.
-	uint64_t	RecvTime[MAXSENDTICS] = {};	// Timestamp for when the client acknowledged our last packet. If in packet server mode, this is the server's delta.
+	uint64_t	RecvTime[MAXSENDTICS] = {};	// Timestamp for when the client acknowledged our last packet.
 
 	int				Flags = 0;				// State of this client.
 
-	uint8_t			StabilityBuffer = 0u;	// If in packet-server mode, account for if the client is trying to stabilize when measuring their performance.
+	uint8_t			StabilityBuffer = 0u;	// Account for if the client is trying to stabilize when measuring their performance.
 	uint8_t			ResendID = 0u;			// Make sure that if the retransmit happened on a wait barrier, it can be properly resent back over.
 	int				ResendSequenceFrom = -1; // If >= 0, send from this sequence up to the most recent one, capped to MAXSENDTICS.
 	int				SequenceAck = -1;		// The last sequence the client reported from us.

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -1239,7 +1239,7 @@ double DBaseStatusBar::DrawConsistancy(double yOfs) const
 		{
 			desync = true;
 			// Fell out of sync with the host in packet server mode. Which specific user it is doesn't really matter.
-			if (NetMode == NET_PacketServer && consoleplayer != Net_Arbitrator)
+			if (consoleplayer != Net_Arbitrator)
 			{
 				text = "Out of sync with host";
 				break;
@@ -1280,7 +1280,7 @@ double DBaseStatusBar::DrawWaiting(double yOfs) const
 		if (players[client].waiting)
 		{
 			isWaiting = true;
-			if (NetMode == NET_PacketServer && consoleplayer != Net_Arbitrator)
+			if (consoleplayer != Net_Arbitrator)
 			{
 				text = "Waiting for host";
 				break;

--- a/src/launcher/networkpage.cpp
+++ b/src/launcher/networkpage.cpp
@@ -168,14 +168,6 @@ void NetworkPage::UpdateLanguage()
 
 HostSubPage::HostSubPage(NetworkPage* main, const FStartupSelectionInfo& info) : Widget(nullptr), MainTab(main)
 {
-	NetModesLabel = new TextLabel(this);
-	NetModesDropdown = new Dropdown(this);
-
-	NetModesDropdown->AddItem("Auto (recommended)");
-	NetModesDropdown->AddItem("Packet-Server");
-	NetModesDropdown->AddItem("Peer-to-Peer");
-	NetModesDropdown->SetSelectedItem(max<int>(info.DefaultNetMode, 0));
-
 	TicDupLabel = new TextLabel(this);
 	TicDupDropdown = new Dropdown(this);
 	ExtraTicCheckbox = new CheckboxLabel(this);
@@ -232,16 +224,6 @@ HostSubPage::HostSubPage(NetworkPage* main, const FStartupSelectionInfo& info) :
 void HostSubPage::SetValues(FStartupSelectionInfo& info) const
 {
 	info.AdditionalNetArgs = "";
-	info.DefaultNetMode = NetModesDropdown->GetSelectedItem();
-	switch (info.DefaultNetMode)
-	{
-	case 1:
-		info.AdditionalNetArgs.AppendFormat(" -netmode 1");
-		break;
-	case 2:
-		info.AdditionalNetArgs.AppendFormat(" -netmode 0");
-		break;
-	}
 
 	info.DefaultNetExtraTic = ExtraTicCheckbox->GetChecked();
 	if (info.DefaultNetExtraTic)
@@ -296,11 +278,6 @@ void HostSubPage::SetValues(FStartupSelectionInfo& info) const
 
 void HostSubPage::UpdateLanguage()
 {
-	NetModesLabel->SetText(GStrings.GetString("PICKER_NETMODE"));
-	NetModesDropdown->UpdateItem(GStrings.GetString("PICKER_NETAUTO"), 0);
-	NetModesDropdown->UpdateItem(GStrings.GetString("PICKER_NETSERVER"), 1);
-	NetModesDropdown->UpdateItem(GStrings.GetString("PICKER_NETPEER"), 2);
-
 	TicDupLabel->SetText(GStrings.GetString("PICKER_NETRATE"));
 	ExtraTicCheckbox->SetText(GStrings.GetString("PICKER_NETBACKUP"));
 
@@ -363,11 +340,6 @@ void HostSubPage::OnGeometryChanged()
 	y += TicDupLabel->GetPreferredHeight();
 	TicDupDropdown->SetFrameGeometry(w - DropdownSize, y, DropdownSize, TicDupDropdown->GetPreferredHeight());
 	y += TicDupDropdown->GetPreferredHeight() + 2.0;
-
-	NetModesLabel->SetFrameGeometry(w - DropdownSize, y, DropdownSize, NetModesLabel->GetPreferredHeight());
-	y += NetModesLabel->GetPreferredHeight();
-	NetModesDropdown->SetFrameGeometry(w - DropdownSize, y, DropdownSize, NetModesDropdown->GetPreferredHeight());
-	y += NetModesDropdown->GetPreferredHeight() + 2.0;
 
 	ExtraTicCheckbox->SetFrameGeometry(w - DropdownSize, y, DropdownSize, ExtraTicCheckbox->GetPreferredHeight());
 

--- a/src/launcher/networkpage.h
+++ b/src/launcher/networkpage.h
@@ -59,8 +59,6 @@ private:
 
 	NetworkPage* MainTab = nullptr;
 
-	TextLabel* NetModesLabel = nullptr;
-	Dropdown* NetModesDropdown = nullptr;
 	TextLabel* TicDupLabel = nullptr;
 	Dropdown* TicDupDropdown = nullptr;
 	CheckboxLabel* ExtraTicCheckbox = nullptr;


### PR DESCRIPTION
With the final engine desync being fixed in packet-server mode, peer-to-peer mode has little reason to be used and will be unable to support certain features in the future. As such, packet-server will now always be how net games are handled for better stability and a more expected experience alongside being easier to maintain overall.

Also, VisualStudio didn't like setting FString to `'\0'` so I changed it to an empty string literal.