### PR TITLE
Tweaked defaults

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -171,7 +171,7 @@ CVAR(Bool, am_showitems, false, CVAR_ARCHIVE);
 CVAR(Bool, am_showtime, true, CVAR_ARCHIVE);
 CVAR(Bool, am_showtotaltime, false, CVAR_ARCHIVE);
 CVAR(Bool, am_showlevelname, true, CVAR_ARCHIVE);
-CVAR(Int, am_colorset, 0, CVAR_ARCHIVE);
+CVAR(Int, am_colorset, -1, CVAR_ARCHIVE);
 CVAR(Bool, am_customcolors, true, CVAR_ARCHIVE);
 CVAR(Int, am_map_secrets, 1, CVAR_ARCHIVE);
 CVAR(Int, am_drawmapback, 1, CVAR_ARCHIVE);
@@ -713,28 +713,42 @@ static void AM_initColors(bool overlayed)
 	{
 		AMColors = AMMod;
 	}
-	else switch (am_colorset)
+	else 
 	{
-	default:
-		/* Use the custom colors in the am_* cvars */
-		AMColors.initFromCVars(cv_standard);
-		break;
+		int set = am_colorset;
+		if (set == -1)
+		{
+			if (gameinfo.gametype & GAME_DoomChex)
+				set = 1;
+			else if (gameinfo.gametype & GAME_Strife)
+				set = 2;
+			else if (gameinfo.gametype & GAME_Raven)
+				set = 3;
+		}
 
-	case 1:	// Doom
-		// Use colors corresponding to the original Doom's
-		AMColors.initFromColors(DoomColors, false);
-		break;
+		switch (set)
+		{
+		default:
+			/* Use the custom colors in the am_* cvars */
+			AMColors.initFromCVars(cv_standard);
+			break;
 
-	case 2:	// Strife
-		// Use colors corresponding to the original Strife's
-		AMColors.initFromColors(StrifeColors, false);
-		break;
+		case 1:	// Doom
+			// Use colors corresponding to the original Doom's
+			AMColors.initFromColors(DoomColors, false);
+			break;
 
-	case 3:	// Raven
-		// Use colors corresponding to the original Raven's
-		AMColors.initFromColors(RavenColors, true);
-		break;
+		case 2:	// Strife
+			// Use colors corresponding to the original Strife's
+			AMColors.initFromColors(StrifeColors, false);
+			break;
 
+		case 3:	// Raven
+			// Use colors corresponding to the original Raven's
+			AMColors.initFromColors(RavenColors, true);
+			break;
+
+		}
 	}
 }
 
@@ -1603,7 +1617,7 @@ void DAutomap::clearFB (const AMColor &color)
 		// only draw background when using a mod defined custom color set or Raven colors, if am_drawmapback is 2.
 		if (!am_customcolors || !AMMod.defined)
 		{
-			drawback &= (am_colorset == 3);
+			drawback &= (am_colorset == 3) || (am_colorset == -1 && (gameinfo.gametype & GAME_Raven));
 		}
 	}
 

--- a/src/common/audio/sound/i_sound.cpp
+++ b/src/common/audio/sound/i_sound.cpp
@@ -97,7 +97,7 @@ void I_CloseSound ();
 // Maximum volume of all audio
 //==========================================================================
 
-CUSTOM_CVAR(Float, snd_mastervolume, 1.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+CUSTOM_CVAR(Float, snd_mastervolume, 0.5f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
 {
 	if (self < 0.f)
 		self = 0.f;

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -64,7 +64,7 @@ CVAR (Int, m_showinputgrid, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, m_blockcontrollers, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 CVAR (Float, snd_menuvolume, 0.6f, CVAR_ARCHIVE)
-CVAR(Int, m_use_mouse, 2, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR(Int, m_use_mouse, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Int, m_show_backbutton, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Bool, m_cleanscale, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 // Option Search

--- a/src/common/menu/savegamemanager.cpp
+++ b/src/common/menu/savegamemanager.cpp
@@ -54,7 +54,7 @@
 
 CVAR(String, save_dir, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_SYSTEM_ONLY);
 FString SavegameFolder;
-CVAR(Int, save_sort_order, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Int, save_sort_order, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 EXTERN_FARG(savedir);
 

--- a/src/common/rendering/hwrenderer/data/hw_cvars.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_cvars.cpp
@@ -56,7 +56,7 @@ CUSTOM_CVAR(Int, gl_fogmode, 2, CVAR_ARCHIVE | CVAR_NOINITCALL)
 CVAR(Bool, gl_portals, true, 0)
 CVAR(Bool,gl_mirrors,true,0)	// This is for debugging only!
 CVAR(Bool,gl_mirror_envmap, true, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-CVAR(Bool, gl_seamless, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CVAR(Bool, gl_seamless, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 
 CUSTOM_CVAR(Int, r_mirror_recursions,4,CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
 {
@@ -115,7 +115,7 @@ CVAR(Int, gl_satformula, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 // Texture CVARs
 //
 //==========================================================================
-CUSTOM_CVARD(Float, gl_texture_filter_anisotropic, 8.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL, "changes the OpenGL texture anisotropy setting")
+CUSTOM_CVARD(Float, gl_texture_filter_anisotropic, 16.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL, "changes the OpenGL texture anisotropy setting")
 {
 	screen->SetTextureFilterMode();
 }

--- a/src/common/startscreen/endoom.cpp
+++ b/src/common/startscreen/endoom.cpp
@@ -67,7 +67,7 @@
 
 // PUBLIC DATA DEFINITIONS -------------------------------------------------
 
-CUSTOM_CVAR(Int, showendoom, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+CUSTOM_CVAR(Int, showendoom, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 {
 	if (self < 0) self = 0;
 	else if (self > 2) self=2;

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -89,7 +89,7 @@ EXTERN_CVAR (Bool, am_showlevelname)
 EXTERN_CVAR(Bool, inter_subtitles)
 EXTERN_CVAR(Bool, ui_screenborder_classic_scaling)
 
-CVAR(Int, hud_scale, 0, CVAR_ARCHIVE);
+CVAR(Int, hud_scale, -1, CVAR_ARCHIVE);
 CVAR(Bool, log_vgafont, false, CVAR_ARCHIVE)
 CVAR(Bool, hud_oldscale, true, CVAR_ARCHIVE)
 
@@ -105,7 +105,7 @@ CVAR (Flag, pf_hazard,		paletteflash, PF_HAZARD)
 
 
 // Stretch status bar to full screen width?
-CUSTOM_CVAR (Int, st_scale, 0, CVAR_ARCHIVE)
+CUSTOM_CVAR (Int, st_scale, -1, CVAR_ARCHIVE)
 {
 	if (self < -1)
 	{

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -71,7 +71,7 @@ EXTERN_CVAR(Bool, show_messages)
 EXTERN_CVAR(Bool, haptics_do_menus)
 EXTERN_CVAR(Float, hud_scalefactor)
 
-CVAR(Bool, m_simpleoptions, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+CVAR(Bool, m_simpleoptions, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 CVAR(Bool, m_simpleoptions_view, true, 0);
 
 typedef void(*hfunc)();

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -60,7 +60,7 @@
 #pragma warning(disable: 6011) // dereference null pointer in thinker iterator
 #endif
 
-CVAR (Int, cl_rockettrails, 1, CVAR_ARCHIVE);
+CVAR (Int, cl_rockettrails, 0, CVAR_ARCHIVE);
 CVAR (Bool, r_rail_smartspiral, false, CVAR_ARCHIVE);
 CVAR (Int, r_rail_spiralsparsity, 1, CVAR_ARCHIVE);
 CVAR (Int, r_rail_trailsparsity, 1, CVAR_ARCHIVE);

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -35,7 +35,7 @@
 static float distfogtable[2][256];	// light to fog conversion table for black fog
 
 CVAR(Int, gl_weaponlight, 8, CVAR_ARCHIVE);
-CVAR(Bool, gl_enhanced_nightvision, true, CVAR_ARCHIVE|CVAR_NOINITCALL)
+CVAR(Bool, gl_enhanced_nightvision, false, CVAR_ARCHIVE|CVAR_NOINITCALL)
 
 //==========================================================================
 //

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -83,17 +83,17 @@ EXTERN_CVAR(Float, r_actorspriteshadowfadeheight)
 
 CVAR(Bool, gl_usecolorblending, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_sprite_blend, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
-CVAR(Int, gl_spriteclip, 1, CVAR_ARCHIVE)
+CVAR(Int, gl_spriteclip, -1, CVAR_ARCHIVE)
 CVAR(Bool, r_debug_nolimitanamorphoses, false, 0)
 CVAR(Float, r_spriteclipanamorphicminbias, 0.6, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipthreshold, 10.0, CVAR_ARCHIVE)
 CVAR(Float, gl_sclipfactor, 1.8f, CVAR_ARCHIVE)
-CVAR(Int, gl_particles_style, 2, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
+CVAR(Int, gl_particles_style, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // 0 = square, 1 = round, 2 = smooth
 CVAR(Int, gl_billboard_mode, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_billboard_faces_camera, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, hw_force_cambbpref, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, gl_billboard_particles, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
-CUSTOM_CVAR(Int, gl_fuzztype, 0, CVAR_ARCHIVE)
+CUSTOM_CVAR(Int, gl_fuzztype, 8, CVAR_ARCHIVE)
 {
 	if (self < 0 || self > 8) self = 0;
 }

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1367,6 +1367,7 @@ OptionMenu "MiscOptions" protected
 
 OptionValue MapColorTypes
 {
+	-1, "$OPTVAL_DEFAULT"
 	0, "$OPTVAL_CUSTOM"
 	1, "$OPTVAL_TRADITIONALDOOM"
 	2, "$OPTVAL_TRADITIONALSTRIFE"


### PR DESCRIPTION
-Map colors now default to game type (added new Default option)
-Master volume set to 0.5 to prevent blowing out system audio easily
-Menu mouse mode set to On (non-touchscreen mode); makes the mouse's position more readable
-Save sorting order set to time-based
-Render quality set to Quality to patch holes by default
-AF set to 16x since it's cheap and looks way better
-ENDOOM screen set to off to make exiting more streamlined
-Status bar and fullscreen HUDs set to scale to fullscreen for better readability
-Simple options menu turned off (this will be replaced later)
-Rocket trails set to off to better match vanilla Doom
-Enhanced night vision mode set to off
-Sprite clipping set to Forced-Perspective to better match vanilla Doom
-Particle style set to square since it better matches Doom's aesthetic
-Fuzz type set to software to better match vanilla Doom

<img width="1920" height="1080" alt="Screenshot_Doom_20251025_225427" src="https://github.com/user-attachments/assets/fedf022b-4cea-4d5a-b0a7-cc8b23c2cc69" />
