### PR TITLE
Remove translucent renderstyle from Doom's bullet puff

### DIFF
--- a/wadsrc/static/zscript/actors/doom/doommisc.zs
+++ b/wadsrc/static/zscript/actors/doom/doommisc.zs
@@ -61,9 +61,6 @@ class BulletPuff : Actor
 		+NOGRAVITY
 		+ALLOWPARTICLES
 		+RANDOMIZE
-		+ZDOOMTRANS
-		RenderStyle "Translucent";
-		Alpha 0.5;
 		VSpeed 1;
 		Mass 5;
 	}


### PR DESCRIPTION
This one might be contentious so I'd like to know what peoples' thoughts are on this.

My argument for it is that the translucent renderstyle greatly reduces the visual impact from the bullet puffs, and in dark rooms, they're straight up almost unseeable.

Here are some video comparisons comparing the translucent style versus the classic, solid style.




https://github.com/user-attachments/assets/215d50de-4ea4-4de3-a439-f01723ae36f3


https://github.com/user-attachments/assets/74de5822-9f17-4a68-8e5a-54687ccc1ff7


