### PR TITLE
L3 Prefetch in FBlockThingsIterator::Next

### DIFF
--- a/src/common/utility/basics.h
+++ b/src/common/utility/basics.h
@@ -4,7 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <type_traits>
+
+#if defined(_M_X64) || defined(__x86_64__) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
 #include <xmmintrin.h>
+#endif
 
 #define MAXWIDTH 12000
 #define MAXHEIGHT 5000

--- a/src/common/utility/basics.h
+++ b/src/common/utility/basics.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <type_traits>
+#include <xmmintrin.h>
 
 #define MAXWIDTH 12000
 #define MAXHEIGHT 5000
@@ -79,8 +80,7 @@ T clamp(T val, T minval, T maxval)
 
 static inline void PrefetchL3(const void* Address)
 {
-#ifdef _M_X64
-    static constexpr int L3CacheHint = 2;
-    _mm_prefetch(static_cast<const char*>(Address), L3CacheHint);
+#if defined(_M_X64) || defined(__x86_64__) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64)
+    _mm_prefetch(static_cast<const char*>(Address), _MM_HINT_T1);
 #endif
 }

--- a/src/common/utility/basics.h
+++ b/src/common/utility/basics.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <algorithm>
 #include <stddef.h>
 #include <stdint.h>
-#include <algorithm>
+#include <type_traits>
 
 #define MAXWIDTH 12000
 #define MAXHEIGHT 5000
@@ -74,4 +75,12 @@ template<typename T>
 T clamp(T val, T minval, T maxval)
 {
     return std::max<T>(std::min<T>(val, maxval), minval);
+}
+
+static inline void PrefetchL3(const void* Address)
+{
+#ifdef _M_X64
+    static constexpr int L3CacheHint = 2;
+    _mm_prefetch(static_cast<const char*>(Address), L3CacheHint);
+#endif
 }

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -982,6 +982,7 @@ AActor *FBlockThingsIterator::Next(bool centeronly)
 	{
 		while (block != NULL)
 		{
+			PrefetchL3(block->NextActor);
 			AActor *me = block->Me;
 			FBlockNode *mynode = block;
 			HashEntry *entry;


### PR DESCRIPTION
Sometimes shows performance improvements in large slaughtermaps. This is in theory a fair prefetch assumption to make, since the NextActor is basically always of interest during this iteration.