### PR TITLE
Discussing build instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,13 @@ Special thanks to Coraline of the EDGE team for allowing us to use her [README.m
 
 ## How to build UZDoom
 
-To build UZDoom, please see the [wiki](https://zdoom.org/wiki/) and see the "Programmer's Corner" on the bottom-right corner of the page to build for your platform.
+To build UZDoom, please see UZDoom's Github [wiki](https://github.com/UZDoom/UZDoom/wiki/) for full list.
+
+Build For [Linux](https://github.com/UZDoom/UZDoom/wiki/Compilation#linux).
+
+Build For [MacOS](https://github.com/UZDoom/UZDoom/wiki/Compilation#macos).
+
+Build For [Windows](https://github.com/UZDoom/UZDoom/wiki/Compilation#windows).
 
 # Resources
 - https://zdoom.org/ - Home Page


### PR DESCRIPTION
currently the READEME.md has advises to do to the zdoom wiki, which then then refers to the Github Wiki, this is redundent i've removed the link to the zdoom wiki and linked it to the github project wiki and also made hyperlinks to the os build instructions

this might be personal preference but i feel it is also better if the build instuctions are self contained rather than advising other sites, I'd rather be able to download the project and be able to use build instructions without having to bring up a separate site