### PR TITLE
Fixed audio not muting properly when unfocused

### DIFF
--- a/src/common/audio/sound/s_sound.cpp
+++ b/src/common/audio/sound/s_sound.cpp
@@ -1844,7 +1844,7 @@ void S_SetSoundPaused(int state)
 		S_PauseSound(false, true);
 		if (GSnd != nullptr)
 		{
-			GSnd->SetInactive(gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL ?
+			GSnd->SetInactive(pauseext && (gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL) ?
 				SoundRenderer::INACTIVE_Complete :
 				SoundRenderer::INACTIVE_Mute);
 		}


### PR DESCRIPTION
When pausing the sound renderer, now checks that the game is fully paused if disabling it entirely. This prevents audio building up while the game is running in the background, causing a burst of sound when re-enabling it.