### PR TITLE
Fixed miss player_t check on player death rumble

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -835,9 +835,11 @@ class PlayerPawn : Actor
 	{
 		Super.Die (source, inflictor, dmgflags, MeansOfDeath);
 
-		if (player.mo == self) Super.PlayerDiedMakeRumble(inflictor);
-
-		if (player != NULL && player.mo == self) player.bonuscount = 0;
+		if (player != NULL && player.mo == self)
+		{
+			PlayerDiedMakeRumble(inflictor);
+			player.bonuscount = 0;
+		}
 
 		// [RL0] To allow voodoo zombies, don't kill the player together with voodoo dolls if the compat flag is enabled
 		if (player != NULL && player.mo != self && !(Level.compatflags2 & COMPATF2_VOODOO_ZOMBIES))


### PR DESCRIPTION
Also fixes a bug where the parent rumble virtual was always invoked instead.

Fixes #66 