### PR TITLE
Allow loading of saves from gzdoom 4.14.2 and below

### DIFF
--- a/src/common/2d/v_drawtext.cpp
+++ b/src/common/2d/v_drawtext.cpp
@@ -380,7 +380,7 @@ void DrawText(F2DDrawer *drawer, FFont* font, int normalcolor, double x, double 
 	{
 		return;
 	}
-	const char *txt = (parms.localize && string[0] == '$') ? GStrings.GetString(&string[1]) : string;
+	const char *txt = (parms.localize && string[0] == '$') ? GStrings.GetString(string + 1) : string;
 	DrawTextCommon(drawer, font, normalcolor, x, y, (const uint8_t*)string, parms);
 }
 
@@ -419,7 +419,7 @@ void DrawText(F2DDrawer *drawer, FFont *font, int normalcolor, double x, double 
 	{
 		return;
 	}
-	const char *txt = (parms.localize && string[0] == '$') ? GStrings.GetString(&string[1]) : string.GetChars();
+	const char *txt = (parms.localize && string.Len() >= 2 && string[0] == '$') ? GStrings.GetString(string.GetChars() + 1) : string.GetChars();
 	DrawTextCommon(drawer, font, normalcolor, x, y, (uint8_t*)txt, parms);
 }
 

--- a/src/common/console/c_bind.cpp
+++ b/src/common/console/c_bind.cpp
@@ -888,7 +888,7 @@ bool C_DoKey (event_t *ev, FKeyBindings *binds, FKeyBindings *doublebinds)
 		dclick = false;
 	}
 
-	if (ev->type == EV_KeyUp && binding[0] != '+')
+	if (ev->type == EV_KeyUp && (binding.Len() == 0 || binding[0] != '+'))
 	{
 		return false;
 	}

--- a/src/common/console/c_dispatch.cpp
+++ b/src/common/console/c_dispatch.cpp
@@ -419,7 +419,7 @@ static FConsoleCommand *ScanChainForName (FConsoleCommand *start, const char *na
 		comp = start->m_Name.CompareNoCase(name, namelen);
 		if (comp > 0)
 			return NULL;
-		else if (comp == 0 && start->m_Name[namelen] == 0)
+		else if (comp == 0 && (start->m_Name.Len() == namelen || start->m_Name[namelen] == 0))
 			return start;
 
 		*prev = start;

--- a/src/common/engine/sc_man.cpp
+++ b/src/common/engine/sc_man.cpp
@@ -244,8 +244,8 @@ void FScanner::PrepareScript ()
 		}
 	}
 
-	ScriptPtr = &ScriptBuffer[0];
-	ScriptEndPtr = &ScriptBuffer[ScriptBuffer.Len()];
+	ScriptPtr = ScriptBuffer.GetChars();
+	ScriptEndPtr = ScriptBuffer.GetChars() + ScriptBuffer.Len();
 	Line = 1;
 	End = false;
 	ScriptOpen = true;

--- a/src/common/engine/stringtable.cpp
+++ b/src/common/engine/stringtable.cpp
@@ -223,7 +223,7 @@ bool FStringTable::ParseLanguageCSV(int filenum, const char* buffer, size_t size
 					else if (lang.Len() < 4)
 					{
 						lang.ToLower();
-						langrows.Push(std::make_pair(column, MAKE_ID(lang[0], lang[1], lang[2], 0)));
+						langrows.Push(std::make_pair(column, MAKE_ID(lang.Len() > 0 ? lang[0] : 0, lang.Len() > 1 ? lang[1] : 0, lang.Len() > 2 ? lang[2] : 0, 0)));
 					}
 				}
 			}

--- a/src/common/utility/memarena.cpp
+++ b/src/common/utility/memarena.cpp
@@ -404,7 +404,7 @@ FSharedStringArena::Node *FSharedStringArena::FindString(const char *str, size_t
 
 	for (Node *node = Buckets[hash % countof(Buckets)]; node != NULL; node = node->Next)
 	{
-		if (node->Hash == hash && node->String.Len() == strlen && memcmp(&node->String[0], str, strlen) == 0)
+		if (node->Hash == hash && node->String.Len() == strlen && memcmp(node->String.GetChars(), str, strlen) == 0)
 		{
 			return node;
 		}

--- a/src/common/utility/zstring.cpp
+++ b/src/common/utility/zstring.cpp
@@ -40,9 +40,37 @@
 #include "zstring.h"
 #include "utf8.h"
 #include "stb_sprintf.h"
+#include "vm.h"
 
 extern uint16_t lowerforupper[65536];
 extern uint16_t upperforlower[65536];
+
+
+void ThrowStringBoundsException(int64_t index, size_t len)
+{
+	if constexpr(sizeof(long int) == 8)
+	{
+		ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "string index %ld out of bounds (string length is %lu)", index, len);
+	}
+	else //if constexpr(sizeof(long long int) == 8)
+	{
+		static_assert(sizeof(long long int) == 8);
+		ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "string index %lld out of bounds (string length is %llu)", index, len);
+	}
+}
+
+void ThrowStringBoundsException(uint64_t index, size_t len)
+{
+	if constexpr(sizeof(long int) == 8)
+	{
+		ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "string index %lu out of bounds (string length is %lu)", index, len);
+	}
+	else //if constexpr(sizeof(long long int) == 8)
+	{
+		static_assert(sizeof(long long int) == 8);
+		ThrowAbortException(X_ARRAY_OUT_OF_BOUNDS, "string index %llu out of bounds (string length is %llu)", index, len);
+	}
+}
 
 FNullStringData FString::NullString =
 {

--- a/src/common/utility/zstring.h
+++ b/src/common/utility/zstring.h
@@ -118,6 +118,9 @@ enum ELumpNum
 {
 };
 
+void ThrowStringBoundsException(int64_t index, size_t len);
+void ThrowStringBoundsException(uint64_t index, size_t len);
+
 class FString
 {
 public:
@@ -168,18 +171,39 @@ public:
 
 	TArrayView<uint8_t> GetTArrayView();
 
-	const char &operator[] (int index) const { return Chars[index]; }
+	const char &operator[] (int index) const
+	{
+		if(index < 0 || index >= Len()) ThrowStringBoundsException((int64_t)index, Len());
+		return Chars[index];
+	}
 #if defined(_WIN32) && !defined(_WIN64) && defined(_MSC_VER)
 	// Compiling 32-bit Windows source with MSVC: size_t is typedefed to an
 	// unsigned int with the 64-bit portability warning attribute, so the
 	// prototype cannot substitute unsigned int for size_t, or you get
 	// spurious warnings.
-	const char &operator[] (size_t index) const { return Chars[index]; }
+	const char &operator[] (size_t index) const
+	{
+		if(index >= Len()) ThrowStringBoundsException((uint64_t)index, Len());
+		return Chars[index];
+	}
 #else
-	const char &operator[] (unsigned int index) const { return Chars[index]; }
+	const char &operator[] (unsigned int index) const
+	{
+		if(index >= Len()) ThrowStringBoundsException((uint64_t)index, Len());
+		return Chars[index];
+	}
 #endif
-	const char &operator[] (unsigned long index) const { return Chars[index]; }
-	const char &operator[] (unsigned long long index) const { return Chars[index]; }
+	const char &operator[] (unsigned long index) const
+	{
+		if(index >= Len()) ThrowStringBoundsException((uint64_t)index, Len());
+		return Chars[index];
+	}
+
+	const char &operator[] (unsigned long long index) const
+	{
+		if(index >= Len()) ThrowStringBoundsException((uint64_t)index, Len());
+		return Chars[index];
+	}
 
 	FString &operator = (const FString &other);
 	FString &operator = (FString &&other) noexcept;

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2020,6 +2020,7 @@ void C_SerializeCVars(FSerializer& arc, const char* label, uint32_t filter)
 
 void SetupLoadingCVars();
 void FinishLoadingCVars();
+bool CheckGZDoomSaveCompat(FString &engine, FString &software);
 
 void G_DoLoadGame ()
 {
@@ -2066,7 +2067,17 @@ void G_DoLoadGame ()
 	arc("Current Map", map);
 	arc("GameUUID", GameUUID);
 
+	#if LOAD_GZDOOM_4142_SAVES
+	FString software = arc.GetString("Software");
+	bool gzdoom_compat_ok = false;
+	if(engine.Compare("GZDOOM") == 0)
+	{
+		gzdoom_compat_ok = CheckGZDoomSaveCompat(engine, software);
+	}
+	if (engine.CompareNoCase(GAMESIG) != 0 && !gzdoom_compat_ok)
+	#else
 	if (engine.CompareNoCase(GAMESIG) != 0)
+	#endif
 	{
 		// Make a special case for the message printed for old savegames that don't
 		// have this information.

--- a/src/r_data/sprites.cpp
+++ b/src/r_data/sprites.cpp
@@ -417,10 +417,11 @@ void R_InitSpriteDefs ()
 			auto tex = TexMan.GetGameTexture(hash);
 			if (TEX_DWNAME(tex) == intname)
 			{
-				bool res = R_InstallSpriteLump (FTextureID(hash), tex->GetName()[4] - 'A', tex->GetName()[5], false, sprtemp, maxframe);
+				if(tex->GetName().Len() < 5) I_Error("Sprite name incomplete");
+				bool res = R_InstallSpriteLump (FTextureID(hash), tex->GetName()[4] - 'A', tex->GetName().Len() >= 6 ? tex->GetName()[5] : 0, false, sprtemp, maxframe);
 
-				if (tex->GetName()[6] && res)
-					R_InstallSpriteLump (FTextureID(hash), tex->GetName()[6] - 'A', tex->GetName()[7], true, sprtemp, maxframe);
+				if (tex->GetName().Len() >= 7 && tex->GetName()[6] && res)
+					R_InstallSpriteLump (FTextureID(hash), tex->GetName()[6] - 'A', tex->GetName().Len() >= 8 ? tex->GetName()[7] : 0, true, sprtemp, maxframe);
 			}
 			hash = hashes[hash].Next;
 		}

--- a/src/version.h
+++ b/src/version.h
@@ -87,6 +87,11 @@ const char *GetVersionString();
 
 // This is so that derivates can use the same savegame versions without worrying about engine compatibility
 #define GAMESIG "UZDOOM"
+
+#ifndef LOAD_GZDOOM_4142_SAVES
+    #define LOAD_GZDOOM_4142_SAVES 1
+#endif
+
 #define BASEWAD "uzdoom.pk3"
 // Set OPTIONALWAD to "" (null) to disable searching for it
 #define OPTIONALWAD "game_support.pk3"


### PR DESCRIPTION
(needs to parse the Software string since that's the only place in the savegame where the actual version is stored, as opposed to the savever)