### PR TITLE
Define SHADOW sneak behavior based on game

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -844,7 +844,7 @@ CUSTOM_CVAR(Int, compatmode, 0, CVAR_ARCHIVE|CVAR_NOINITCALL)
 
 	case 4: // Old ZDoom compat mode
 		v = COMPATF_SOUNDTARGET | COMPATF_LIGHT;
-		w = COMPATF2_MULTIEXIT | COMPATF2_TELEPORT | COMPATF2_PUSHWINDOW | COMPATF2_CHECKSWITCHRANGE | COMPATF2_NOMBF21;
+		w = COMPATF2_MULTIEXIT | COMPATF2_TELEPORT | COMPATF2_PUSHWINDOW | COMPATF2_CHECKSWITCHRANGE | COMPATF2_NOMBF21 | COMPATF2_ZDOOMSHADOW;
 		break;
 
 	case 5: // MBF compat mode
@@ -932,6 +932,7 @@ CVAR (Flag, compat_nombf21,				compatflags2, COMPATF2_NOMBF21);
 CVAR (Flag, compat_voodoozombies,		compatflags2, COMPATF2_VOODOO_ZOMBIES);
 CVAR (Flag, compat_fdteleport,			compatflags2, COMPATF2_FDTELEPORT);
 CVAR (Flag, compat_novdolllockmsg,		compatflags2, COMPATF2_NOVDOLLLOCKMSG);
+CVAR (Flag, compat_zdoomshadow,			compatflags2, COMPATF2_ZDOOMSHADOW);
 
 CVAR(Bool, vid_activeinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -240,6 +240,7 @@ enum : unsigned int
 	COMPATF2_FDTELEPORT		= 1 << 16,	// Emulate Final Doom's teleporter z glitch.
 	COMPATF2_NOACSARGCHECK	= 1 << 17,	// Disable arg count checking for ACS
 	COMPATF2_NOVDOLLLOCKMSG = 1 << 18,	// Voodoo dolls no longer trigger lock messages
+	COMPATF2_ZDOOMSHADOW	= 1 << 19,	// Allow SHADOW to use sneak as well regardless of game, similar to ZDoom.
 };
 
 // Emulate old bugs for select maps. These are not exposed by a cvar

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1944,6 +1944,7 @@ MapFlagHandlers[] =
 	{ "compat_voodoozombies",			MITYPE_COMPATFLAG, 0, COMPATF2_VOODOO_ZOMBIES },
 	{ "compat_noacsargcheck",			MITYPE_COMPATFLAG, 0, COMPATF2_NOACSARGCHECK },
 	{ "compat_novdolllockmsg",			MITYPE_COMPATFLAG, 0, COMPATF2_NOVDOLLLOCKMSG },
+	{ "compat_zdoomshadow",				MITYPE_COMPATFLAG, 0, COMPATF2_ZDOOMSHADOW},
 
 	{ "cd_start_track",					MITYPE_EATNEXT,	0, 0 },
 	{ "cd_end1_track",					MITYPE_EATNEXT,	0, 0 },

--- a/src/maploader/compatibility.cpp
+++ b/src/maploader/compatibility.cpp
@@ -176,6 +176,7 @@ static FCompatOption Options[] =
 	{ "fdteleport",				COMPATF2_FDTELEPORT, SLOT_COMPAT2 },
 	{ "noacsargcheck",			COMPATF2_NOACSARGCHECK, SLOT_COMPAT2 },
 	{ "novdolllockmsg",			COMPATF2_NOVDOLLLOCKMSG, SLOT_COMPAT2 },
+	{ "zdoomshadow",			COMPATF2_ZDOOMSHADOW, SLOT_COMPAT2 },
 	{ NULL, 0, 0 }
 };
 

--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1321,8 +1321,17 @@ bool isTargetablePlayer(AActor *actor, player_t *player, INTBOOL allaround, void
 	// the player then, eh?
 	if (!(actor->flags6 & MF6_SEEINVISIBLE))
 	{
-		if ((player->mo->flags & MF_SHADOW && !(actor->Level->i_compatflags & COMPATF_INVISIBILITY)) ||
-			player->mo->flags3 & MF3_GHOST)
+		// Raven-specific SHADOW behavior, so always apply sneak to it.
+		bool shouldSneak = (player->mo->flags3 & MF3_GHOST);
+		if (!shouldSneak)
+		{
+			// In Raven's games there was no GHOST flag and SHADOW was used directly instead, so always treat its sneak
+			// behavior the same in them.
+			shouldSneak = (player->mo->flags & MF_SHADOW)
+							&& ((gameinfo.gametype & GAME_Raven) || (actor->Level->i_compatflags2 & COMPATF2_ZDOOMSHADOW))
+							&& !(actor->Level->i_compatflags & COMPATF_INVISIBILITY);
+		}
+		if (shouldSneak)
 		{
 			if (player->mo->Distance2D(actor) > 128 && player->mo->Vel.XY().LengthSquared() < 5 * 5)
 			{ // Player is sneaking - can't detect


### PR DESCRIPTION
The current SHADOW behavior always allows sneaking since this was brought over from Raven's version of it (while also adding a GHOST flag to emulate its fuller behaviors). This has very odd effects in Doom, so it now only applies this behavior to Raven games specifically. A compat flag, compat_zdoomshadow, was added to bring back the old behavior of allowing it in any game.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.