### PR TITLE
Fix colours in netstart and error windows

### DIFF
--- a/src/common/widgets/errorwindow.cpp
+++ b/src/common/widgets/errorwindow.cpp
@@ -1,13 +1,39 @@
+/*
+** errorwindow.cpp
+**
+**---------------------------------------------------------------------------
+**
+** Copyright 2024 Magnus Norddahl
+** Copyright 2024-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see http://www.gnu.org/licenses/
+**
+**---------------------------------------------------------------------------
+**
+*/
 
-#include "errorwindow.h"
-#include "version.h"
-#include "v_font.h"
-#include "printf.h"
+#include <miniz.h>
 #include <zwidget/core/image.h>
+#include <zwidget/systemdialogs/save_file_dialog.h>
 #include <zwidget/widgets/pushbutton/pushbutton.h>
 #include <zwidget/widgets/scrollbar/scrollbar.h>
-#include <zwidget/systemdialogs/save_file_dialog.h>
-#include <miniz.h>
+
+#include "errorwindow.h"
+#include "printf.h"
+#include "v_font.h"
+#include "version.h"
 
 bool ErrorWindow::ExecModal(const std::string& text, const std::string& log, std::vector<uint8_t> minidump)
 {
@@ -29,10 +55,6 @@ ErrorWindow::ErrorWindow(std::vector<uint8_t> initminidump) : Widget(nullptr, Wi
 {
 	FStringf caption("Fatal Error - " GAMENAME " %s (%s)", GetVersionString(), GetGitTime());
 	SetWindowTitle(caption.GetChars());
-	SetWindowBackground(Colorf::fromRgba8(51, 51, 51));
-	SetWindowBorderColor(Colorf::fromRgba8(51, 51, 51));
-	SetWindowCaptionColor(Colorf::fromRgba8(33, 33, 33));
-	SetWindowCaptionTextColor(Colorf::fromRgba8(226, 223, 219));
 
 	LogView = new LogViewer(this);
 	ClipboardButton = new PushButton(this);

--- a/src/common/widgets/netstartwindow.cpp
+++ b/src/common/widgets/netstartwindow.cpp
@@ -1,12 +1,36 @@
+/*
+** netstartwindow.cpp
+**
+**---------------------------------------------------------------------------
+**
+** Copyright 2024 Magnus Norddahl
+** Copyright 2024-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see http://www.gnu.org/licenses/
+**
+**---------------------------------------------------------------------------
+**
+*/
+
+#include <zwidget/core/timer.h>
+#include <zwidget/widgets/listview/listview.h>
+#include <zwidget/widgets/pushbutton/pushbutton.h>
+#include <zwidget/widgets/textlabel/textlabel.h>
 
 #include "netstartwindow.h"
 #include "version.h"
-#include "engineerrors.h"
-#include "gstrings.h"
-#include <zwidget/core/timer.h>
-#include <zwidget/widgets/textlabel/textlabel.h>
-#include <zwidget/widgets/listview/listview.h>
-#include <zwidget/widgets/pushbutton/pushbutton.h>
 
 NetStartWindow* NetStartWindow::Instance = nullptr;
 
@@ -155,10 +179,6 @@ bool NetStartWindow::NetLoop(bool (*loopCallback)(void*), void* data)
 
 NetStartWindow::NetStartWindow(bool host) : Widget(nullptr, WidgetType::Window)
 {
-	SetWindowBackground(Colorf::fromRgba8(51, 51, 51));
-	SetWindowBorderColor(Colorf::fromRgba8(51, 51, 51));
-	SetWindowCaptionColor(Colorf::fromRgba8(33, 33, 33));
-	SetWindowCaptionTextColor(Colorf::fromRgba8(226, 223, 219));
 	SetWindowTitle(GAMENAME);
 
 	MessageLabel = new TextLabel(this);


### PR DESCRIPTION
Netstart and error windows now follow theme

(Error console is unchanged, still white on grey)

Fixes #254