### PR TITLE
Cleaned up client-side spawners and scoping

### DIFF
--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -1096,9 +1096,14 @@ DVisualThinker* DVisualThinker::NewVisualThinker(FLevelLocals* Level, PClass* ty
 	return zs;
 }
 
-static DVisualThinker* SpawnVisualThinker(FLevelLocals* Level, PClass* type, bool clientSide)
+static DVisualThinker* SpawnVisualThinker(FLevelLocals* Level, PClass* type)
 {
-	return DVisualThinker::NewVisualThinker(Level, type, clientSide);
+	return DVisualThinker::NewVisualThinker(Level, type, false);
+}
+
+static DVisualThinker* SpawnClientSideVisualThinker(FLevelLocals* Level, PClass* type)
+{
+	return DVisualThinker::NewVisualThinker(Level, type, true);
 }
 
 void DVisualThinker::UpdateSector(subsector_t * newSubsector)
@@ -1132,8 +1137,15 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, SpawnVisualThinker, SpawnVisualThink
 {
 	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
 	PARAM_CLASS_NOT_NULL(type, DVisualThinker);
-	PARAM_BOOL(clientSide);
-	DVisualThinker* zs = SpawnVisualThinker(self, type, clientSide);
+	DVisualThinker* zs = SpawnVisualThinker(self, type);
+	ACTION_RETURN_OBJECT(zs);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, SpawnClientSideVisualThinker, SpawnClientSideVisualThinker)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_CLASS_NOT_NULL(type, DVisualThinker);
+	DVisualThinker* zs = SpawnClientSideVisualThinker(self, type);
 	ACTION_RETURN_OBJECT(zs);
 }
 

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2673,7 +2673,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, setFrozen, setFrozen)
 	return 0;
 }
 
-static DThinker* CreateThinker(FLevelLocals* self, PClass* type, int statnum, bool clientSide)
+static DThinker* CreateThinker(FLevelLocals* self, PClass* type, int statnum)
 {
 	if (type->IsDescendantOf(NAME_Actor))
 	{
@@ -2686,7 +2686,7 @@ static DThinker* CreateThinker(FLevelLocals* self, PClass* type, int statnum, bo
 		return nullptr;
 	}
 
-	return clientSide ? self->CreateClientSideThinker(type, statnum) : self->CreateThinker(type, statnum);
+	return self->CreateThinker(type, statnum);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateThinker, CreateThinker)
@@ -2694,9 +2694,33 @@ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateThinker, CreateThinker)
 	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
 	PARAM_POINTER_NOT_NULL(type, PClass);
 	PARAM_INT(statnum);
-	PARAM_BOOL(clientSide);
 
-	ACTION_RETURN_OBJECT(CreateThinker(self, type, statnum, clientSide));
+	ACTION_RETURN_OBJECT(CreateThinker(self, type, statnum));
+}
+
+static DThinker* CreateClientSideThinker(FLevelLocals* self, PClass* type, int statnum)
+{
+	if (type->IsDescendantOf(NAME_Actor))
+	{
+		ThrowAbortException(X_OTHER, "Actors cannot be created from this function");
+		return nullptr;
+	}
+	else if (type->IsDescendantOf(NAME_VisualThinker))
+	{
+		ThrowAbortException(X_OTHER, "VisualThinkers cannot be created from this function");
+		return nullptr;
+	}
+
+	return self->CreateClientSideThinker(type, statnum);
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, CreateClientSideThinker, CreateClientSideThinker)
+{
+	PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	PARAM_POINTER_NOT_NULL(type, PClass);
+	PARAM_INT(statnum);
+
+	ACTION_RETURN_OBJECT(CreateClientSideThinker(self, type, statnum));
 }
 
 //=====================================================================================

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -582,7 +582,7 @@ struct LevelLocals native
 	native bool IsFreelookAllowed() const;
 	native void StartIntermission(Name type, int state) const;
 	native play SpotState GetSpotState(bool create = true);
-	native int FindUniqueTid(int start = 0, int limit = 0, bool clientSide = false);
+	native clearscope int FindUniqueTid(int start = 0, int limit = 0, bool clientSide = false);
 	native uint GetSkyboxPortal(Actor actor);
 	native void ReplaceTextures(String from, String to, int flags);
     clearscope native HealthGroup FindHealthGroup(int id);
@@ -623,10 +623,11 @@ struct LevelLocals native
 	native void SetThickFog(float distance, float multiplier);
 	native void ForceLightning(int mode = 0, sound tempSound = "");
 
-	native clearscope Thinker CreateThinker(class<Thinker> type, int statnum = Thinker.STAT_DEFAULT, bool clientSide = false);
-	native SectorTagIterator CreateSectorTagIterator(int tag, line defline = null);
-	native LineIdIterator CreateLineIdIterator(int tag);
-	native ActorIterator CreateActorIterator(int tid, class<Actor> type = "Actor", bool clientSide = false);
+	native play Thinker CreateThinker(class<Thinker> type, int statnum = Thinker.STAT_DEFAULT);
+	native clearscope Thinker CreateClientSideThinker(class<Thinker> type, int statnum = Thinker.STAT_DEFAULT);
+	native clearscope SectorTagIterator CreateSectorTagIterator(int tag, line defline = null);
+	native clearscope LineIdIterator CreateLineIdIterator(int tag);
+	native clearscope ActorIterator CreateActorIterator(int tid, class<Actor> type = "Actor", bool clientSide = false);
 
 	String TimeFormatted(bool totals = false)
 	{
@@ -644,8 +645,9 @@ struct LevelLocals native
 	native String GetClusterName();
 	native String GetEpisodeName();
 
-	native void SpawnParticle(FSpawnParticleParams p);
-	native VisualThinker SpawnVisualThinker(Class<VisualThinker> type, bool clientSide = false);
+	native clearscope void SpawnParticle(FSpawnParticleParams p);
+	native play VisualThinker SpawnVisualThinker(Class<VisualThinker> type);
+	native clearscope VisualThinker SpawnClientSideVisualThinker(Class<VisualThinker> type);
 
 	clearscope native static bool WorldPaused(bool checkLag = true);
 }

--- a/wadsrc/static/zscript/visualthinker.zs
+++ b/wadsrc/static/zscript/visualthinker.zs
@@ -37,11 +37,11 @@ Class VisualThinker : Thinker native
 	native protected void UpdateSpriteInfo(); // needs to be called every time the texture is updated if the thinker uses SPF_LOCAL_ANIM and is set to a non-ticking statnum (or if Tick is overriden and doesn't call Super.Tick())
 
 	static VisualThinker Spawn(Class<VisualThinker> type, TextureID tex, Vector3 pos, Vector3 vel = (0,0,0), double alpha = 1.0, int flags = 0,
-						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0, int VisualThinkerFlags = 0, bool clientSide = false)
+						  double roll = 0.0, Vector2 scale = (1,1), Vector2 offset = (0,0), int style = STYLE_Normal, TranslationID trans = 0, int VisualThinkerFlags = 0)
 	{
 		if (!Level)	return null;
 
-		let p = level.SpawnVisualThinker(type, clientSide);
+		let p = level.SpawnVisualThinker(type);
 		if (p)
 		{
 			p.Texture = tex;


### PR DESCRIPTION
Splits up client-side spawners as needed so they can be properly scoped (these can't be parameter-based if spawning things from the UI is desired). Adds proper scope guards to certain functions.