### PR TITLE
TFlags<> and Enum support for VM-callable Native functions

### DIFF
--- a/src/bbannouncer.cpp
+++ b/src/bbannouncer.cpp
@@ -185,7 +185,7 @@ void DoVoiceAnnounce (const char *sound)
 	if (LastAnnounceTime == 0 || LastAnnounceTime <= primaryLevel->time-5)
 	{
 		LastAnnounceTime = primaryLevel->time;
-		S_Sound (CHAN_VOICE, 0, sound, 1, ATTN_NONE);
+		S_Sound (CHAN_VOICE, CHANF_NONE, sound, 1, ATTN_NONE);
 	}
 }
 

--- a/src/common/audio/sound/i_soundinternal.h
+++ b/src/common/audio/sound/i_soundinternal.h
@@ -7,7 +7,7 @@
 #include "tflags.h"
 #include "vectors.h"
 
-enum EChanFlag
+enum EChanFlag : uint32_t
 {
 	// modifier flags
 	CHANF_LISTENERZ = 8,

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -120,7 +120,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, StatusbarToRealCoords, StatusbarTo
 	return min(4, numret);
 }
 
-void SBar_DrawTexture(DStatusBarCore* self, int texid, double x, double y, int flags, double alpha, double w, double h, double scaleX, double scaleY, int style, int color, int translation, double clipwidth)
+void SBar_DrawTexture(DStatusBarCore* self, int texid, double x, double y, EDrawImageFlags flags, double alpha, double w, double h, double scaleX, double scaleY, int style, int color, int translation, double clipwidth)
 {
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
 	self->DrawGraphic(FSetTextureID(texid), x, y, flags, alpha, w, h, scaleX, scaleY, ERenderStyle(style), color, translation, clipwidth);
@@ -132,21 +132,21 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, DrawTexture, SBar_DrawTexture)
 	PARAM_INT(texid);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	PARAM_INT(flags);
+	PARAM_FLAGS(EDrawImageFlags, flags);
 	PARAM_FLOAT(alpha);
 	PARAM_FLOAT(w);
 	PARAM_FLOAT(h);
 	PARAM_FLOAT(scaleX);
 	PARAM_FLOAT(scaleY);
-	PARAM_INT(style);
+	PARAM_ENUM(ERenderStyle, style);
 	PARAM_INT(col);
 	PARAM_INT(trans);
 	PARAM_FLOAT(clipwidth);
-	SBar_DrawTexture(self, texid, x, y, flags, alpha, w, h, scaleX, scaleY, style, col, trans, clipwidth);
+	SBar_DrawTexture(self, texid, x, y, EDrawImageFlags(flags), alpha, w, h, scaleX, scaleY, ERenderStyle(style), col, trans, clipwidth);
 	return 0;
 }
 
-void SBar_DrawImage(DStatusBarCore* self, const FString& texid, double x, double y, int flags, double alpha, double w, double h, double scaleX, double scaleY, int style, int color, int translation, double clipwidth)
+void SBar_DrawImage(DStatusBarCore* self, const FString& texid, double x, double y, EDrawImageFlags flags, double alpha, double w, double h, double scaleX, double scaleY, ERenderStyle style, int color, int translation, double clipwidth)
 {
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
 	self->DrawGraphic(TexMan.CheckForTexture(texid.GetChars(), ETextureType::Any), x, y, flags, alpha, w, h, scaleX, scaleY, ERenderStyle(style), color, translation, clipwidth);
@@ -158,21 +158,21 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, DrawImage, SBar_DrawImage)
 	PARAM_STRING(texid);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	PARAM_INT(flags);
+	PARAM_FLAGS(EDrawImageFlags, flags);
 	PARAM_FLOAT(alpha);
 	PARAM_FLOAT(w);
 	PARAM_FLOAT(h);
 	PARAM_FLOAT(scaleX);
 	PARAM_FLOAT(scaleY);
-	PARAM_INT(style);
+	PARAM_ENUM(ERenderStyle, style);
 	PARAM_INT(col);
 	PARAM_INT(trans);
 	PARAM_FLOAT(clipwidth);
-	SBar_DrawImage(self, texid, x, y, flags, alpha, w, h, scaleX, scaleY, style, col, trans, clipwidth);
+	SBar_DrawImage(self, texid, x, y, (EDrawImageFlags)flags, alpha, w, h, scaleX, scaleY, (ERenderStyle)style, col, trans, clipwidth);
 	return 0;
 }
 
-void SBar_DrawImageRotated(DStatusBarCore* self, const FString& texid, double x, double y, int flags, double angle, double alpha, double scaleX, double scaleY, int style, int color, int translation)
+void SBar_DrawImageRotated(DStatusBarCore* self, const FString& texid, double x, double y, EDrawImageFlags flags, double angle, double alpha, double scaleX, double scaleY, ERenderStyle style, int color, int translation)
 {
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
 	self->DrawRotated(TexMan.CheckForTexture(texid.GetChars(), ETextureType::Any), x, y, flags, angle, alpha, scaleX, scaleY, color, translation, (ERenderStyle)style);
@@ -184,22 +184,22 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, DrawImageRotated, SBar_DrawImageRo
 	PARAM_STRING(texid);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	PARAM_INT(flags);
+	PARAM_FLAGS(EDrawImageFlags, flags);
 	PARAM_FLOAT(angle);
 	PARAM_FLOAT(alpha);
 	PARAM_FLOAT(scaleX);
 	PARAM_FLOAT(scaleY);
-	PARAM_INT(style);
+	PARAM_ENUM(ERenderStyle, style);
 	PARAM_INT(col);
 	PARAM_INT(trans);
-	SBar_DrawImageRotated(self, texid, x, y, flags, angle, alpha, scaleX, scaleY, style, col, trans);
+	SBar_DrawImageRotated(self, texid, x, y, EDrawImageFlags(flags), angle, alpha, scaleX, scaleY, ERenderStyle(style), col, trans);
 	return 0;
 }
 
-void SBar_DrawTextureRotated(DStatusBarCore* self, int texid, double x, double y, int flags, double angle, double alpha, double scaleX, double scaleY, int style, int color, int translation)
+void SBar_DrawTextureRotated(DStatusBarCore* self, int texid, double x, double y, EDrawImageFlags flags, double angle, double alpha, double scaleX, double scaleY, ERenderStyle style, int color, int translation)
 {
 	if (!twod->HasBegun2D()) ThrowAbortException(X_OTHER, "Attempt to draw to screen outside a draw function");
-	self->DrawRotated(FSetTextureID(texid), x, y, flags, angle, alpha, scaleX, scaleY, color, translation, (ERenderStyle)style);
+	self->DrawRotated(FSetTextureID(texid), x, y, flags, angle, alpha, scaleX, scaleY, color, translation, style);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, DrawTextureRotated, SBar_DrawTextureRotated)
@@ -208,15 +208,15 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, DrawTextureRotated, SBar_DrawTextu
 	PARAM_INT(texid);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	PARAM_INT(flags);
+	PARAM_FLAGS(EDrawImageFlags, flags);
 	PARAM_FLOAT(angle);
 	PARAM_FLOAT(alpha);
 	PARAM_FLOAT(scaleX);
 	PARAM_FLOAT(scaleY);
-	PARAM_INT(style);
+	PARAM_ENUM(ERenderStyle, style);
 	PARAM_INT(col);
 	PARAM_INT(trans);
-	SBar_DrawTextureRotated(self, texid, x, y, flags, angle, alpha, scaleX, scaleY, style, col, trans);
+	SBar_DrawTextureRotated(self, texid, x, y, EDrawImageFlags(flags), angle, alpha, scaleX, scaleY, (ERenderStyle)style, col, trans);
 	return 0;
 }
 

--- a/src/common/scripting/vm/vm.h
+++ b/src/common/scripting/vm/vm.h
@@ -46,6 +46,7 @@
 #include "name.h"
 #include "scopebarrier.h"
 #include <type_traits>
+#include "tflags.h"
 
 class DObject;
 union VMOP;
@@ -846,6 +847,7 @@ bool AssertObject(void * ob);
 
 // For required parameters.
 #define PARAM_INT_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); int x = param[p].i;
+#define PARAM_FLAGS_AT(T, p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); unsigned x = T::ToUnderlyingAsUint(T::FromInt(param[p].i));
 #define PARAM_UINT_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); unsigned x = param[p].i;
 #define PARAM_BOOL_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); bool x = !!param[p].i;
 #define PARAM_NAME_AT(p,x)			assert((p) < numparam); assert(reginfo[p] == REGT_INT); FName x = ENamedName(param[p].i);
@@ -873,6 +875,7 @@ bool AssertObject(void * ob);
 #define PARAM_PROLOGUE				int paramnum = -1;
 
 #define PARAM_INT(x)				++paramnum; PARAM_INT_AT(paramnum,x)
+#define PARAM_FLAGS(T, x)				++paramnum; PARAM_FLAGS_AT(T, paramnum,x)
 #define PARAM_UINT(x)				++paramnum; PARAM_UINT_AT(paramnum,x)
 #define PARAM_BOOL(x)				++paramnum; PARAM_BOOL_AT(paramnum,x)
 #define PARAM_NAME(x)				++paramnum; PARAM_NAME_AT(paramnum,x)
@@ -916,6 +919,11 @@ namespace
 	template<typename T> struct native_is_valid { static const bool value = false; static const bool retval = false; };
 	template<typename T> struct native_is_valid<T*> { static const bool value = true; static const bool retval = true; };
 	template<typename T> struct native_is_valid<T&> { static const bool value = true; static const bool retval = true; };
+	template<typename T> struct native_is_valid<TFlags<T>> 
+	{ 
+		static const bool value = sizeof(TFlags<T>) <= sizeof(int); 
+		static const bool retval = sizeof(TFlags<T>) <= sizeof(int);
+	};
 	template<> struct native_is_valid<void> { static const bool value = true; static const bool retval = true; };
 	template<> struct native_is_valid<int> { static const bool value = true;  static const bool retval = true; };
 	// [RL0] this is disabled for now due to graf's concerns
@@ -932,7 +940,11 @@ struct DirectNativeDesc
 
 	template<typename Ret, typename... Params> DirectNativeDesc(Ret(*func)(Params...)) : Ptr(reinterpret_cast<void*>(func)) { ValidateRet<Ret>(); (ValidateType<Params>(), ...); }
 
-	template<typename T> void ValidateType() { static_assert(native_is_valid<T>::value, "Argument type is not valid as a direct native parameter or return type"); }
+	template<typename T> void ValidateType() 
+	{ 
+		static_assert(native_is_valid<T>::value, "Argument type is not valid as a direct native parameter or return type");
+	}
+
 	template<typename T> void ValidateRet() { static_assert(native_is_valid<T>::retval, "Return type is not valid as a direct native parameter or return type"); }
 
 	operator void *() const { return Ptr; }

--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -469,7 +469,7 @@ void DStatusBarCore::StatusbarToRealCoords(double& x, double& y, double& w, doub
 //
 //============================================================================
 
-void DStatusBarCore::DrawGraphic(FTextureID texture, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style, PalEntry color, int translation, double clipwidth)
+void DStatusBarCore::DrawGraphic(FTextureID texture, double x, double y, EDrawImageFlags flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style, PalEntry color, int translation, double clipwidth)
 {
 	if (!texture.isValid())
 		return;
@@ -478,7 +478,7 @@ void DStatusBarCore::DrawGraphic(FTextureID texture, double x, double y, int fla
 	DrawGraphic(tex, x, y, flags, Alpha, boxwidth, boxheight, scaleX, scaleY, style, color, translation, clipwidth);
 }
 
-void DStatusBarCore::DrawGraphic(FGameTexture* tex, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style, PalEntry color, int translation, double clipwidth)
+void DStatusBarCore::DrawGraphic(FGameTexture* tex, double x, double y, EDrawImageFlags flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style, PalEntry color, int translation, double clipwidth)
 {
 	double texwidth = tex->GetDisplayWidth() * scaleX;
 	double texheight = tex->GetDisplayHeight() * scaleY;
@@ -619,7 +619,7 @@ void DStatusBarCore::DrawGraphic(FGameTexture* tex, double x, double y, int flag
 //
 //============================================================================
 
-void DStatusBarCore::DrawRotated(FTextureID texture, double x, double y, int flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color, int translation, ERenderStyle style)
+void DStatusBarCore::DrawRotated(FTextureID texture, double x, double y, EDrawImageFlags flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color, int translation, ERenderStyle style)
 {
 	if (!texture.isValid())
 		return;
@@ -628,7 +628,7 @@ void DStatusBarCore::DrawRotated(FTextureID texture, double x, double y, int fla
 	DrawRotated(tex, x, y, flags, angle, Alpha, scaleX, scaleY, color, translation, style);
 }
 
-void DStatusBarCore::DrawRotated(FGameTexture* tex, double x, double y, int flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color, int translation, ERenderStyle style)
+void DStatusBarCore::DrawRotated(FGameTexture* tex, double x, double y, EDrawImageFlags flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color, int translation, ERenderStyle style)
 {
 	double texwidth = tex->GetDisplayWidth() * scaleX;
 	double texheight = tex->GetDisplayHeight() * scaleY;

--- a/src/common/statusbar/base_sbar.h
+++ b/src/common/statusbar/base_sbar.h
@@ -2,8 +2,9 @@
 
 #include "dobject.h"
 #include "textureid.h"
-#include "zstring.h"
+#include "tflags.h"
 #include "v_draw.h"
+#include "zstring.h"
 
 class FGameTexture;
 class FFont;
@@ -13,7 +14,7 @@ void ST_UnloadCrosshair();
 void ST_DrawCrosshair(int phealth, double xpos, double ypos, double scale, DAngle angle = nullAngle);
 
 
-enum DI_Flags
+enum DI_Flags : uint32_t
 {
 	DI_SKIPICON = 0x1,
 	DI_SKIPALTICON = 0x2,
@@ -97,6 +98,7 @@ enum DI_Flags
 	DI_ALTERNATEONFAIL = DI_TEXT_ALIGN_CENTER,
 
 };
+using EDrawImageFlags = TFlags<DI_Flags>;
 
 //============================================================================
 //
@@ -184,10 +186,10 @@ public:
 	virtual void SetScale();
 	void ValidateResolution(int& hres, int& vres) const;
 	void StatusbarToRealCoords(double& x, double& y, double& w, double& h) const;
-	void DrawGraphic(FGameTexture* texture, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style = STYLE_Translucent, PalEntry color = 0xffffffff, int translation = 0, double clipwidth = -1.0);
-	void DrawGraphic(FTextureID texture, double x, double y, int flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style = STYLE_Translucent, PalEntry color = 0xffffffff, int translation = 0, double clipwidth = -1.0);
-	void DrawRotated(FTextureID texture, double x, double y, int flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color = 0xffffffff, int translation = 0, ERenderStyle style = STYLE_Translucent);
-	void DrawRotated(FGameTexture* tex, double x, double y, int flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color = 0xffffffff, int translation = 0, ERenderStyle style = STYLE_Translucent);
+	void DrawGraphic(FGameTexture* texture, double x, double y, EDrawImageFlags flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style = STYLE_Translucent, PalEntry color = 0xffffffff, int translation = 0, double clipwidth = -1.0);
+	void DrawGraphic(FTextureID texture, double x, double y, EDrawImageFlags flags, double Alpha, double boxwidth, double boxheight, double scaleX, double scaleY, ERenderStyle style = STYLE_Translucent, PalEntry color = 0xffffffff, int translation = 0, double clipwidth = -1.0);
+	void DrawRotated(FTextureID texture, double x, double y, EDrawImageFlags flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color = 0xffffffff, int translation = 0, ERenderStyle style = STYLE_Translucent);
+	void DrawRotated(FGameTexture* tex, double x, double y, EDrawImageFlags flags, double angle, double Alpha, double scaleX, double scaleY, PalEntry color = 0xffffffff, int translation = 0, ERenderStyle style = STYLE_Translucent);
 	void DrawString(FFont* font, const FString& cstring, double x, double y, int flags, double Alpha, int translation, int spacing, EMonospacing monospacing, int shadowX, int shadowY, double scaleX, double scaleY, FTranslationID pt, int style);
 	void TransformRect(double& x, double& y, double& w, double& h, int flags = 0);
 	void Fill(PalEntry color, double x, double y, double w, double h, int flags = 0);

--- a/src/common/utility/tflags.h
+++ b/src/common/utility/tflags.h
@@ -47,8 +47,6 @@
 template<typename T, typename TT = typename std::underlying_type<T>::type>
 class TFlags
 {
-	struct ZeroDummy {};
-
 public:
 	typedef TFlags<T, TT> Self;
 	typedef T EnumType;
@@ -61,9 +59,9 @@ public:
 	~TFlags() = default;
 	constexpr TFlags (T value) : Value (static_cast<TT> (value)) {}
 
-	// This allows initializing the flagset with 0, as 0 implicitly converts into a null pointer.
-	explicit constexpr TFlags (ZeroDummy*) : Value (0) {}
 	explicit constexpr TFlags(const TT& inVal) : Value(inVal) {} //allowing creation from underlying explicitly, for compat with VM
+	explicit constexpr TFlags(TT&& inVal) : Value(inVal) {} //allowing creation from underlying explicitly, for compat with VM
+	explicit constexpr TFlags(TT& inVal) : Value(inVal) {} //allowing creation from underlying explicitly, for compat with VM
 
 	// Relation operators
 	constexpr Self operator| (const Self& other) const { return Self::FromInt (Value | other.GetValue()); }

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -405,7 +405,7 @@ CCMD (weapnext)
 	}
 	if (SendItemUse != players[consoleplayer].ReadyWeapon)
 	{
-		S_Sound(CHAN_AUTO, 0, "misc/weaponchange", 1.0, ATTN_NONE);
+		S_Sound(CHAN_AUTO, CHANF_NONE, "misc/weaponchange", 1.0, ATTN_NONE);
 	}
 }
 
@@ -430,7 +430,7 @@ CCMD (weapprev)
 	}
 	if (SendItemUse != players[consoleplayer].ReadyWeapon)
 	{
-		S_Sound(CHAN_AUTO, 0, "misc/weaponchange", 1.0, ATTN_NONE);
+		S_Sound(CHAN_AUTO, CHANF_NONE, "misc/weaponchange", 1.0, ATTN_NONE);
 	}
 }
 

--- a/src/gamedata/a_keys.cpp
+++ b/src/gamedata/a_keys.cpp
@@ -520,7 +520,7 @@ int P_CheckKeys (AActor *owner, int keynum, bool remote, bool quiet)
 				auto snd = S_FindSkinnedSound(owner, failsound[i]);
 				if (snd != NO_SOUND)
 				{
-					S_Sound (owner, CHAN_VOICE, 0, snd, 1, ATTN_NORM);
+					S_Sound (owner, CHAN_VOICE, CHANF_NONE, snd, 1, ATTN_NORM);
 					break;
 				}
 			}

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -4155,7 +4155,7 @@ void ClearBounces(AActor* info)
 	info->flags6 &= ~MF6_VULNERABLE;
 	info->flags3 &= ~MF3_NOBLOCKMONST;
 	info->flags4 &= ~(MF4_FORCERADIUSDMG | MF4_DONTHARMCLASS);
-	info->BounceFlags = 0;
+	info->BounceFlags = BOUNCE_None;
 }
 
 // The missile flag affects the bouncing mode.

--- a/src/playsim/a_decals.cpp
+++ b/src/playsim/a_decals.cpp
@@ -850,7 +850,7 @@ void SprayDecal(AActor *shooter, const char *name, double distance, DVector3 off
 	auto trans = useBloodColor ? shooter->BloodTranslation : translation;
 	PalEntry entry = !useBloodColor ? (PalEntry)decalColor : shooter->BloodColor;
 
-	if (Trace(off, shooter->Sector, dir, distance, 0, ML_BLOCKEVERYTHING, shooter, trace, TRACE_NoSky))
+	if (Trace(off, shooter->Sector, dir, distance, MF_NONE, ML_BLOCKEVERYTHING, shooter, trace, TRACE_NoSky))
 	{
 		if (trace.HitType == TRACE_HitWall)
 		{
@@ -874,7 +874,7 @@ DBaseDecal *ShootDecal(FLevelLocals *Level, const FDecalTemplate *tpl, sector_t 
 
 	FTraceResults trace;
 
-	Trace(DVector3(x,y,z), sec, DVector3(angle.ToVector(), 0), tracedist, 0, 0, NULL, trace, TRACE_NoSky);
+	Trace(DVector3(x,y,z), sec, DVector3(angle.ToVector(), 0), tracedist, MF_NONE, 0, NULL, trace, TRACE_NoSky);
 
 	if (trace.HitType == TRACE_HitWall)
 	{

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -34,6 +34,7 @@ enum
 
 enum LightFlag
 {
+	LF_NONE = 0,
 	LF_SUBTRACTIVE = 1,
 	LF_ADDITIVE = 2,
 	LF_DONTLIGHTSELF = 4,
@@ -122,7 +123,7 @@ protected:
 	DVector3 m_Pos = { 0,0,0 };
 	int m_type;
 	int8_t m_attenuate = -1;
-	LightFlags m_lightFlags = 0;
+	LightFlags m_lightFlags = LF_NONE;
 	bool m_swapped = false;
 	bool m_spot = false;
 	bool m_explicitPitch = false;

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -126,6 +126,7 @@ struct FDynamicLight;
 // --- mobj.flags ---
 enum ActorFlag
 {
+	MF_NONE = 0,
 	MF_SPECIAL			= 0x00000001,	// call P_SpecialThing when touched
 	MF_SOLID			= 0x00000002,
 	MF_SHOOTABLE		= 0x00000004,
@@ -173,6 +174,7 @@ enum ActorFlag
 // --- mobj.flags2 ---
 enum ActorFlag2
 {
+	MF2_NONE = 0,
 	MF2_DONTREFLECT		= 0x00000001,	// this projectile cannot be reflected
 	MF2_WINDTHRUST		= 0x00000002,	// gets pushed around by the wind specials
 	MF2_DONTSEEKINVISIBLE=0x00000004,	// For seeker missiles: Don't home in on invisible/shadow targets
@@ -214,6 +216,7 @@ enum ActorFlag2
 // --- mobj.flags3 ---
 enum ActorFlag3
 {
+	MF3_NONE = 0,
 	MF3_FLOORHUGGER		= 0x00000001,	// Missile stays on floor
 	MF3_CEILINGHUGGER	= 0x00000002,	// Missile stays on ceiling
 	MF3_NORADIUSDMG		= 0x00000004,	// Actor does not take radius damage
@@ -251,6 +254,7 @@ enum ActorFlag3
 // --- mobj.flags4 ---
 enum ActorFlag4
 {
+	MF4_NONE = 0,
 	MF4_NOHATEPLAYERS	= 0x00000001,	// Ignore player attacks
 	MF4_QUICKTORETALIATE= 0x00000002,	// Always switch targets when hurt
 	MF4_NOICEDEATH		= 0x00000004,	// Actor never enters an ice death, not even the generic one
@@ -290,6 +294,7 @@ enum ActorFlag4
 
 enum ActorFlag5
 {
+	MF5_NONE = 0,
 	MF5_DONTDRAIN		= 0x00000001,	// cannot be drained health from.
 	MF5_GETOWNER		= 0x00000002,
 	MF5_NODROPOFF		= 0x00000004,	// cannot drop off under any circumstances.
@@ -328,6 +333,7 @@ enum ActorFlag5
 // --- mobj.flags6 ---
 enum ActorFlag6
 {
+	MF6_NONE = 0,
 	MF6_NOBOSSRIP		= 0x00000001,	// For rippermissiles: Don't rip through bosses.
 	MF6_THRUSPECIES		= 0x00000002,	// Actors passes through other of the same species.
 	MF6_MTHRUSPECIES	= 0x00000004,	// Missile passes through actors of its shooter's species.
@@ -365,6 +371,7 @@ enum ActorFlag6
 // --- mobj.flags7 ---
 enum ActorFlag7
 {
+	MF7_NONE = 0,
 	MF7_NEVERTARGET		= 0x00000001,	// can not be targetted at all, even if monster friendliness is considered.
 	MF7_NOTELESTOMP		= 0x00000002,	// cannot telefrag under any circumstances (even when set by MAPINFO)
 	MF7_ALWAYSTELEFRAG	= 0x00000004,	// will unconditionally be telefragged when in the way. Overrides all other settings.
@@ -402,6 +409,7 @@ enum ActorFlag7
 // --- mobj.flags8 ---
 enum ActorFlag8
 {
+	MF8_NONE = 0,
 	MF8_FRIGHTENING		= 0x00000001,	// for those moments when halloween just won't do
 	MF8_INSCROLLSEC		= 0x00000002,	// actor is partially inside a scrolling sector
 	MF8_BLOCKASPLAYER	= 0x00000004,	// actor is blocked by player-blocking lines even if not a player
@@ -438,6 +446,7 @@ enum ActorFlag8
 // --- mobj.flags9 ---
 enum ActorFlag9
 {
+	MF9_NONE = 0,
 	MF9_SHADOWAIM				= 0x00000001,	// [inkoalawetrust] Monster still gets aim penalty from aiming at shadow actors even with MF6_SEEINVISIBLE on.
 	MF9_DOSHADOWBLOCK			= 0x00000002,	// [inkoalawetrust] Should the monster look for SHADOWBLOCK actors ?
 	MF9_SHADOWBLOCK				= 0x00000004,	// [inkoalawetrust] Actors in the line of fire with this flag trigger the MF_SHADOW aiming penalty.

--- a/src/playsim/fragglescript/t_func.cpp
+++ b/src/playsim/fragglescript/t_func.cpp
@@ -588,7 +588,7 @@ void FParser::SF_Input(void)
 
 void FParser::SF_Beep(void)
 {
-	S_Sound(CHAN_AUTO, 0, "misc/chat", 1.0f, ATTN_IDLE);
+	S_Sound(CHAN_AUTO, CHANF_NONE, "misc/chat", 1.0f, ATTN_IDLE);
 }
 
 //==========================================================================
@@ -1474,7 +1474,7 @@ void FParser::SF_StartSound(void)
 		
 		if (mo)
 		{
-			S_Sound(mo, CHAN_BODY, 0, T_FindSound(stringvalue(t_argv[1])), 1, ATTN_NORM);
+			S_Sound(mo, CHAN_BODY, CHANF_NONE, T_FindSound(stringvalue(t_argv[1])), 1, ATTN_NORM);
 		}
 	}
 }
@@ -1500,7 +1500,7 @@ void FParser::SF_StartSectorSound(void)
 		while ((i = itr.Next()) >= 0)
 		{
 			sector = &Level->sectors[i];
-			S_Sound(sector, CHAN_BODY, 0, T_FindSound(stringvalue(t_argv[1])), 1.0f, ATTN_NORM);
+			S_Sound(sector, CHAN_BODY, CHANF_NONE, T_FindSound(stringvalue(t_argv[1])), 1.0f, ATTN_NORM);
 		}
 	}
 }
@@ -2817,7 +2817,7 @@ void FParser::SF_AmbientSound(void)
 {
 	if (CheckArgs(1))
 	{
-		S_Sound(CHAN_AUTO, 0, T_FindSound(stringvalue(t_argv[0])), 1, ATTN_NORM);
+		S_Sound(CHAN_AUTO, CHANF_NONE, T_FindSound(stringvalue(t_argv[0])), 1, ATTN_NORM);
 	}
 }
 
@@ -2916,7 +2916,7 @@ void FParser::SF_SpawnExplosion()
 		{
 			spawn->ClearCounters();
 			t_return.value.i = spawn->SetState(spawn->FindState(NAME_Death));
-			if(spawn->DeathSound.isvalid()) S_Sound (spawn, CHAN_BODY, 0, spawn->DeathSound, 1, ATTN_NORM);
+			if(spawn->DeathSound.isvalid()) S_Sound (spawn, CHAN_BODY, CHANF_NONE, spawn->DeathSound, 1, ATTN_NORM);
 		}
 	}
 }
@@ -3743,7 +3743,7 @@ void FParser::SF_SpawnShot2(void)
 		AActor *mo = Spawn(Level, pclass, source->PosPlusZ(z), ALLOW_REPLACE);
 		if (mo)
 		{
-			S_Sound(mo, CHAN_VOICE, 0, mo->SeeSound, 1, ATTN_NORM);
+			S_Sound(mo, CHAN_VOICE, CHANF_NONE, mo->SeeSound, 1, ATTN_NORM);
 			mo->target = source;
 			mo->Angles.Yaw = source->Angles.Yaw;
 			mo->Thrust();

--- a/src/playsim/mapthinkers/a_doors.cpp
+++ b/src/playsim/mapthinkers/a_doors.cpp
@@ -453,7 +453,7 @@ bool FLevelLocals::EV_DoDoor (DDoor::EVlDoor type, line_t *line, AActor *thing,
 		// if the wrong side of door is pushed, give oof sound
 		if (line->sidedef[1] == NULL)			// killough
 		{
-			S_Sound (thing, CHAN_VOICE, 0, "*usefail", 1, ATTN_NORM);
+			S_Sound (thing, CHAN_VOICE, CHANF_NONE, "*usefail", 1, ATTN_NORM);
 			return false;
 		}
 

--- a/src/playsim/mapthinkers/a_lightning.cpp
+++ b/src/playsim/mapthinkers/a_lightning.cpp
@@ -181,11 +181,11 @@ void DLightningThinker::LightningFlash ()
 	Level->flags |= LEVEL_SWAPSKIES;	// set alternate sky
 	if (TempLightningSound == NO_SOUND)
 	{
-		S_Sound(CHAN_AUTO, 0, Level->LightningSound, 1.0, ATTN_NONE);
+		S_Sound(CHAN_AUTO, CHANF_NONE, Level->LightningSound, 1.0, ATTN_NONE);
 	}
 	else
 	{
-		S_Sound(CHAN_AUTO, 0, TempLightningSound, 1.0, ATTN_NONE);
+		S_Sound(CHAN_AUTO, CHANF_NONE, TempLightningSound, 1.0, ATTN_NONE);
 		TempLightningSound = NO_SOUND;
 	}
 	// [ZZ] just in case

--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -9019,7 +9019,7 @@ scriptwait:
 				{
 					S_Sound (
 						activationline->frontsector,
-						CHAN_AUTO, 0,	// Not CHAN_AREA, because that'd probably break existing scripts.
+						CHAN_AUTO, CHANF_NONE,	// Not CHAN_AREA, because that'd probably break existing scripts.
 						S_FindSound(lookup),
 						(float)(STACK(1)) / 127.f,
 						ATTN_NORM);
@@ -9027,7 +9027,7 @@ scriptwait:
 				else
 				{
 					S_Sound (
-						CHAN_AUTO, 0,
+						CHAN_AUTO, CHANF_NONE,
 						lookup,
 						(float)(STACK(1)) / 127.f,
 						ATTN_NORM);
@@ -9040,7 +9040,7 @@ scriptwait:
 			lookup = Level->Behaviors.LookupString (STACK(2));
 			if (lookup != NULL)
 			{
-				S_Sound (CHAN_AUTO, 0,
+				S_Sound (CHAN_AUTO, CHANF_NONE,
 						 lookup,
 						 (float)(STACK(1)) / 127.f, ATTN_NONE);
 			}
@@ -9051,7 +9051,7 @@ scriptwait:
 			lookup = Level->Behaviors.LookupString (STACK(2));
 			if (lookup != NULL && activator && activator->CheckLocalView())
 			{
-				S_Sound (CHAN_AUTO, 0,
+				S_Sound (CHAN_AUTO, CHANF_NONE,
 						 lookup,
 						 (float)(STACK(1)) / 127.f, ATTN_NONE);
 			}
@@ -9064,13 +9064,13 @@ scriptwait:
 			{
 				if (activator != NULL)
 				{
-					S_Sound (activator, CHAN_AUTO, 0,
+					S_Sound (activator, CHAN_AUTO, CHANF_NONE,
 							 lookup,
 							 (float)(STACK(1)) / 127.f, ATTN_NORM);
 				}
 				else
 				{
-					S_Sound (CHAN_AUTO, 0,
+					S_Sound (CHAN_AUTO, CHANF_NONE,
 							 lookup,
 							 (float)(STACK(1)) / 127.f, ATTN_NONE);
 				}
@@ -9238,7 +9238,7 @@ scriptwait:
 
 				while ( (spot = iterator.Next ()) )
 				{
-					S_Sound (spot, CHAN_AUTO, 0,
+					S_Sound (spot, CHAN_AUTO, CHANF_NONE,
 							 lookup,
 							 (float)(STACK(1))/127.f, ATTN_NORM);
 				}

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -718,7 +718,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_PlaySoundEx)
 
 	if (!looping)
 	{
-		S_Sound (self, channel.GetIndex() - NAME_Auto, 0, soundid, 1, attenuation);
+		S_Sound (self, channel.GetIndex() - NAME_Auto, CHANF_NONE, soundid, 1, attenuation);
 	}
 	else
 	{
@@ -794,7 +794,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_BulletAttack)
 
 	DAngle slope = P_AimLineAttack (self, self->Angles.Yaw, MISSILERANGE);
 
-	S_Sound (self, CHAN_WEAPON, 0, self->AttackSound, 1, ATTN_NORM);
+	S_Sound (self, CHAN_WEAPON, CHANF_NONE, self->AttackSound, 1, ATTN_NORM);
 	for (i = self->GetMissileDamage (0, 1); i > 0; --i)
     {
 		DAngle angle = self->Angles.Yaw + DAngle::fromDeg(pr_cabullet.Random2() * (5.625 / 256.));
@@ -1079,7 +1079,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomMeleeAttack)
 	if (P_CheckMeleeRange(self))
 	{
 		if (meleesound.isvalid())
-			S_Sound (self, CHAN_WEAPON, 0, meleesound, 1, ATTN_NORM);
+			S_Sound (self, CHAN_WEAPON, CHANF_NONE, meleesound, 1, ATTN_NORM);
 		int newdam = P_DamageMobj (self->target, self, self, damage, damagetype);
 		if (bleed)
 			P_TraceBleed (newdam > 0 ? newdam : damage, self->target, self);
@@ -1087,7 +1087,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomMeleeAttack)
 	else
 	{
 		if (misssound.isvalid())
-			S_Sound (self, CHAN_WEAPON, 0, misssound, 1, ATTN_NORM);
+			S_Sound (self, CHAN_WEAPON, CHANF_NONE, misssound, 1, ATTN_NORM);
 	}
 	return 0;
 }
@@ -1116,7 +1116,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_CustomComboAttack)
 		if (damagetype == NAME_None)
 			damagetype = NAME_Melee;	// Melee is the default type
 		if (meleesound.isvalid())
-			S_Sound (self, CHAN_WEAPON, 0, meleesound, 1, ATTN_NORM);
+			S_Sound (self, CHAN_WEAPON, CHANF_NONE, meleesound, 1, ATTN_NORM);
 		int newdam = P_DamageMobj (self->target, self, self, damage, damagetype);
 		if (bleed)
 			P_TraceBleed (newdam > 0 ? newdam : damage, self->target, self);
@@ -3566,7 +3566,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_WolfAttack)
 	}
 
 	// And finally, let's play the sound
-	S_Sound (self, CHAN_WEAPON, 0, sound, 1, ATTN_NORM);
+	S_Sound (self, CHAN_WEAPON, CHANF_NONE, sound, 1, ATTN_NORM);
 	return 0;
 }
 
@@ -4740,7 +4740,7 @@ DEFINE_ACTION_FUNCTION(AActor, CheckBlock)
 		// results in picking up false positives due to actors or lines being in the way
 		// when they clearly should not be.
 
-		int fpass = PCM_DROPOFF;
+		ECheckMoveFlags fpass = PCM_DROPOFF;
 		if (flags & CBF_NOACTORS)	fpass |= PCM_NOACTORS;
 		if (flags & CBF_NOLINES)	fpass |= PCM_NOLINES;
 		mobj->SetZ(pos.Z);

--- a/src/playsim/p_destructible.cpp
+++ b/src/playsim/p_destructible.cpp
@@ -425,7 +425,7 @@ static bool PGRA_CheckExplosionBlocked(DVector3 pt, DVector3 check, sector_t* ch
 	double ptDst = ptVec.Length() - 0.5;
 	ptVec.MakeUnit();
 	FTraceResults res;
-	bool isblocked = Trace(check, checksector, ptVec, ptDst, 0, ML_BLOCKEVERYTHING, nullptr, res);
+	bool isblocked = Trace(check, checksector, ptVec, ptDst, MF_NONE, ML_BLOCKEVERYTHING, nullptr, res);
 	return isblocked;
 }
 

--- a/src/playsim/p_effect.cpp
+++ b/src/playsim/p_effect.cpp
@@ -763,7 +763,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 				
 				if (fabs(mo->X() - trail[0].start.X) < 20 && fabs(mo->Y() - trail[0].start.Y) < 20)
 				{ // This player (probably) fired the railgun
-					S_Sound (mo, CHAN_WEAPON, 0, sound, 1, ATTN_NORM);
+					S_Sound (mo, CHAN_WEAPON, CHANF_NONE, sound, 1, ATTN_NORM);
 				}
 				else
 				{
@@ -772,7 +772,7 @@ void P_DrawRailTrail(AActor *source, TArray<SPortalHit> &portalhits, int color1,
 					{
 						if (shortest == NULL || shortest->sounddist > seg.sounddist) shortest = &seg;
 					}
-					S_Sound (source->Level, DVector3(shortest->soundpos, r_viewpoint.Pos.Z), CHAN_WEAPON, 0, sound, 1, ATTN_NORM);
+					S_Sound (source->Level, DVector3(shortest->soundpos, r_viewpoint.Pos.Z), CHAN_WEAPON, CHANF_NONE, sound, 1, ATTN_NORM);
 				}
 			}
 		}

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -2014,11 +2014,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_Look)
 	{
 		if ((self->flags2 & MF2_BOSS) || (self->flags8 & MF8_FULLVOLSEE))
 		{ // full volume
-			S_Sound (self, CHAN_VOICE, 0, self->SeeSound, 1, ATTN_NONE);
+			S_Sound (self, CHAN_VOICE, CHANF_NONE, self->SeeSound, 1, ATTN_NONE);
 		}
 		else
 		{
-			S_Sound (self, CHAN_VOICE, 0, self->SeeSound, 1, ATTN_NORM);
+			S_Sound (self, CHAN_VOICE, CHANF_NONE, self->SeeSound, 1, ATTN_NORM);
 		}
 	}
 
@@ -2195,11 +2195,11 @@ DEFINE_ACTION_FUNCTION(AActor, A_LookEx)
 	{
 		if (flags & LOF_FULLVOLSEESOUND)
 		{ // full volume
-			S_Sound (self, CHAN_VOICE, 0, self->SeeSound, 1, ATTN_NONE);
+			S_Sound (self, CHAN_VOICE, CHANF_NONE, self->SeeSound, 1, ATTN_NONE);
 		}
 		else
 		{
-			S_Sound (self, CHAN_VOICE, 0, self->SeeSound, 1, ATTN_NORM);
+			S_Sound (self, CHAN_VOICE, CHANF_NONE, self->SeeSound, 1, ATTN_NORM);
 		}
 	}
 
@@ -2624,7 +2624,7 @@ void A_DoChase (AActor *actor, bool fastchase, FState *meleestate, FState *missi
 		if (meleestate && P_CheckMeleeRange(actor))
 		{
 			if (actor->AttackSound.isvalid())
-				S_Sound (actor, CHAN_WEAPON, 0, actor->AttackSound, 1, ATTN_NORM);
+				S_Sound (actor, CHAN_WEAPON, CHANF_NONE, actor->AttackSound, 1, ATTN_NORM);
 
 			actor->SetState (meleestate);
 			actor->flags7 &= ~MF7_INCHASE;
@@ -2887,7 +2887,7 @@ bool P_CheckForResurrection(AActor* self, bool usevilestates, FState* state = nu
 					}
 				}
 				if (sound == NO_SOUND) sound = S_FindSound("vile/raise");
-				S_Sound(corpsehit, CHAN_BODY, 0, sound, 1, ATTN_IDLE);
+				S_Sound(corpsehit, CHAN_BODY, CHANF_NONE, sound, 1, ATTN_IDLE);
 				info = corpsehit->GetDefault();
 
 				if (GetTranslationType(corpsehit->Translation) == TRANSLATION_Blood)
@@ -3224,7 +3224,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Pain)
 	}
 	else if (self->PainSound.isvalid())
 	{
-		S_Sound (self, CHAN_VOICE, 0, self->PainSound, 1, ATTN_NORM);
+		S_Sound (self, CHAN_VOICE, CHANF_NONE, self->PainSound, 1, ATTN_NORM);
 	}
 	return 0;
 }

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1499,7 +1499,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				}
 				if (P_GiveBody(source, draindmg))
 				{
-					S_Sound(source, CHAN_ITEM, 0, "*drainhealth", 1, ATTN_NORM);
+					S_Sound(source, CHAN_ITEM, CHANF_NONE, "*drainhealth", 1, ATTN_NORM);
 				}
 			}
 		}

--- a/src/playsim/p_lnspec.cpp
+++ b/src/playsim/p_lnspec.cpp
@@ -2191,7 +2191,7 @@ FUNC(LS_UsePuzzleItem)
 	}
 
 	// [RH] Say "hmm" if you don't have the puzzle item
-	S_Sound (it, CHAN_VOICE, 0, "*puzzfail", 1, ATTN_IDLE);
+	S_Sound (it, CHAN_VOICE, CHANF_NONE, "*puzzfail", 1, ATTN_IDLE);
 	return false;
 }
 
@@ -3244,7 +3244,7 @@ FUNC(LS_SendToCommunicator)
 			S_StopSound (CHAN_VOICE);
 			auto snd = S_FindSound(name);
 			it->player->SetSubtitle(arg0, snd);
-			S_Sound (CHAN_VOICE, 0, snd, 1, ATTN_NORM);
+			S_Sound (CHAN_VOICE, CHANF_NONE, snd, 1, ATTN_NORM);
 
 			// Get the message from the LANGUAGE lump.
 			FString msg;

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -54,6 +54,7 @@ class DViewPosition;
 struct FRenderViewpoint;
 
 #include <stdlib.h>
+#include "tflags.h"
 
 #define STEEPSLOPE		(46342/65536.)	// [RH] Minimum floorplane.c value for walking
 
@@ -222,12 +223,14 @@ enum SPF
 	SPF_SCALEDNOLERP = 4,
 };
 
-enum PCM
+enum PCM : uint8_t
 {
+	PCM_NONE = 0,
 	PCM_DROPOFF =		1,
 	PCM_NOACTORS =		1 << 1,
 	PCM_NOLINES =		1 << 2,
 };
+using ECheckMoveFlags = TFlags<PCM>;
 
 
 int P_CheckFov(AActor* t1, AActor* t2, double fov);
@@ -259,8 +262,8 @@ void	P_FakeZMovement (AActor *mo);
 bool	P_TryMove(AActor* thing, const DVector2 &pos, int dropoff, const secplane_t * onfloor, FCheckPosition &tm, bool missileCheck = false);
 bool	P_TryMove(AActor* thing, const DVector2 &pos, int dropoff, const secplane_t * onfloor = NULL, bool missilecheck = false);
 
-bool P_CheckMove(AActor *thing, const DVector2 &pos, FCheckPosition& tm, int flags);
-bool	P_CheckMove(AActor *thing, const DVector2 &pos, int flags = 0);
+bool P_CheckMove(AActor *thing, const DVector2 &pos, FCheckPosition& tm, ECheckMoveFlags flags);
+bool	P_CheckMove(AActor* thing, const DVector2& pos, ECheckMoveFlags flags = PCM_NONE);
 void	P_ApplyTorque(AActor *mo);
 
 bool	P_TeleportMove(AActor* thing, const DVector3 &pos, bool telefrag, bool modifyactor = true);	// [RH] Added z and telefrag parameters
@@ -285,7 +288,7 @@ bool	P_TalkFacing (AActor *player);
 void	P_UseLines (player_t* player);
 int	P_UsePuzzleItem (AActor *actor, int itemType);
 
-enum
+enum EFindFloorCeilingFlag
 {
 	FFCF_ONLYSPAWNPOS = 1,
 	FFCF_SAMESECTOR = 2,
@@ -297,6 +300,7 @@ enum
 	FFCF_RESTRICTEDPORTAL = 128,	// current values in the iterator's return are through a restricted portal type (i.e. some features are blocked.)
 	FFCF_NODROPOFF = 256,			// Caller does not need a dropoff (saves some time when checking portals)
 };
+using EFindFloorCeilingFlags = TFlags<EFindFloorCeilingFlag>;
 void	P_FindFloorCeiling (AActor *actor, int flags=0);
 
 bool	P_ChangeSector (sector_t* sector, int crunch, double amt, int floorOrCeil, bool isreset, bool instant = false);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -1354,7 +1354,7 @@ void P_DoMissileDamage(AActor* self, AActor* victim)
 	if (damage > 0 || (self->flags6 & MF6_FORCEPAIN) || (self->flags7 & MF7_CAUSEPAIN))
 	{
 		if (ripper)
-			S_Sound(self, CHAN_BODY, 0, self->SoundVar(NAME_RipSound), 1.0f, ATTN_IDLE);
+			S_Sound(self, CHAN_BODY, CHANF_NONE, self->SoundVar(NAME_RipSound), 1.0f, ATTN_IDLE);
 
 		int dealt = P_DamageMobj(victim, self, self->target, damage, self->DamageType);
 		if (damage > 0 && !(self->flags3 & MF3_BLOODLESSIMPACT)
@@ -2877,7 +2877,7 @@ bool P_TryMove(AActor *thing, const DVector2 &pos,
 //
 //==========================================================================
 
-bool P_CheckMove(AActor *thing, const DVector2 &pos, FCheckPosition& tm, int flags)
+bool P_CheckMove(AActor *thing, const DVector2 &pos, FCheckPosition& tm, ECheckMoveFlags flags)
 {
 	double		newz = thing->Z();
 
@@ -2971,7 +2971,7 @@ bool P_CheckMove(AActor *thing, const DVector2 &pos, FCheckPosition& tm, int fla
 	return true;
 }
 
-bool P_CheckMove(AActor *thing, const DVector2 &pos, int flags)
+bool P_CheckMove(AActor *thing, const DVector2 &pos, ECheckMoveFlags flags)
 {
 	FCheckPosition tm;
 	return P_CheckMove(thing, pos, tm, flags);
@@ -3048,7 +3048,7 @@ void FSlide::HitSlideLine(line_t* ld)
 			tmmove.Y /= 2; // absorb half the velocity
 			if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
 			{
-				S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!//   ^
+				S_Sound(slidemo, CHAN_VOICE, CHANF_NONE, "*grunt", 1, ATTN_IDLE); // oooff!//   ^
 			}
 		}																		//   |
 		else																	// phares
@@ -3064,7 +3064,7 @@ void FSlide::HitSlideLine(line_t* ld)
 			tmmove.Y = -tmmove.Y / 2;
 			if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
 			{
-				S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!
+				S_Sound(slidemo, CHAN_VOICE, CHANF_NONE, "*grunt", 1, ATTN_IDLE); // oooff!
 			}
 		}
 		else
@@ -3096,7 +3096,7 @@ void FSlide::HitSlideLine(line_t* ld)
 		movelen /= 2; // absorb
 		if (slidemo->player && slidemo->health > 0 && !(slidemo->player->cheats & CF_PREDICTING))
 		{
-			S_Sound(slidemo, CHAN_VOICE, 0, "*grunt", 1, ATTN_IDLE); // oooff!
+			S_Sound(slidemo, CHAN_VOICE, CHANF_NONE, "*grunt", 1, ATTN_IDLE); // oooff!
 		}
 		tmmove = moveangle.ToVector(movelen);
 	}	
@@ -4817,7 +4817,7 @@ AActor *P_LineAttack(AActor *t1, DAngle angle, double distance,
 	{ // hit nothing
 		if (!nointeract && puffDefaults && puffDefaults->ActiveSound.isvalid())
 		{ // Play miss sound
-			S_Sound(t1, CHAN_WEAPON, 0, puffDefaults->ActiveSound, 1, ATTN_NORM);
+			S_Sound(t1, CHAN_WEAPON, CHANF_NONE, puffDefaults->ActiveSound, 1, ATTN_NORM);
 		}
 
 		// [MC] LAF_NOINTERACT guarantees puff spawning and returns it directly to the calling function.
@@ -5263,7 +5263,7 @@ void P_TraceBleed(int damage, const DVector3 &pos, AActor *actor, DAngle angle, 
 		if (bleedDist <= 0.0)
 			bleedDist = (double)172.0;
 
-		if (Trace(pos, actor->Sector, vdir, bleedDist, 0, ML_BLOCKEVERYTHING, actor, bleedtrace, TRACE_NoSky))
+		if (Trace(pos, actor->Sector, vdir, bleedDist, MF_NONE, ML_BLOCKEVERYTHING, actor, bleedtrace, TRACE_NoSky))
 		{
 			if (bleedtrace.HitType == TRACE_HitWall)
 			{
@@ -5667,7 +5667,7 @@ void R_OffsetView(FRenderViewpoint& viewPoint, const DVector3& dir, const double
 		viewPoint.Pos += dir * distance;
 		viewPoint.sector = viewPoint.ViewLevel->PointInRenderSubsector(viewPoint.Pos)->sector;
 	}
-	else if (Trace(viewPoint.Pos, viewPoint.sector, dir, distance, 0u, 0u, nullptr, trace))
+	else if (Trace(viewPoint.Pos, viewPoint.sector, dir, distance, MF_NONE, 0u, nullptr, trace))
 	{
 		viewPoint.Pos = trace.HitPos - trace.HitVector * min<double>(5.0, trace.Distance);
 		viewPoint.sector = viewPoint.ViewLevel->PointInRenderSubsector(viewPoint.Pos)->sector;
@@ -5862,7 +5862,7 @@ bool P_UseTraverse(AActor *usething, const DVector2 &start, const DVector2 &end,
 
 				if (usething->player)
 				{
-					S_Sound(usething, CHAN_VOICE, 0, "*usefail", 1, ATTN_IDLE);
+					S_Sound(usething, CHAN_VOICE, CHANF_NONE, "*usefail", 1, ATTN_IDLE);
 				}
 				return true;		// can't use through a wall
 			}
@@ -5979,7 +5979,7 @@ void P_UseLines(player_t *player)
 		if ((!sec->SecActTarget || !sec->TriggerSectorActions(player->mo, spac)) &&
 			P_NoWayTraverse(player->mo, start, end))
 		{
-			S_Sound(player->mo, CHAN_VOICE, 0, "*usefail", 1, ATTN_IDLE);
+			S_Sound(player->mo, CHAN_VOICE, CHANF_NONE, "*usefail", 1, ATTN_IDLE);
 		}
 	}
 }
@@ -6678,7 +6678,7 @@ void P_DoCrunch(AActor *thing, FChangePosition *cpos)
 			}
 			if (thing->CrushPainSound != NO_SOUND && !S_GetSoundPlayingInfo(thing, thing->CrushPainSound))
 			{
-				S_Sound(thing, CHAN_VOICE, 0, thing->CrushPainSound, 1.f, ATTN_NORM);
+				S_Sound(thing, CHAN_VOICE, CHANF_NONE, thing->CrushPainSound, 1.f, ATTN_NORM);
 			}
 		}
 	}

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -1619,7 +1619,7 @@ static int Grind(AActor* actor, int items)
 			actor->SetState (state);
 			if (isgeneric)	// Not a custom crush state, so colorize it appropriately.
 			{
-				S_Sound (actor, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
+				S_Sound (actor, CHAN_BODY, CHANF_NONE, "misc/fallingsplat", 1, ATTN_IDLE);
 				actor->Translation = actor->BloodTranslation;
 			}
 			actor->Level->localEventManager->WorldThingGround(actor, state);
@@ -1665,7 +1665,7 @@ static int Grind(AActor* actor, int items)
 				gib->radius = 0;
 				gib->Translation = actor->BloodTranslation;
 			}
-			S_Sound (actor, CHAN_BODY, 0, "misc/fallingsplat", 1, ATTN_IDLE);
+			S_Sound (actor, CHAN_BODY, CHANF_NONE, "misc/fallingsplat", 1, ATTN_IDLE);
 			actor->Level->localEventManager->WorldThingGround(actor, nullptr);
 		}
 		if (actor->flags & MF_ICECORPSE)
@@ -2059,7 +2059,7 @@ void P_ExplodeMissile (AActor *mo, line_t *line, AActor *target, bool onsky, FNa
 	// play the sound before changing the state, so that AActor::OnDestroy can call S_RelinkSounds on it and the death state can override it.
 	if (mo->DeathSound.isvalid())
 	{
-		S_Sound (mo, CHAN_VOICE, 0, mo->DeathSound, 1,
+		S_Sound (mo, CHAN_VOICE, CHANF_NONE, mo->DeathSound, 1,
 			(mo->flags3 & MF3_FULLVOLDEATH) ? ATTN_NONE : ATTN_NORM);
 	}
 
@@ -2123,15 +2123,15 @@ void AActor::PlayBounceSound(bool onfloor, double volume)
 		volume = clamp(volume, 0.0, 1.0);
 		if (BounceFlags & BOUNCE_UseSeeSound)
 		{
-			S_Sound (this, CHAN_VOICE, 0, SeeSound, (float)volume, ATTN_IDLE);
+			S_Sound (this, CHAN_VOICE, CHANF_NONE, SeeSound, (float)volume, ATTN_IDLE);
 		}
 		else if (onfloor || !WallBounceSound.isvalid())
 		{
-			S_Sound (this, CHAN_VOICE, 0, BounceSound, (float)volume, ATTN_IDLE);
+			S_Sound (this, CHAN_VOICE, CHANF_NONE, BounceSound, (float)volume, ATTN_IDLE);
 		}
 		else
 		{
-			S_Sound (this, CHAN_VOICE, 0, WallBounceSound, (float)volume, ATTN_IDLE);
+			S_Sound (this, CHAN_VOICE, CHANF_NONE, WallBounceSound, (float)volume, ATTN_IDLE);
 		}
 	}
 }
@@ -3755,7 +3755,7 @@ void AActor::Howl ()
 	FSoundID howl = SoundVar(NAME_HowlSound);
 	if (!S_IsActorPlayingSomething(this, CHAN_BODY, howl))
 	{
-		S_Sound (this, CHAN_BODY, 0, howl, 1, ATTN_NORM);
+		S_Sound (this, CHAN_BODY, CHANF_NONE, howl, 1, ATTN_NORM);
 	}
 }
 
@@ -3940,7 +3940,7 @@ void AActor::PlayActiveSound ()
 {
 	if (ActiveSound.isvalid() && !S_IsActorPlayingSomething(this, CHAN_VOICE))
 	{
-		S_Sound (this, CHAN_VOICE, 0, ActiveSound, 1,
+		S_Sound (this, CHAN_VOICE, CHANF_NONE, ActiveSound, 1,
 			(flags3 & MF3_FULLVOLACTIVE) ? ATTN_NONE : ATTN_IDLE);
 	}
 }
@@ -3957,7 +3957,7 @@ void AActor::PlayPushSound()
 	FSoundID push = SoundVar(NAME_PushSound);
 	if (!S_IsActorPlayingSomething(this, CHAN_BODY, push))
 	{
-		S_Sound(this, CHAN_BODY, 0, push, 1, ATTN_NORM);
+		S_Sound(this, CHAN_BODY, CHANF_NONE, push, 1, ATTN_NORM);
 	}
 }
 
@@ -7472,13 +7472,13 @@ foundone:
 		}
 		if (mo)
 		{
-			S_Sound(mo, CHAN_ITEM, 0, smallsplash ?
+			S_Sound(mo, CHAN_ITEM, CHANF_NONE, smallsplash ?
 				splash->SmallSplashSound : splash->NormalSplashSound,
 				1, ATTN_IDLE);
 		}
 		else
 		{
-			S_Sound(thing->Level, pos, CHAN_ITEM, 0, smallsplash ?
+			S_Sound(thing->Level, pos, CHAN_ITEM, CHANF_NONE, smallsplash ?
 				splash->SmallSplashSound : splash->NormalSplashSound,
 				1, ATTN_IDLE);
 		}
@@ -7675,18 +7675,18 @@ void P_PlaySpawnSound(AActor *missile, AActor *spawner)
 	{
 		if (!(missile->flags & MF_SPAWNSOUNDSOURCE))
 		{
-			S_Sound (missile, CHAN_VOICE, 0, missile->SeeSound, 1, ATTN_NORM);
+			S_Sound (missile, CHAN_VOICE, CHANF_NONE, missile->SeeSound, 1, ATTN_NORM);
 		}
 		else if (spawner != NULL)
 		{
-			S_Sound (spawner, CHAN_WEAPON, 0, missile->SeeSound, 1, ATTN_NORM);
+			S_Sound (spawner, CHAN_WEAPON, CHANF_NONE, missile->SeeSound, 1, ATTN_NORM);
 		}
 		else
 		{
 			// If there is no spawner use the spawn position.
 			// But not in a silenced sector.
 			if (!(missile->Sector->Flags & SECF_SILENT))
-				S_Sound (missile->Level, missile->Pos(), CHAN_WEAPON, 0, missile->SeeSound, 1, ATTN_NORM);
+				S_Sound (missile->Level, missile->Pos(), CHAN_WEAPON, CHANF_NONE, missile->SeeSound, 1, ATTN_NORM);
 		}
 	}
 }
@@ -8676,7 +8676,7 @@ void AActor::RestoreSpecialPosition()
 	SetXY(sp);
 	LinkToWorld(&ctx, true);
 	SetZ(Sector->floorplane.ZatPoint(sp));
-	P_FindFloorCeiling(this, FFCF_ONLYSPAWNPOS | FFCF_NOPORTALS);	// no portal checks here so that things get spawned in this sector.
+	P_FindFloorCeiling(this, (FFCF_ONLYSPAWNPOS | FFCF_NOPORTALS));	// no portal checks here so that things get spawned in this sector.
 
 	if (flags & MF_SPAWNCEILING)
 	{

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -692,7 +692,7 @@ void P_ActorOnSpecialFlat (AActor *victim, int floorType)
 		}
 		if (damage > 0 && Terrains[floorType].Splash != -1)
 		{
-			S_Sound (victim, CHAN_AUTO, 0,
+			S_Sound (victim, CHAN_AUTO, CHANF_NONE,
 				Splashes[Terrains[floorType].Splash].NormalSplashSound, 1,
 				ATTN_IDLE);
 		}

--- a/src/playsim/p_things.cpp
+++ b/src/playsim/p_things.cpp
@@ -479,7 +479,7 @@ bool P_Thing_Raise(AActor *thing, AActor *raiser, int flags)
 	if (!P_CanResurrect(raiser, thing))
 		return false;
 
-	S_Sound (thing, CHAN_BODY, 0, "vile/raise", 1, ATTN_IDLE);
+	S_Sound (thing, CHAN_BODY, CHANF_NONE, "vile/raise", 1, ATTN_IDLE);
 
 	thing->Revive();
 

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1169,7 +1169,7 @@ void P_FallingDamage (AActor *actor)
 
 	if (actor->player)
 	{
-		S_Sound (actor, CHAN_AUTO, 0, "*land", 1, ATTN_NORM);
+		S_Sound (actor, CHAN_AUTO, CHANF_NONE, "*land", 1, ATTN_NORM);
 		P_NoiseAlert (actor, actor, true);
 		if (damage >= TELEFRAG_DAMAGE && ((actor->player->cheats & (CF_GODMODE | CF_BUDDHA) ||
 			(actor->FindInventory(PClass::FindActor(NAME_PowerBuddha), true) != nullptr))))
@@ -1236,7 +1236,7 @@ void P_CheckEnvironment(player_t *player)
 		auto id = S_FindSkinnedSound(player->mo, S_FindSound("*falling"));
 		if (id != NO_SOUND && !S_IsActorPlayingSomething(player->mo, CHAN_VOICE, id))
 		{
-			S_Sound(player->mo, CHAN_VOICE, 0, id, 1, ATTN_NORM);
+			S_Sound(player->mo, CHAN_VOICE, CHANF_NONE, id, 1, ATTN_NORM);
 		}
 	}
 }

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -826,10 +826,10 @@ void HWDrawInfo::SetDitherTransFlags(AActor* actor)
 		{
 			startsec = Level->PointInRenderSubsector(campos)->sector;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				  MF_NONE, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z += actor->Height * 0.5;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				MF_NONE, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z -= actor->Height * 0.5;
 			campos.X += horix; campos.Y -= horiy;
 		}

--- a/src/scripting/thingdef_properties.cpp
+++ b/src/scripting/thingdef_properties.cpp
@@ -1058,15 +1058,15 @@ DEFINE_PROPERTY(friction, F, Actor)
 //==========================================================================
 DEFINE_PROPERTY(clearflags, 0, Actor)
 {
-	defaults->flags = 0;
+	defaults->flags = MF_NONE;
 	defaults->flags2 &= MF2_ARGSDEFINED;	// this flag must not be cleared
-	defaults->flags3 = 0;
-	defaults->flags4 = 0;
-	defaults->flags5 = 0;
-	defaults->flags6 = 0;
-	defaults->flags7 = 0;
-	defaults->flags8 = 0;
-	defaults->flags9 = 0;
+	defaults->flags3 = MF3_NONE;
+	defaults->flags4 = MF4_NONE;
+	defaults->flags5 = MF5_NONE;
+	defaults->flags6 = MF6_NONE;
+	defaults->flags7 = MF7_NONE;
+	defaults->flags8 = MF8_NONE;
+	defaults->flags9 = MF9_NONE;
 }
 
 //==========================================================================

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -673,7 +673,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, SetFriendPlayer, SetFriendPlayer)
 
 void ClearBounce(AActor *self)
 {
-	self->BounceFlags = 0;
+	self->BounceFlags = BOUNCE_None;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, ClearBounce, ClearBounce)
@@ -1141,7 +1141,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, TryMove, TryMove)
 	ACTION_RETURN_BOOL(TryMove(self, x, y, dropoff, missilecheck, tm));
 }
 
-static int CheckMove(AActor *self ,double x, double y, int flags, FCheckPosition *tm)
+static int CheckMove(AActor *self ,double x, double y, ECheckMoveFlags flags, FCheckPosition *tm)
 {
 	if (tm == nullptr)
 	{
@@ -1158,9 +1158,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, CheckMove, CheckMove)
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_FLOAT(x);
 	PARAM_FLOAT(y);
-	PARAM_INT(flags);
+	PARAM_FLAGS(ECheckMoveFlags, flags);
 	PARAM_POINTER(tm, FCheckPosition);
-	ACTION_RETURN_BOOL(CheckMove(self, x, y, flags, tm));
+	ACTION_RETURN_BOOL(CheckMove(self, x, y, ECheckMoveFlags(flags), tm));
 }
 
 static double AimLineAttack(AActor *self, double angle, double distance, FTranslatedLineTarget *pLineTarget, double vrange, int flags, AActor *target, AActor *friender)

--- a/src/sound/s_advsound.cpp
+++ b/src/sound/s_advsound.cpp
@@ -1785,7 +1785,7 @@ DEFINE_ACTION_FUNCTION(AAmbientSound, Tick)
 		return 0;
 
 	FAmbientSound *ambient;
-	EChanFlags loop = 0;
+	EChanFlags loop = CHANF_NONE;
 
 	ambient = Ambients.CheckKey(self->args[0]);
 	if (ambient == NULL)


### PR DESCRIPTION
Add support for using explicitly typed Enums and TFlags for native functions called by the VM. In practice this means we should be able to use strongly typed enums and tflags in the native side of the code, where before regular ints labeled 'flags' / 'style' etc were being passed around and it wasn't apparent what types they actually represented.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.