### PR TITLE
Global storage

### DIFF
--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -118,6 +118,25 @@ DEFINE_ACTION_FUNCTION(_Globals, GetInt)
 }
 
 
+DEFINE_ACTION_FUNCTION(_Globals, GetKeys)
+{
+	PARAM_PROLOGUE;
+	PARAM_POINTER(out, TArray<FString>);
+
+	// Copy keys to out
+	TMapIterator<FString, FString> it(globalStorage);
+	TMap<FString, FString>::Pair* pair;
+	int outSize = out->Size();
+
+	while (it.NextPair(pair))
+	{
+		out->Push(pair->Key);
+	}
+
+	ACTION_RETURN_INT(out->Size() - outSize);
+}
+
+
 DEFINE_ACTION_FUNCTION(_Globals, Set)
 {
 	PARAM_PROLOGUE;

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>
+#include <fstream>
 
 #include "r_defs.h"
 
@@ -80,6 +81,115 @@ EXTERN_CVAR(Bool, longsavemessages);
 FARG(shotdir, "Configuration", "Sets an alternate directory for saving screenshots.", "path",
 	"Specifies an alternate directory to use for screenshots. If this is not specified, " GAMENAME
 	" stores them in the directory indicated by the screenshot_dir CVAR.");
+
+
+TMap<FString, FString> globalStorage;
+
+void M_LoadGlobalVars(const char* filename);
+void M_SaveGlobalVars(const char* filename);
+
+
+// Quick funcs for global vars
+DEFINE_ACTION_FUNCTION(_Globals, Get)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(key);
+
+	FString *val = globalStorage.CheckKey(key);
+
+	if (numret > 0) ret[0].SetString(val != NULL ? *val : FString(""));
+	if (numret > 1) ret[1].SetInt(val != NULL);
+
+	return numret;
+}
+
+
+DEFINE_ACTION_FUNCTION(_Globals, GetInt)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(key);
+
+	FString* val = globalStorage.CheckKey(key);
+
+	if (numret > 0) ret[0].SetInt(val != NULL ? (int)val->ToLong() : 0);
+	if (numret > 1) ret[1].SetInt(val != NULL);
+
+	return numret;
+}
+
+
+DEFINE_ACTION_FUNCTION(_Globals, Set)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(key);
+	PARAM_STRING(value);
+
+	if (key.Len() > 0)
+	{
+		if (value.Len() == 0)
+		{
+			globalStorage.Remove(key);
+		}
+		else
+		{
+			globalStorage[key] = value;
+		}
+	}
+
+	return 0;
+}
+
+
+
+DEFINE_ACTION_FUNCTION(_Globals, SetInt)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(key);
+	PARAM_INT(value);
+
+	if (key.Len() > 0)
+	{
+		FString v;
+		v.Format("%d", value);
+		globalStorage[key] = v;
+	}
+
+	return 0;
+}
+
+
+DEFINE_ACTION_FUNCTION(_Globals, Save)
+{
+	// Save global vars from the same path as GameConfig
+	if (GameConfig != nullptr && GameConfig->GetPathName() != nullptr)
+	{
+		FString filename = GameConfig->GetPathName();
+		filename += ".globals";
+		M_SaveGlobalVars(filename.GetChars());
+	}
+	else
+	{
+		Printf(TEXTCOLOR_RED"Failed to write globals!");
+	}
+
+	return 0;
+}
+
+
+UNSAFE_CCMD(writeglobals)
+{
+	if (GameConfig != nullptr && GameConfig->GetPathName() != nullptr)
+	{
+		FString filename = GameConfig->GetPathName();
+		filename += ".globals";
+		M_SaveGlobalVars(filename.GetChars());
+	}
+	else
+	{
+		Printf(TEXTCOLOR_RED"Failed to write globals!");
+	}
+}
+
 
 static size_t ParseCommandLine (const char *args, int *argc, char **argv);
 
@@ -291,6 +401,15 @@ bool M_SaveDefaults (const char *filename)
 	{
 		GameConfig->ChangePathName (filename);
 	}
+
+	// Save global vars from the same path as GameConfig
+	if (success && GameConfig->GetPathName() != nullptr)
+	{
+		FString filename = GameConfig->GetPathName();
+		filename += ".globals";
+		M_SaveGlobalVars(filename.GetChars());
+	}
+
 	return success;
 }
 
@@ -324,6 +443,118 @@ CCMD(openconfig)
 	I_OpenShellFolder(ExtractFilePath(GameConfig->GetPathName()).GetChars());
 }
 
+
+// M_LoadGlobalVars
+// @Cockatrice - Simple as fu, load global vars in a silly binary format that is somewhat hard to edit
+// These variables are only used in ZScript for storing game-wide information outside of a save file and outside of CVars
+void M_LoadGlobalVars(const char* filename)
+{
+	globalStorage.Clear();
+
+	FileReader fr;
+	fr.OpenFile(filename);
+
+	const unsigned int fileSize = fr.isOpen() ? fr.GetLength() : 0;
+
+	if (!fr.isOpen() || fileSize < sizeof(uint32_t))
+		return;
+
+	const uint32_t numEntries = fr.ReadUInt32();
+	const char hash = (char)(numEntries % 256);
+	if (numEntries == 0)
+	{
+		fr.Close();
+		return;
+	}
+
+	for (uint32_t x = 0; x < numEntries && fr.isOpen() && fr.Tell() < fileSize; x++)
+	{
+		char buf[256];
+		uint8_t bufLen = 0;
+		FString key, value;
+
+		// Length of key
+		const unsigned char keyLen = fr.ReadUInt8();
+
+		// Key
+		for (int k = 0; k < keyLen && k < 255 && fr.Tell() < fileSize; k++)
+		{
+			char tpos = (char)(fr.Tell() % 256);
+			char c = fr.ReadInt8() - hash - tpos;
+			buf[bufLen++] = c;
+		}
+		buf[bufLen] = '\0';
+		key = buf;
+
+		// Length of value
+		const unsigned char valLen = fr.ReadUInt8();
+
+		// Value
+		bufLen = 0;
+		for (int k = 0; k < valLen && k < 255 && fr.Tell() < fileSize; k++)
+		{
+			char tpos = (char)(fr.Tell() % 256);
+			char c = fr.ReadInt8() - hash - tpos;
+			buf[bufLen++] = c;
+		}
+		buf[bufLen] = '\0';
+		value = buf;
+
+		if (!key.Len() == 0 && !value.Len() == 0)
+		{
+			globalStorage[key] = value;
+			Printf("Read: %s = %s\n", key.GetChars(), value.GetChars());
+		}
+	}
+
+	fr.Close();
+}
+
+
+void M_SaveGlobalVars(const char* filename)
+{
+	std::ofstream fw(filename, std::ios_base::binary | std::ios_base::out);
+
+	const uint32_t numEntries = globalStorage.CountUsed();
+	const char hash = (char)(numEntries % 256);
+	uint32_t ne = LittleLong(numEntries);
+	fw.write(reinterpret_cast<char*>(&ne), sizeof(ne));
+
+	if (numEntries == 0)
+	{
+		fw.close();
+		return;
+	}
+
+	TMapIterator<FString, FString> it(globalStorage);
+	TMap<FString, FString>::Pair* pair;
+
+	while (it.NextPair(pair))
+	{
+		unsigned char keyLen = (unsigned char)clamp(pair->Key.Len(), (size_t)0, (size_t)255);
+		unsigned char valLen = (unsigned char)clamp(pair->Value.Len(), (size_t)0, (size_t)255);
+
+		fw.write(reinterpret_cast<char*>(&keyLen), sizeof(keyLen));
+		for (char x = 0; x < keyLen; x++)
+		{
+			char tpos = (char)(fw.tellp() % 256);
+			char c = pair->Key[x] + hash + tpos;
+			fw.write(&c, sizeof(c));
+		}
+
+		fw.write(reinterpret_cast<char*>(&valLen), sizeof(valLen));
+		for (char x = 0; x < valLen; x++)
+		{
+			char tpos = (char)(fw.tellp() % 256);
+			char c = pair->Value[x] + hash + tpos;
+			fw.write(&c, sizeof(c));
+		}
+	}
+
+	fw.close();
+}
+
+
 //
 // M_LoadDefaults
 //
@@ -332,6 +563,14 @@ void M_LoadDefaults ()
 {
 	GameConfig = new FGameConfigFile;
 	GameConfig->DoGlobalSetup ();
+
+	// Load global vars from the same path as GameConfig
+	if (GameConfig->GetPathName() != nullptr)
+	{
+		FString filename = GameConfig->GetPathName();
+		filename += ".globals";
+		M_LoadGlobalVars(filename.GetChars());
+	}
 }
 
 
@@ -351,17 +590,17 @@ struct pcx_t
 	uint16_t			ymin;
 	uint16_t			xmax;
 	uint16_t			ymax;
-	
+
 	uint16_t			hdpi;
 	uint16_t			vdpi;
 
 	uint8_t				palette[48];
-	
+
 	int8_t				reserved;
 	int8_t				color_planes;
 	uint16_t			bytes_per_line;
 	uint16_t			palette_type;
-	
+
 	int8_t				filler[58];
 };
 
@@ -707,4 +946,3 @@ DEFINE_ACTION_FUNCTION_NATIVE(_CVar, SaveConfig, SaveConfig)
 	PARAM_PROLOGUE;
 	ACTION_RETURN_INT(M_SaveDefaults(nullptr));
 }
-

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <time.h>
 #include <fstream>
+#include <filesystem>
 
 #include "r_defs.h"
 
@@ -82,11 +83,13 @@ FARG(shotdir, "Configuration", "Sets an alternate directory for saving screensho
 	"Specifies an alternate directory to use for screenshots. If this is not specified, " GAMENAME
 	" stores them in the directory indicated by the screenshot_dir CVAR.");
 
+EXTERN_CVAR(Int, developer);
 
 TMap<FString, FString> globalStorage;
 
 void M_LoadGlobalVars(const char* filename);
-void M_SaveGlobalVars(const char* filename);
+bool M_SaveGlobalVars(const char* filename);
+void M_ReadGlobalVars(FileReader& fr, TMap<FString, FString>& map);
 
 
 // Quick funcs for global vars
@@ -182,9 +185,9 @@ DEFINE_ACTION_FUNCTION(_Globals, Save)
 	// Save global vars from the same path as GameConfig
 	if (GameConfig != nullptr && GameConfig->GetPathName() != nullptr)
 	{
-		FString filename = GameConfig->GetPathName();
-		filename += ".globals";
-		M_SaveGlobalVars(filename.GetChars());
+		FString path = M_GetSavegamesPath();
+		path += GAMENAMELOWERCASE".globals"; // [Sal] TODO: Do this per-mod
+		M_SaveGlobalVars(path.GetChars());
 	}
 	else
 	{
@@ -197,11 +200,11 @@ DEFINE_ACTION_FUNCTION(_Globals, Save)
 
 UNSAFE_CCMD(writeglobals)
 {
-	if (GameConfig != nullptr && GameConfig->GetPathName() != nullptr)
+	FString path = M_GetSavegamesPath();
+	path += GAMENAMELOWERCASE".globals"; // [Sal] TODO: Do this per-mod
+	if (M_SaveGlobalVars(path.GetChars()))
 	{
-		FString filename = GameConfig->GetPathName();
-		filename += ".globals";
-		M_SaveGlobalVars(filename.GetChars());
+		Printf(TEXTCOLOR_BLUE"Wrote globals to: %s", path.GetChars());
 	}
 	else
 	{
@@ -421,12 +424,12 @@ bool M_SaveDefaults (const char *filename)
 		GameConfig->ChangePathName (filename);
 	}
 
-	// Save global vars from the same path as GameConfig
-	if (success && GameConfig->GetPathName() != nullptr)
+	// Save global vars from the same path as save games
+	if (success)
 	{
-		FString filename = GameConfig->GetPathName();
-		filename += ".globals";
-		M_SaveGlobalVars(filename.GetChars());
+		FString path = M_GetSavegamesPath();
+		path += GAMENAMELOWERCASE".globals"; // [Sal] TODO: Do this per-mod
+		M_SaveGlobalVars(path.GetChars());
 	}
 
 	return success;
@@ -470,9 +473,16 @@ void M_LoadGlobalVars(const char* filename)
 {
 	globalStorage.Clear();
 
+	Printf("Loading Globals...\n");
 	FileReader fr;
 	fr.OpenFile(filename);
+	M_ReadGlobalVars(fr, globalStorage);
+	fr.Close();
+}
 
+
+void M_ReadGlobalVars(FileReader& fr, TMap<FString, FString>& map)
+{
 	const unsigned int fileSize = fr.isOpen() ? fr.GetLength() : 0;
 
 	if (!fr.isOpen() || fileSize < sizeof(uint32_t))
@@ -521,18 +531,19 @@ void M_LoadGlobalVars(const char* filename)
 
 		if (!key.Len() == 0 && !value.Len() == 0)
 		{
-			globalStorage[key] = value;
-			Printf("Read: %s = %s\n", key.GetChars(), value.GetChars());
+			map[key] = value;
+			if (developer)
+				Printf("Globals Read: %s = %s\n", key.GetChars(), value.GetChars());
 		}
 	}
-
-	fr.Close();
 }
 
 
-void M_SaveGlobalVars(const char* filename)
+bool M_SaveGlobalVars(const char* filename)
 {
 	std::ofstream fw(filename, std::ios_base::binary | std::ios_base::out);
+
+	if (!fw.is_open()) return false;
 
 	const uint32_t numEntries = globalStorage.CountUsed();
 	const char hash = (char)(numEntries % 256);
@@ -542,7 +553,7 @@ void M_SaveGlobalVars(const char* filename)
 	if (numEntries == 0)
 	{
 		fw.close();
-		return;
+		return true;
 	}
 
 	TMapIterator<FString, FString> it(globalStorage);
@@ -571,6 +582,8 @@ void M_SaveGlobalVars(const char* filename)
 	}
 
 	fw.close();
+
+	return true;
 }
 
 
@@ -583,13 +596,9 @@ void M_LoadDefaults ()
 	GameConfig = new FGameConfigFile;
 	GameConfig->DoGlobalSetup ();
 
-	// Load global vars from the same path as GameConfig
-	if (GameConfig->GetPathName() != nullptr)
-	{
-		FString filename = GameConfig->GetPathName();
-		filename += ".globals";
-		M_LoadGlobalVars(filename.GetChars());
-	}
+	FString path = M_GetSavegamesPath();
+	path += GAMENAMELOWERCASE".globals"; // [Sal] TODO: Do this per-mod
+	M_LoadGlobalVars(path.GetChars());
 }
 
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -1083,6 +1083,15 @@ class ScriptScanner native
 	native readonly double Float;
 }
 
+struct Globals native play
+{
+	native static string, bool Get(string key);
+	native static int, bool GetInt(string key);
+	native static void Set(string key, string value);
+	native static void SetInt(string key, int value);
+	native static void Save();
+}
+
 // this struct does not exist. It is just a type for being referenced by an opaque pointer.
 struct VMFunction native version("4.10")
 {

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -1085,8 +1085,9 @@ class ScriptScanner native
 
 struct Globals native play
 {
-	native static string, bool Get(string key);
-	native static int, bool GetInt(string key);
+	native static clearscope string, bool Get(string key);
+	native static clearscope int, bool GetInt(string key);
+	native static clearscope int GetKeys(out Array<string> keys);
 	native static void Set(string key, string value);
 	native static void SetInt(string key, int value);
 	native static void Save();


### PR DESCRIPTION
Cherry-picked from Selaco. Implements a canon way for mods to save variables between multiple sessions, instead of abusing console variables for it.

Related to #5, but not exactly a replacement for it. (Implementing that could still be useful for cross-port compatibility.)

# Lots to do

- [ ] Rework for multiplayer support. These are a straight-forward key-value pairs, it should be easy to do exactly the same as console variables
- [ ] Use separated storage, limit one per mod
  - [ ] Add a place to reserve your file's name in advance (`MAPINFO/GameInfo`?), and to signal the game to load it into memory
  - [ ] Read-only access to other mods' storage
- [ ] Implement a size limit
  - [ ] Size limit cvar
  - [ ] Warn the user in the console once when this limit is breached
  - [ ] Determine how to handle altering the storage after the limit is reached. (Probably keep the changes in memory, in case the user wants to change their limit afterwards.)
