### PR TITLE
Trace fix and minor refactor

### DIFF
--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1399,20 +1399,19 @@ void FPathTraverse::AddThingIntercepts (int bx, int by, FBlockThingsIterator &it
 intercept_t *FPathTraverse::Next()
 {
 	intercept_t *in = NULL;
-
 	double dist = FLT_MAX;
-	for (unsigned scanpos = intercept_index; scanpos < intercepts.Size (); scanpos++)
+
+	if (intercept_count > 0 && intercept_index < intercept_count)
 	{
-		intercept_t *scan = &intercepts[scanpos];
-		if (scan->frac < dist && !scan->done)
-		{
-			dist = scan->frac;
-			in = scan;
-		}
+		in = &intercepts[intercept_index++];
+		dist = in->frac;
 	}
-	
-	if (dist > 1. || in == NULL) return NULL;	// checked everything in range			
-	in->done = true;
+	else
+	{
+		return NULL;
+	}
+	if (dist > 1. || in == NULL) return NULL;	// checked everything in range
+	// in->done = true;
 	return in;
 }
 
@@ -1630,6 +1629,17 @@ void FPathTraverse::init(double x1, double y1, double x2, double y2, int flags, 
 			break;
 		}
 	}
+
+	struct
+	{
+		bool operator()(intercept_t a, intercept_t b) const { return a.frac < b.frac; }
+	} lesserfrac;
+	intercept_count = intercepts.Size();
+	if (intercept_count > intercept_index)
+	{
+		std::sort(intercepts.begin(), intercepts.end(), lesserfrac); // [DVR] Can start from [intercept_index] instead of begin()??
+	}
+	intercepts.end()->done = true;
 }
 
 //===========================================================================
@@ -1656,7 +1666,12 @@ int FPathTraverse::PortalRelocate(intercept_t *in, int flags, DVector3 *optpos)
 		P_TranslatePortalZ(in->d.line, optpos->Z);
 	}
 	line_t *saved = in->d.line;	// this gets overwritten by the init call.
-	intercepts.Resize(intercept_index);
+	if (intercept_index > 0) intercepts.Resize(--intercept_index);
+	if (flags & PT_DELTA)
+	{
+		endx -= hitx;
+		endy -= hity;
+	}
 	init(hitx, hity, endx, endy, flags, in->frac + EQUAL_EPSILON);
 	return saved->getPortal()->mType == PORTT_LINKED? 1:-1;
 }
@@ -1665,9 +1680,9 @@ void FPathTraverse::PortalRelocate(const DVector2 &displacement, int flags, doub
 {
 	double hitx = trace.x + displacement.X;
 	double hity = trace.y + displacement.Y;
-	double endx = hitx + trace.dx;
-	double endy = hity + trace.dy;
-	intercepts.Resize(intercept_index);
+	double endx = (flags & PT_DELTA ? trace.dx : hitx + trace.dx);
+	double endy = (flags & PT_DELTA ? trace.dy : hity + trace.dy);
+	if(intercept_index > 0) intercepts.Resize(--intercept_index);
 	init(hitx, hity, endx, endy, flags, hitfrac);
 }
 
@@ -1679,7 +1694,8 @@ void FPathTraverse::PortalRelocate(const DVector2 &displacement, int flags, doub
 
 FPathTraverse::~FPathTraverse()
 {
-	intercepts.Resize(intercept_index);
+	// intercepts.Resize(intercept_index);
+	intercepts.Clear();
 }
 
 

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1601,14 +1601,11 @@ void FPathTraverse::init(double x1, double y1, double x2, double y2, int flags, 
 		}
 	}
 
-	struct
-	{
-		bool operator()(intercept_t a, intercept_t b) const { return a.frac < b.frac; }
-	} lesserfrac;
 	intercept_count = intercepts.Size();
 	if (intercept_count > intercept_index)
 	{
-		std::sort(intercepts.begin(), intercepts.end(), lesserfrac); // [DVR] Can start from [intercept_index] instead of begin()??
+		std::sort(intercepts.begin(), intercepts.end(), // [DVR] Can start from [intercept_index] instead of begin()??
+				  [](const intercept_t &a, const intercept_t &b) { return a.frac < b.frac; });
 	}
 	intercepts.end()->done = true;
 }

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1630,14 +1630,11 @@ void FPathTraverse::init(double x1, double y1, double x2, double y2, int flags, 
 		}
 	}
 
-	struct
-	{
-		bool operator()(intercept_t a, intercept_t b) const { return a.frac < b.frac; }
-	} lesserfrac;
 	intercept_count = intercepts.Size();
 	if (intercept_count > intercept_index)
 	{
-		std::sort(intercepts.begin(), intercepts.end(), lesserfrac); // [DVR] Can start from [intercept_index] instead of begin()??
+		std::sort(intercepts.begin(), intercepts.end(), // [DVR] Can start from [intercept_index] instead of begin()??
+				  [](const intercept_t &a, const intercept_t &b) { return a.frac < b.frac; });
 	}
 	intercepts.end()->done = true;
 }

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1370,20 +1370,19 @@ void FPathTraverse::AddThingIntercepts (int bx, int by, FBlockThingsIterator &it
 intercept_t *FPathTraverse::Next()
 {
 	intercept_t *in = NULL;
-
 	double dist = FLT_MAX;
-	for (unsigned scanpos = intercept_index; scanpos < intercepts.Size (); scanpos++)
-	{
-		intercept_t *scan = &intercepts[scanpos];
-		if (scan->frac < dist && !scan->done)
-		{
-			dist = scan->frac;
-			in = scan;
-		}
-	}
 
+	if (intercept_count > 0 && intercept_index < intercept_count)
+	{
+		in = &intercepts[intercept_index++];
+		dist = in->frac;
+	}
+	else
+	{
+		return NULL;
+	}
 	if (dist > 1. || in == NULL) return NULL;	// checked everything in range
-	in->done = true;
+	// in->done = true;
 	return in;
 }
 
@@ -1601,6 +1600,17 @@ void FPathTraverse::init(double x1, double y1, double x2, double y2, int flags, 
 			break;
 		}
 	}
+
+	struct
+	{
+		bool operator()(intercept_t a, intercept_t b) const { return a.frac < b.frac; }
+	} lesserfrac;
+	intercept_count = intercepts.Size();
+	if (intercept_count > intercept_index)
+	{
+		std::sort(intercepts.begin(), intercepts.end(), lesserfrac); // [DVR] Can start from [intercept_index] instead of begin()??
+	}
+	intercepts.end()->done = true;
 }
 
 //===========================================================================
@@ -1627,7 +1637,12 @@ int FPathTraverse::PortalRelocate(intercept_t *in, int flags, DVector3 *optpos)
 		P_TranslatePortalZ(in->d.line, optpos->Z);
 	}
 	line_t *saved = in->d.line;	// this gets overwritten by the init call.
-	intercepts.Resize(intercept_index);
+	if (intercept_index > 0) intercepts.Resize(--intercept_index);
+	if (flags & PT_DELTA)
+	{
+		endx -= hitx;
+		endy -= hity;
+	}
 	init(hitx, hity, endx, endy, flags, in->frac + EQUAL_EPSILON);
 	return saved->getPortal()->mType == PORTT_LINKED? 1:-1;
 }
@@ -1636,9 +1651,9 @@ void FPathTraverse::PortalRelocate(const DVector2 &displacement, int flags, doub
 {
 	double hitx = trace.x + displacement.X;
 	double hity = trace.y + displacement.Y;
-	double endx = hitx + trace.dx;
-	double endy = hity + trace.dy;
-	intercepts.Resize(intercept_index);
+	double endx = (flags & PT_DELTA ? trace.dx : hitx + trace.dx);
+	double endy = (flags & PT_DELTA ? trace.dy : hity + trace.dy);
+	if(intercept_index > 0) intercepts.Resize(--intercept_index);
 	init(hitx, hity, endx, endy, flags, hitfrac);
 }
 
@@ -1650,7 +1665,8 @@ void FPathTraverse::PortalRelocate(const DVector2 &displacement, int flags, doub
 
 FPathTraverse::~FPathTraverse()
 {
-	intercepts.Resize(intercept_index);
+	// intercepts.Resize(intercept_index);
+	intercepts.Clear();
 }
 
 

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -1382,7 +1382,7 @@ intercept_t *FPathTraverse::Next()
 		return NULL;
 	}
 	if (dist > 1. || in == NULL) return NULL;	// checked everything in range
-	// in->done = true;
+
 	return in;
 }
 
@@ -1662,7 +1662,6 @@ void FPathTraverse::PortalRelocate(const DVector2 &displacement, int flags, doub
 
 FPathTraverse::~FPathTraverse()
 {
-	// intercepts.Resize(intercept_index);
 	intercepts.Clear();
 }
 

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -209,7 +209,6 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 	}
 }
 
-
 //============================================================================
 //
 // traverses a sector portal
@@ -328,15 +327,6 @@ void FTraceInfo::Setup3DFloors()
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = Results->HitPos;
-							if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-							{
-								// [DVR] Trace does not halt at 3D water crossings
-								// because we are only catching the crossing of the top surface/flat.
-								// In future, could extend to crossing water from the sides
-								Results->ffloor = rover;
-								TraceCallback(*Results, TraceCallbackData);
-								Results->ffloor = NULL;
-							}
 							Results->Distance = 0;
 						}
 					}
@@ -493,13 +483,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 				{
 					Results->CrossedWater = &Level->sectors[CurSector->sectornum];
 					Results->CrossedWaterPos = Results->HitPos;
-					if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-					{
-						// [DVR] Trace does not halt at water crossings even with a callback
-						TraceCallback(*Results, TraceCallbackData);
-					}
+					Results->Distance = 0;
 				}
-				Results->Distance = 0;
 			}
 		}
 	}
@@ -922,15 +907,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								Results->Crossed3DWater = rover;
 								Results->Crossed3DWaterPos = Results->HitPos;
-								if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-								{
-									// [DVR] Trace does not halt at 3D water crossings
-									// because we are only catching the crossing of the top surface/flat.
-									// In future, could extend to crossing water from the sides
-									Results->ffloor = rover;
-									TraceCallback(*Results, TraceCallbackData);
-									Results->ffloor = NULL;
-								}
 								Results->Distance = 0;
 							}
 						}
@@ -1025,15 +1001,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-											{
-												// [DVR] Trace does not halt at 3D water crossings
-												// because we are only catching the crossing of the top surface/flat.
-												// In future, could extend to crossing water from the sides
-												Results->ffloor = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->ffloor = NULL;
-											}
 											Results->Distance = 0;
 										}
 									}
@@ -1090,15 +1057,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-											{
-												// [DVR] Trace does not halt at 3D water crossings
-												// because we are only catching the crossing of the top surface/flat.
-												// In future, could extend to crossing water from the sides
-												Results->ffloor = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->ffloor = NULL;
-											}
 											Results->Distance = 0;
 										}
 									}

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -323,9 +323,9 @@ void FTraceInfo::Setup3DFloors()
 							{
 								Results->HitType = TRACE_HitFloor;
 								Results->HitVector = Vec;
-								TraceCallback(*Results, TraceCallbackData);
-								inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
 								Results->Crossed3DWater = NULL;
 								Results->HitType = TRACE_HitNone;
 							}
@@ -346,9 +346,9 @@ void FTraceInfo::Setup3DFloors()
 							{
 								Results->HitType = TRACE_HitCeiling;
 								Results->HitVector = Vec;
-								TraceCallback(*Results, TraceCallbackData);
-								inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
 								Results->Crossed3DWater = NULL;
 								Results->HitType = TRACE_HitNone;
 							}
@@ -665,6 +665,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = hit;
+							Results->entering3DLiquid = true;
 						}
 						if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 						{
@@ -683,6 +684,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			Results->ffloor = in3DLiquid;
 			Results->Crossed3DWater = in3DLiquid;
 			Results->Crossed3DWaterPos = hit;
+			Results->entering3DLiquid = false;
 			if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 			{
 				P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
@@ -979,9 +981,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 								{
 									Results->HitType = TRACE_HitFloor;
 									Results->HitVector = Vec;
-									TraceCallback(*Results, TraceCallbackData);
-									inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 									in3DLiquid = rover;
+									TraceCallback(*Results, TraceCallbackData);
 									Results->Crossed3DWater = NULL;
 									Results->HitType = TRACE_HitNone;
 								}
@@ -1003,9 +1005,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 								{
 									Results->HitType = TRACE_HitCeiling;
 									Results->HitVector = Vec;
-									TraceCallback(*Results, TraceCallbackData);
-									inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 									in3DLiquid = rover;
+									TraceCallback(*Results, TraceCallbackData);
 									Results->Crossed3DWater = NULL;
 									Results->HitType = TRACE_HitNone;
 								}
@@ -1108,9 +1110,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitFloor;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1132,9 +1134,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitCeiling;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1199,9 +1201,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitFloor;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1223,9 +1225,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitCeiling;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1442,6 +1444,7 @@ DEFINE_FIELD_NAMED_X(TraceResults, FTraceResults, Line, HitLine)
 DEFINE_FIELD_X(TraceResults, FTraceResults, Side)
 DEFINE_FIELD_X(TraceResults, FTraceResults, Tier)
 DEFINE_FIELD_X(TraceResults, FTraceResults, unlinked)
+DEFINE_FIELD_X(TraceResults, FTraceResults, entering3DLiquid)
 DEFINE_FIELD_X(TraceResults, FTraceResults, HitType)
 DEFINE_FIELD_X(TraceResults, FTraceResults, ffloor)
 DEFINE_FIELD_X(TraceResults, FTraceResults, CrossedWater)

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -71,8 +71,10 @@ struct FTraceInfo
 	// These are required for 3D-floor checking
 	// to create a fake sector with a floor 
 	// or ceiling plane coming from a 3D-floor
-	sector_t DummySector[2];	
-	int sectorsel;		
+	sector_t DummySector[2];
+	int sectorsel;
+	bool using3DFloorTop, using3DFloorBottom, inside3DFloor;
+	F3DFloor *usedTop, *usedBottom;
 
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
@@ -198,7 +200,7 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 	}
 
 	if (reslt)
-	{ 
+	{
 		return flags ? EditTraceResult(flags, res) : true;
 	}
 	else
@@ -216,7 +218,7 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 
 void FTraceInfo::EnterSectorPortal(FPathTraverse &pt, int position, double frac, sector_t *entersec)
 {
-	DVector2 displacement = entersec->GetPortalDisplacement(position);;
+	DVector2 displacement = entersec->GetPortalDisplacement(position);
 	double enterdist = MaxDist * frac;
 	DVector3 exit = Start + enterdist * Vec;
 	DVector3 enter = exit + displacement;
@@ -290,6 +292,12 @@ void FTraceInfo::EnterLinePortal(FPathTraverse &pt, intercept_t *in)
 void FTraceInfo::Setup3DFloors()
 {
 	TDeletingArray<F3DFloor*> &ff = CurSector->e->XFloor.ffloors;
+	using3DFloorTop = false;
+	using3DFloorBottom = false;
+	inside3DFloor = false;
+	usedTop = NULL;
+	usedBottom = NULL;
+	Results->ffloor = NULL;
 
 	if (ff.Size())
 	{
@@ -316,9 +324,21 @@ void FTraceInfo::Setup3DFloors()
 					// only consider if the plane is above the actual floor.
 					if (rover->top.plane->ZatPoint(Results->HitPos) > bf)
 					{
-						Results->Crossed3DWater = rover;
-						Results->Crossed3DWaterPos = Results->HitPos;
-						Results->Distance = 0;
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+							{
+								// [DVR] Trace does not halt at 3D water crossings
+								// because we are only catching the crossing of the top surface/flat.
+								// In future, could extend to crossing water from the sides
+								Results->ffloor = rover;
+								TraceCallback(*Results, TraceCallbackData);
+								Results->ffloor = NULL;
+							}
+							Results->Distance = 0;
+						}
 					}
 				}
 			}
@@ -337,6 +357,8 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::floor, *rover->top.texture, false);
 						CurSector->ClearPortal(sector_t::floor);
 						bf = ff_top;
+						using3DFloorTop = true;
+						usedTop = rover;
 					}
 				}
 				else if (pos.Z < ff_bottom)
@@ -348,17 +370,22 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::ceiling, *rover->bottom.texture, false);
 						bc = ff_bottom;
 						CurSector->ClearPortal(sector_t::ceiling);
+						using3DFloorBottom = true;
+						usedBottom = rover;
 					}
 				}
 				else
 				{
 					// inside
+					inside3DFloor = true;
 					if (bf < ff_bottom)
 					{
 						CurSector->floorplane = *rover->bottom.plane;
 						CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
 						CurSector->ClearPortal(sector_t::floor);
 						bf = ff_bottom;
+						using3DFloorBottom = true;
+						usedBottom = rover;
 					}
 
 					if (bc > ff_top)
@@ -367,6 +394,8 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
 						CurSector->ClearPortal(sector_t::ceiling);
 						bc = ff_top;
+						using3DFloorTop = true;
+						usedTop = rover;
 					}
 					inshootthrough = false;
 				}
@@ -387,7 +416,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 	int lineside;
 	sector_t *entersector;
 
-	double ff, fc, bf = 0, bc = 0;
+	double ff = FLT_MAX, fc = FLT_MIN, bf = 0, bc = 0;
+	bool OoBflag = false;
 
 	if (in->d.line->frontsector->sectornum == CurSector->sectornum)
 	{
@@ -413,7 +443,17 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 
 	if (!(in->d.line->flags & ML_TWOSIDED))
 	{
-		entersector = NULL;
+		lineside = P_PointOnLineSide(Start.XY(), in->d.line);
+		if (lineside == 1) // Trace coming in from Out of Bounds
+		{
+			entersector = in->d.line->frontsector;
+			CurSector = NULL;
+			lineside = 0;
+		}
+		else
+		{
+			entersector = NULL;
+		}
 	}
 	else
 	{
@@ -436,8 +476,33 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		}
 	}
 
-	ff = CurSector->floorplane.ZatPoint(hit);
-	fc = CurSector->ceilingplane.ZatPoint(hit);
+	if (CurSector != NULL)
+	{
+		ff = CurSector->floorplane.ZatPoint(hit);
+		fc = CurSector->ceilingplane.ZatPoint(hit);
+		sector_t *hsec = CurSector->GetHeightSec();
+		if (Results->CrossedWater == NULL &&
+			hsec != NULL &&
+			Start.Z > hsec->floorplane.ZatPoint(Start) &&
+			hit.Z <= hsec->floorplane.ZatPoint(hit))
+		{
+			// hit crossed a water plane
+			if (CheckSectorPlane(hsec, true))
+			{
+				if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+				{
+					Results->CrossedWater = &Level->sectors[CurSector->sectornum];
+					Results->CrossedWaterPos = Results->HitPos;
+					if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+					{
+						// [DVR] Trace does not halt at water crossings even with a callback
+						TraceCallback(*Results, TraceCallbackData);
+					}
+				}
+				Results->Distance = 0;
+			}
+		}
+	}
 
 	if (entersector != NULL)
 	{
@@ -445,44 +510,53 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		bc = entersector->ceilingplane.ZatPoint(hit);
 	}
 
-	sector_t *hsec = CurSector->GetHeightSec();
-	if (Results->CrossedWater == NULL &&
-		hsec != NULL &&
-		Start.Z > hsec->floorplane.ZatPoint(Start) &&
-		hit.Z <= hsec->floorplane.ZatPoint(hit))
-	{
-		// hit crossed a water plane
-		if (CheckSectorPlane(hsec, true))
-		{
-			Results->CrossedWater = &Level->sectors[CurSector->sectornum];
-			Results->CrossedWaterPos = Results->HitPos;
-			Results->Distance = 0;
-		}
-	}
-
-	if (hit.Z <= ff)
+	if (CurSector != NULL && hit.Z <= ff && (using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0)
 	{
 		// hit floor in front of wall
-		Results->HitType = TRACE_HitFloor;
+		Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
 		Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+		if (using3DFloorTop) Results->ffloor = usedTop;
+		else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 	}
-	else if (hit.Z >= fc)
+	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
 	{
 		// hit ceiling in front of wall
-		Results->HitType = TRACE_HitCeiling;
+		Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 		Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+		if (using3DFloorBottom) Results->ffloor = usedBottom;
+		else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
 	}
 	else if (entersector == NULL ||
 		hit.Z < bf || hit.Z > bc ||
 		((in->d.line->flags & WallMask) && !special3dpass))
 	{
 		// hit the wall
-		Results->HitType = TRACE_HitWall;
 		Results->Tier =
 			entersector == NULL ? TIER_Middle :
 			hit.Z <= bf ? TIER_Lower :
 			hit.Z >= bc ? TIER_Upper : TIER_Middle;
-		if ((TraceFlags & TRACE_Impact) && !special3dpass)
+		switch (Results->Tier)
+		{
+		case TIER_Lower:
+			if (CurSector != NULL && hit.Z >= ff) Results->HitType = TRACE_HitWall;
+			else
+			{
+				Results->HitType = TRACE_HitNone;
+				OoBflag = true;
+			}
+			break;
+		case TIER_Upper:
+			if (CurSector != NULL && hit.Z <= fc) Results->HitType = TRACE_HitWall;
+			else
+			{
+				Results->HitType = TRACE_HitNone;
+				OoBflag = true;
+			}
+			break;
+		default:
+			Results->HitType = TRACE_HitWall;
+		}
+		if ((Results->HitType == TRACE_HitWall) && (TraceFlags & TRACE_Impact) && !special3dpass)
 		{
 			P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
 		}
@@ -499,6 +573,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			// We need to make sure that 3D floors clipping underneath the ground/above the ceiling don't
 			// accidentally get ignored.
 			bool setFloor = false, setCeiling = false;
+			using3DFloorBottom = false;
+			using3DFloorTop = false;
 
 			for (auto rover : entersector->e->XFloor.ffloors)
 			{
@@ -531,6 +607,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							entersector->SetTexture(sector_t::floor, *rover->top.texture, false);
 							entersector->ClearPortal(sector_t::floor);
 							bf = ff_top;
+							using3DFloorTop = true;
+							usedTop = rover;
 						}
 					}
 					else if (hit.Z < ff_bottom)
@@ -554,6 +632,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							entersector->SetTexture(sector_t::ceiling, *rover->bottom.texture, false);
 							entersector->ClearPortal(sector_t::ceiling);
 							bc = ff_bottom;
+							using3DFloorBottom = true;
+							usedBottom = rover;
 						}
 					}
 					else
@@ -591,10 +671,11 @@ cont:
 	if (Results->HitType != TRACE_HitNone)
 	{
 		// We hit something, so figure out where exactly
-		Results->Sector = &Level->sectors[CurSector->sectornum];
+		if (CurSector != NULL) Results->Sector = &Level->sectors[CurSector->sectornum];
+		else if (entersector != NULL) Results->Sector = &Level->sectors[entersector->sectornum];
 
 		if (Results->HitType != TRACE_HitWall &&
-			!CheckSectorPlane(CurSector, Results->HitType == TRACE_HitFloor))
+			CurSector != NULL && !CheckSectorPlane(CurSector, Results->HitType == (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor)))
 		{ // trace is parallel to the plane (or right on it)
 			if (entersector == NULL)
 			{
@@ -631,6 +712,11 @@ cont:
 			Results->Side = lineside;
 		}
 	}
+	if (CurSector == NULL && entersector)
+	{
+		CurSector = entersector; // Trace probably came in from out of bounds, but we can't let CurSector be NULL after LineCheck() returns
+		Results->Sector = CurSector;
+	}
 
 	if (TraceCallback != NULL && Results->HitType != TRACE_HitNone)
 	{
@@ -640,6 +726,13 @@ cont:
 			return false;
 
 		case TRACE_ContinueOutOfBounds:
+			if (Results->ffloor)
+			{
+				startfrac = Results->Fraction + EQUAL_EPSILON;
+				CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
+				Setup3DFloors();
+				if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+			}
 			return true;
 
 		case TRACE_Abort:
@@ -661,6 +754,11 @@ cont:
 	{
 		CurSector = entersector;
 		EnterDist = dist;
+		if (OoBflag)
+		{
+			startfrac = in->frac + EQUAL_EPSILON;
+			Setup3DFloors();
+		}
 		return true;
 	}
 	else
@@ -719,20 +817,24 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 
 		if (hit.Z > ff_ceiling && CurSector->PortalBlocksMovement(sector_t::ceiling))	// actor is hit above the current ceiling
 		{
-			Results->HitType = TRACE_HitCeiling;
+			Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 			Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+			if (using3DFloorBottom) Results->ffloor = usedBottom;
+			else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
 		}
 		else if (hit.Z < ff_floor && CurSector->PortalBlocksMovement(sector_t::floor))	// actor is hit below the current floor
 		{
-			Results->HitType = TRACE_HitFloor;
+			Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
 			Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+			if (using3DFloorTop) Results->ffloor = usedTop;
+			else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 		}
 		else goto cont1;
 
 		// the trace hit a 3D floor before the thing.
 		// Calculate an intersection and abort.
 		Results->Sector = &Level->sectors[CurSector->sectornum];
-		if (!CheckSectorPlane(CurSector, Results->HitType == TRACE_HitFloor))
+		if (!CheckSectorPlane(CurSector, Results->HitType == (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor)))
 		{
 			Results->HitType = TRACE_HitNone;
 		}
@@ -741,7 +843,15 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 			switch (TraceCallback(*Results, TraceCallbackData))
 			{
 			case TRACE_Continue: return true;
-			case TRACE_ContinueOutOfBounds: return true;
+			case TRACE_ContinueOutOfBounds:
+				if (Results->ffloor && (Results->HitType != TRACE_HitNone))
+				{
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = Results->Sector;
+					Setup3DFloors();
+					return ThingCheck(in, dist, hit);
+				}
+				return true;
 			case TRACE_Stop:	 return false;
 			case TRACE_Abort:	 Results->HitType = TRACE_HitNone; return false;
 			case TRACE_Skip:	 Results->HitType = TRACE_HitNone; return true;
@@ -792,6 +902,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 	FPathTraverse it(Level, Start.X, Start.Y, Vec.X * MaxDist, Vec.Y * MaxDist, ptflags | PT_DELTA, startfrac);
 	intercept_t *in;
 	int lastsplashsector = -1;
+	bool lastflathit = false;
 
 	while ((in = it.Next()))
 	{
@@ -807,9 +918,21 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 						// only consider if the plane is above the actual floor.
 						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
 						{
-							Results->Crossed3DWater = rover;
-							Results->Crossed3DWaterPos = Results->HitPos;
-							Results->Distance = 0;
+							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+							{
+								Results->Crossed3DWater = rover;
+								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+								{
+									// [DVR] Trace does not halt at 3D water crossings
+									// because we are only catching the crossing of the top surface/flat.
+									// In future, could extend to crossing water from the sides
+									Results->ffloor = rover;
+									TraceCallback(*Results, TraceCallbackData);
+									Results->ffloor = NULL;
+								}
+								Results->Distance = 0;
+							}
 						}
 					}
 				}
@@ -869,17 +992,182 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		}
 	}
 
+	// Check for sector portals when no line or thing was crossed
 	if (Results->HitType == TRACE_HitNone)
 	{
-		if (CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
+		// Crossed a floor portals?
+		while (Vec.Z < 0 && !CurSector->PortalBlocksMovement(sector_t::floor))
 		{
-			Results->HitType = TRACE_HitFloor;
-			Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+			double dist2 = MaxDist;
+			DVector3 hit2 = Start + Vec * MaxDist;
+			// calculate position where the portal is crossed
+			double portz = CurSector->GetPortalPlaneZ(sector_t::floor);
+			if (hit2.Z < portz && limitz > portz)
+			{
+				limitz = portz;
+				EnterSectorPortal(it, sector_t::floor, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
+				bool actorfound = false;
+				while ((in = it.Next()))
+				{
+					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
+					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
+					{
+						for (auto rover : CurSector->e->XFloor.ffloors)
+						{
+							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
+							{
+								if (Check3DFloorPlane(rover, false))
+								{
+									// only consider if the plane is above the actual floor.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+											{
+												// [DVR] Trace does not halt at 3D water crossings
+												// because we are only catching the crossing of the top surface/flat.
+												// In future, could extend to crossing water from the sides
+												Results->ffloor = rover;
+												TraceCallback(*Results, TraceCallbackData);
+												Results->ffloor = NULL;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+							}
+						}
+						lastsplashsector = CurSector->sectornum;
+					}
+					dist2 = MaxDist * in->frac;
+					hit2 = Start + Vec * dist2;
+					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
+					{
+						if (!ThingCheck(in, dist2, hit2))
+						{
+							actorfound = true;
+							break;
+						}
+					}
+				}
+				if (actorfound) break;
+			}
+			else
+			{
+				break;
+			}
 		}
-		else if (CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+		// ... or a ceiling portals?
+		while (Vec.Z > 0 && !CurSector->PortalBlocksMovement(sector_t::ceiling))
 		{
-			Results->HitType = TRACE_HitCeiling;
-			Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+			double dist2 = MaxDist;
+			DVector3 hit2 = Start + Vec * dist2;
+			// calculate position where the portal is crossed
+			double portz = CurSector->GetPortalPlaneZ(sector_t::ceiling);
+			if (hit2.Z > portz && limitz < portz)
+			{
+				limitz = portz;
+				EnterSectorPortal(it, sector_t::ceiling, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
+				bool actorfound = false;
+				while ((in = it.Next()))
+				{
+					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
+					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
+					{
+						for (auto rover : CurSector->e->XFloor.ffloors)
+						{
+							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
+							{
+								if (Check3DFloorPlane(rover, false))
+								{
+									// only consider if the plane is above the actual floor.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+											{
+												// [DVR] Trace does not halt at 3D water crossings
+												// because we are only catching the crossing of the top surface/flat.
+												// In future, could extend to crossing water from the sides
+												Results->ffloor = rover;
+												TraceCallback(*Results, TraceCallbackData);
+												Results->ffloor = NULL;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+							}
+						}
+						lastsplashsector = CurSector->sectornum;
+					}
+					dist2 = MaxDist * in->frac;
+					hit2 = Start + Vec * dist2;
+					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
+					{
+						if (!ThingCheck(in, dist2, hit2))
+						{
+							actorfound = true;
+							break;
+						}
+					}
+				}
+				if (actorfound) break;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	// Check for intersection with flats when no line or thing was crossed
+	if (Results->HitType == TRACE_HitNone)
+	{
+		while (!lastflathit)
+		{
+			if ((using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
+			{
+				Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
+				Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+				lastflathit = true;
+				if (using3DFloorTop) Results->ffloor = usedTop;
+				else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
+				else Results->ffloor = NULL;
+			}
+			else if ((using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+			{
+				Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
+				Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+				lastflathit = true;
+				if (using3DFloorBottom) Results->ffloor = usedBottom;
+				else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
+				else Results->ffloor = NULL;
+			}
+			if (lastflathit && (TraceCallback != NULL))
+			{
+				// [DVR] Call TraceCallback for the last floor/ceiling hit without crossing a line or thing
+				F3DFloor* Rff = Results->ffloor;
+				Results->Sector = &Level->sectors[CurSector->sectornum];
+				ETraceStatus mytracestatus = TraceCallback(*Results, TraceCallbackData);
+				if ((mytracestatus  == TRACE_ContinueOutOfBounds) && Rff)
+				{
+					lastflathit = false;
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = Results->Sector;
+					Setup3DFloors();
+				}
+			}
+			else
+			{
+				break;
+			}
 		}
 	}
 
@@ -917,40 +1205,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		Results->Fraction = 1.;
 	}
 
-	// [MK] set 3d floor on plane hits (if any)
-	// modders will need this to get accurate plane normals on slopes
-	if (Results->HitType == TRACE_HitFloor)
-	{
-		double secbottom = Results->Sector->floorplane.ZatPoint(Results->HitPos);
-		for (auto rover : Results->Sector->e->XFloor.ffloors)
-		{
-			if (!(rover->flags&FF_EXISTS))
-				continue;
-			double ff_top = rover->top.plane->ZatPoint(Results->HitPos);
-			if (fabs(ff_top-secbottom) < EQUAL_EPSILON)
-				continue;
-			if (fabs(ff_top-Results->HitPos.Z) > EQUAL_EPSILON)
-				continue;
-			Results->ffloor = rover;
-			break;
-		}
-	}
-	else if (Results->HitType == TRACE_HitCeiling)
-	{
-		double sectop = Results->Sector->ceilingplane.ZatPoint(Results->HitPos);
-		for (auto rover : Results->Sector->e->XFloor.ffloors)
-		{
-			if (!(rover->flags&FF_EXISTS))
-				continue;
-			double ff_bottom = rover->bottom.plane->ZatPoint(Results->HitPos);
-			if (fabs(ff_bottom-sectop) < EQUAL_EPSILON)
-				continue;
-			if (fabs(ff_bottom-Results->HitPos.Z) > EQUAL_EPSILON)
-				continue;
-			Results->ffloor = rover;
-			break;
-		}
-	}
 	return Results->HitType != TRACE_HitNone;
 }
 
@@ -1032,6 +1286,7 @@ static bool EditTraceResult (uint32_t flags, FTraceResults &res)
 			}
 		}
 	}
+
 	return true;
 }
 

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -334,9 +334,9 @@ void FTraceInfo::Setup3DFloors()
 							{
 								Results->HitType = TRACE_HitFloor;
 								Results->HitVector = Vec;
-								TraceCallback(*Results, TraceCallbackData);
-								inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
 								Results->Crossed3DWater = NULL;
 								Results->HitType = TRACE_HitNone;
 							}
@@ -357,9 +357,9 @@ void FTraceInfo::Setup3DFloors()
 							{
 								Results->HitType = TRACE_HitCeiling;
 								Results->HitVector = Vec;
-								TraceCallback(*Results, TraceCallbackData);
-								inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
 								Results->Crossed3DWater = NULL;
 								Results->HitType = TRACE_HitNone;
 							}
@@ -676,6 +676,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = hit;
+							Results->entering3DLiquid = true;
 						}
 						if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 						{
@@ -694,6 +695,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			Results->ffloor = in3DLiquid;
 			Results->Crossed3DWater = in3DLiquid;
 			Results->Crossed3DWaterPos = hit;
+			Results->entering3DLiquid = false;
 			if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 			{
 				P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
@@ -990,9 +992,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 								{
 									Results->HitType = TRACE_HitFloor;
 									Results->HitVector = Vec;
-									TraceCallback(*Results, TraceCallbackData);
-									inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 									in3DLiquid = rover;
+									TraceCallback(*Results, TraceCallbackData);
 									Results->Crossed3DWater = NULL;
 									Results->HitType = TRACE_HitNone;
 								}
@@ -1014,9 +1016,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 								{
 									Results->HitType = TRACE_HitCeiling;
 									Results->HitVector = Vec;
-									TraceCallback(*Results, TraceCallbackData);
-									inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 									in3DLiquid = rover;
+									TraceCallback(*Results, TraceCallbackData);
 									Results->Crossed3DWater = NULL;
 									Results->HitType = TRACE_HitNone;
 								}
@@ -1119,9 +1121,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitFloor;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1143,9 +1145,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitCeiling;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1210,9 +1212,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitFloor;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1234,9 +1236,9 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 											{
 												Results->HitType = TRACE_HitCeiling;
 												Results->HitVector = Vec;
-												TraceCallback(*Results, TraceCallbackData);
-												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
 												in3DLiquid = rover;
+												TraceCallback(*Results, TraceCallbackData);
 												Results->Crossed3DWater = NULL;
 												Results->HitType = TRACE_HitNone;
 											}
@@ -1453,6 +1455,7 @@ DEFINE_FIELD_NAMED_X(TraceResults, FTraceResults, Line, HitLine)
 DEFINE_FIELD_X(TraceResults, FTraceResults, Side)
 DEFINE_FIELD_X(TraceResults, FTraceResults, Tier)
 DEFINE_FIELD_X(TraceResults, FTraceResults, unlinked)
+DEFINE_FIELD_X(TraceResults, FTraceResults, entering3DLiquid)
 DEFINE_FIELD_X(TraceResults, FTraceResults, HitType)
 DEFINE_FIELD_X(TraceResults, FTraceResults, ffloor)
 DEFINE_FIELD_X(TraceResults, FTraceResults, CrossedWater)

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -198,7 +198,6 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 	}
 }
 
-
 //============================================================================
 //
 // traverses a sector portal
@@ -317,15 +316,6 @@ void FTraceInfo::Setup3DFloors()
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = Results->HitPos;
-							if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-							{
-								// [DVR] Trace does not halt at 3D water crossings
-								// because we are only catching the crossing of the top surface/flat.
-								// In future, could extend to crossing water from the sides
-								Results->ffloor = rover;
-								TraceCallback(*Results, TraceCallbackData);
-								Results->ffloor = NULL;
-							}
 							Results->Distance = 0;
 						}
 					}
@@ -482,13 +472,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 				{
 					Results->CrossedWater = &Level->sectors[CurSector->sectornum];
 					Results->CrossedWaterPos = Results->HitPos;
-					if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-					{
-						// [DVR] Trace does not halt at water crossings even with a callback
-						TraceCallback(*Results, TraceCallbackData);
-					}
+					Results->Distance = 0;
 				}
-				Results->Distance = 0;
 			}
 		}
 	}
@@ -911,15 +896,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								Results->Crossed3DWater = rover;
 								Results->Crossed3DWaterPos = Results->HitPos;
-								if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-								{
-									// [DVR] Trace does not halt at 3D water crossings
-									// because we are only catching the crossing of the top surface/flat.
-									// In future, could extend to crossing water from the sides
-									Results->ffloor = rover;
-									TraceCallback(*Results, TraceCallbackData);
-									Results->ffloor = NULL;
-								}
 								Results->Distance = 0;
 							}
 						}
@@ -1014,15 +990,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-											{
-												// [DVR] Trace does not halt at 3D water crossings
-												// because we are only catching the crossing of the top surface/flat.
-												// In future, could extend to crossing water from the sides
-												Results->ffloor = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->ffloor = NULL;
-											}
 											Results->Distance = 0;
 										}
 									}
@@ -1079,15 +1046,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
-											{
-												// [DVR] Trace does not halt at 3D water crossings
-												// because we are only catching the crossing of the top surface/flat.
-												// In future, could extend to crossing water from the sides
-												Results->ffloor = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->ffloor = NULL;
-											}
 											Results->Distance = 0;
 										}
 									}

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -799,7 +799,7 @@ cont:
 
 bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 {
-	if (hit.Z > in->d.thing->Top())
+	if (hit.Z >= in->d.thing->Top())
 	{
 		// trace enters above actor
 		if (Vec.Z >= 0) return true;      // Going up: can't hit
@@ -816,7 +816,7 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 		if (fabs(hit.X - in->d.thing->X()) > in->d.thing->radius ||
 			fabs(hit.Y - in->d.thing->Y()) > in->d.thing->radius) return true;
 	}
-	else if (hit.Z < in->d.thing->Z())
+	else if (hit.Z <= in->d.thing->Z())
 	{ // trace enters below actor
 		if (Vec.Z <= 0) return true;      // Going down: can't hit
 

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -549,6 +549,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 	else
 	{ 	// made it past the wall
 		// check for 3D floors first
+		using3DFloorBottom = false;
+		using3DFloorTop = false;
 		if (entersector->e->XFloor.ffloors.Size())
 		{
 			memcpy(&DummySector[sectorsel], entersector, sizeof(sector_t));
@@ -558,8 +560,6 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			// We need to make sure that 3D floors clipping underneath the ground/above the ceiling don't
 			// accidentally get ignored.
 			bool setFloor = false, setCeiling = false;
-			using3DFloorBottom = false;
-			using3DFloorTop = false;
 
 			for (auto rover : entersector->e->XFloor.ffloors)
 			{

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -538,6 +538,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 	else
 	{ 	// made it past the wall
 		// check for 3D floors first
+		using3DFloorBottom = false;
+		using3DFloorTop = false;
 		if (entersector->e->XFloor.ffloors.Size())
 		{
 			memcpy(&DummySector[sectorsel], entersector, sizeof(sector_t));
@@ -547,8 +549,6 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			// We need to make sure that 3D floors clipping underneath the ground/above the ceiling don't
 			// accidentally get ignored.
 			bool setFloor = false, setCeiling = false;
-			using3DFloorBottom = false;
-			using3DFloorTop = false;
 
 			for (auto rover : entersector->e->XFloor.ffloors)
 			{

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -62,8 +62,8 @@ struct FTraceInfo
 	// or ceiling plane coming from a 3D-floor
 	sector_t DummySector[2];
 	int sectorsel;
-	bool using3DFloorTop, using3DFloorBottom, inside3DFloor;
-	F3DFloor *usedTop, *usedBottom;
+	bool using3DFloorTop, using3DFloorBottom, inside3DFloor, inside3DLiquid;
+	F3DFloor *usedTop, *usedBottom, *in3DLiquid;
 
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
@@ -283,6 +283,7 @@ void FTraceInfo::Setup3DFloors()
 	using3DFloorTop = false;
 	using3DFloorBottom = false;
 	inside3DFloor = false;
+	inside3DLiquid = false;
 	usedTop = NULL;
 	usedBottom = NULL;
 	Results->ffloor = NULL;
@@ -305,7 +306,9 @@ void FTraceInfo::Setup3DFloors()
 			if (!(rover->flags&FF_EXISTS))
 				continue;
 
-			if (Results->Crossed3DWater == NULL)
+			// [DVR] This block seems redundant. I'll leave it commented out instead of deleting it, in case it ends up being needed
+			/*
+			if (Results->Crossed3DWater == NULL || (TraceFlags & TRACE_3DLiquidCallback))
 			{
 				if (Check3DFloorPlane(rover, false) && isLiquid(rover))
 				{
@@ -316,18 +319,52 @@ void FTraceInfo::Setup3DFloors()
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitFloor;
+								Results->HitVector = Vec;
+								TraceCallback(*Results, TraceCallbackData);
+								inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
+							Results->Distance = 0;
+						}
+					}
+				}
+				if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true) && isLiquid(rover))
+				{
+					// only consider if the bottom plane is below the actual ceiling.
+					if (rover->bottom.plane->ZatPoint(Results->HitPos) < bc)
+					{
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitCeiling;
+								Results->HitVector = Vec;
+								TraceCallback(*Results, TraceCallbackData);
+								inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
 							Results->Distance = 0;
 						}
 					}
 				}
 			}
+			*/
 
-			if (!(rover->flags&FF_SHOOTTHROUGH))
+			if (!(rover->flags&FF_SHOOTTHROUGH) || (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 			{
 				double ff_bottom = rover->bottom.plane->ZatPoint(pos);
 				double ff_top = rover->top.plane->ZatPoint(pos);
 				// clip to the part of the sector we are in
-				if (pos.Z > ff_top)
+				if (pos.Z > ff_top && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 				{
 					// above
 					if (bf < ff_top)
@@ -340,7 +377,7 @@ void FTraceInfo::Setup3DFloors()
 						usedTop = rover;
 					}
 				}
-				else if (pos.Z < ff_bottom)
+				else if (pos.Z < ff_bottom && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 				{
 					//below
 					if (bc > ff_bottom)
@@ -353,30 +390,38 @@ void FTraceInfo::Setup3DFloors()
 						usedBottom = rover;
 					}
 				}
-				else
+				else if (pos.Z < ff_top && pos.Z > ff_bottom)
 				{
 					// inside
-					inside3DFloor = true;
-					if (bf < ff_bottom)
+					if (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover))
 					{
-						CurSector->floorplane = *rover->bottom.plane;
-						CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
-						CurSector->ClearPortal(sector_t::floor);
-						bf = ff_bottom;
-						using3DFloorBottom = true;
-						usedBottom = rover;
+						inside3DLiquid = true;
+						in3DLiquid = rover;
 					}
+					else
+					{
+						inside3DFloor = true;
+						if (bf < ff_bottom)
+						{
+							CurSector->floorplane = *rover->bottom.plane;
+							CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
+							CurSector->ClearPortal(sector_t::floor);
+							bf = ff_bottom;
+							using3DFloorBottom = true;
+							usedBottom = rover;
+						}
 
-					if (bc > ff_top)
-					{
-						CurSector->ceilingplane = *rover->top.plane;
-						CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
-						CurSector->ClearPortal(sector_t::ceiling);
-						bc = ff_top;
-						using3DFloorTop = true;
-						usedTop = rover;
+						if (bc > ff_top)
+						{
+							CurSector->ceilingplane = *rover->top.plane;
+							CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
+							CurSector->ClearPortal(sector_t::ceiling);
+							bc = ff_top;
+							using3DFloorTop = true;
+							usedTop = rover;
+						}
+						inshootthrough = false;
 					}
-					inshootthrough = false;
 				}
 			}
 		}
@@ -554,13 +599,13 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			{
 				int entershootthrough = !!(rover->flags&FF_SHOOTTHROUGH);
 
-				if (entershootthrough != inshootthrough && rover->flags&FF_EXISTS)
+				if (rover->flags&FF_EXISTS && (entershootthrough != inshootthrough || (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover))))
 				{
 					double ff_bottom = rover->bottom.plane->ZatPoint(hit);
 					double ff_top = rover->top.plane->ZatPoint(hit);
 
 					// clip to the part of the sector we are in
-					if (hit.Z > ff_top)
+					if (hit.Z > ff_top && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 					{
 						// 3D floor height is the same as the floor height or underground. We need to test a second spot to see if it is above or below
 						if ((ff_top < bf && !setFloor) || fabs(bf - ff_top) < EQUAL_EPSILON)
@@ -585,7 +630,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							usedTop = rover;
 						}
 					}
-					else if (hit.Z < ff_bottom)
+					else if (hit.Z < ff_bottom && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 					{
 						// 3D floor height is the same as the ceiling height or above it. We need to test a second spot to see if it is above or below
 						if ((ff_bottom > bc && !setCeiling) || fabs(bc - ff_bottom) < EQUAL_EPSILON)
@@ -610,12 +655,17 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							usedBottom = rover;
 						}
 					}
-					else
+					else if (hit.Z > ff_bottom && hit.Z < ff_top)
 					{
 						//hit the edge - equivalent to hitting the wall
 						Results->HitType = TRACE_HitWall;
 						Results->Tier = TIER_FFloor;
 						Results->ffloor = rover;
+						if (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover) && !inside3DLiquid)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = hit;
+						}
 						if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 						{
 							P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
@@ -624,6 +674,20 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 					}
 				}
 			}
+		}
+
+		if (inside3DLiquid && TraceFlags & TRACE_3DLiquidCallback)
+		{
+			Results->HitType = TRACE_HitWall;
+			Results->Tier = TIER_FFloor;
+			Results->ffloor = in3DLiquid;
+			Results->Crossed3DWater = in3DLiquid;
+			Results->Crossed3DWaterPos = hit;
+			if ((TraceFlags & TRACE_Impact) && in->d.line->special)
+			{
+				P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
+			}
+			goto cont;
 		}
 
 		Results->HitType = TRACE_HitNone;
@@ -694,33 +758,47 @@ cont:
 
 	if (TraceCallback != NULL && Results->HitType != TRACE_HitNone)
 	{
-		switch (TraceCallback(*Results, TraceCallbackData))
+		if (TraceFlags & TRACE_3DLiquidCallback && Results->Crossed3DWater != NULL)
 		{
-		case TRACE_Stop:
-			return false;
-
-		case TRACE_ContinueOutOfBounds:
-			if (Results->ffloor)
+			// Callback and fall through
+			TraceCallback(*Results, TraceCallbackData);
+			Results->Crossed3DWater = NULL;
+			Results->HitType = TRACE_HitNone;
+			Results->ffloor = NULL;
+			Results->Line = NULL;
+			Results->Distance = 0;
+			OoBflag = true;
+		}
+		else
+		{
+			switch (TraceCallback(*Results, TraceCallbackData))
 			{
-				startfrac = Results->Fraction + EQUAL_EPSILON;
-				CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
-				Setup3DFloors();
-				if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+			case TRACE_Stop:
+				return false;
+
+			case TRACE_ContinueOutOfBounds:
+				if (Results->ffloor)
+				{
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
+					Setup3DFloors();
+					if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+				}
+				return true;
+
+			case TRACE_Abort:
+				Results->HitType = TRACE_HitNone;
+				return false;
+
+			case TRACE_Skip:
+				Results->HitType = TRACE_HitNone;
+				if (!special3dpass && (TraceFlags & TRACE_3DCallback) && entersector && entersector->e->XFloor.ffloors.Size())
+					return LineCheck(in, dist, hit, true);
+				break;
+
+			default:
+				break;
 			}
-			return true;
-
-		case TRACE_Abort:
-			Results->HitType = TRACE_HitNone;
-			return false;
-
-		case TRACE_Skip:
-			Results->HitType = TRACE_HitNone;
-			if (!special3dpass && (TraceFlags & TRACE_3DCallback) && entersector && entersector->e->XFloor.ffloors.Size())
-				return LineCheck(in, dist, hit, true);
-			break;
-
-		default:
-			break;
 		}
 	}
 
@@ -889,13 +967,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				{
 					if (Check3DFloorPlane(rover, false))
 					{
-						// only consider if the plane is above the actual floor.
-						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+						// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+							&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 						{
 							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 							{
 								Results->Crossed3DWater = rover;
 								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+								{
+									Results->HitType = TRACE_HitFloor;
+									Results->HitVector = Vec;
+									TraceCallback(*Results, TraceCallbackData);
+									inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+									in3DLiquid = rover;
+									Results->Crossed3DWater = NULL;
+									Results->HitType = TRACE_HitNone;
+								}
+								Results->Distance = 0;
+							}
+						}
+					}
+					if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+					{
+						// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+						if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+							&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+						{
+							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+							{
+								Results->Crossed3DWater = rover;
+								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+								{
+									Results->HitType = TRACE_HitCeiling;
+									Results->HitVector = Vec;
+									TraceCallback(*Results, TraceCallbackData);
+									inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+									in3DLiquid = rover;
+									Results->Crossed3DWater = NULL;
+									Results->HitType = TRACE_HitNone;
+								}
 								Results->Distance = 0;
 							}
 						}
@@ -983,13 +1096,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								if (Check3DFloorPlane(rover, false))
 								{
-									// only consider if the plane is above the actual floor.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 									{
 										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitFloor;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+								{
+									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitCeiling;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
 											Results->Distance = 0;
 										}
 									}
@@ -1039,13 +1187,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								if (Check3DFloorPlane(rover, false))
 								{
-									// only consider if the plane is above the actual floor.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 									{
 										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitFloor;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+								{
+									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitCeiling;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
 											Results->Distance = 0;
 										}
 									}

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -174,7 +174,8 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 
 	// [DVR] Future person looking at this. These two ReportPortals blocks are necessary for
 	// the for-loop over TArray<SPortalHit> &portalhits argument of P_DrawRailTrail() function
-	// in /src/playsim/p_effect.cpp
+	// in /src/playsim/p_effect.cpp. Also the reason P_LineTrace() is having NumPortals field
+	// manually reduced by 2 in /src/playsim/p_map.cpp.
 	if ((flags & TRACE_ReportPortals) && callback != NULL)
 	{
 		tempResult.HitType = TRACE_CrossingPortal;
@@ -232,11 +233,11 @@ void FTraceInfo::EnterSectorPortal(FPathTraverse &pt, int position, double frac,
 		Results->SrcAngleFromTarget = Vec.Angle();
 		Results->Fraction = frac;
 		Results->Line = NULL;
-		Results->Sector = entersec->GetPortal(position)->mDestination;
+		Results->Sector = CurSector;
 		Results->Distance = enterdist;
 		TraceCallback(*Results, TraceCallbackData);
 		Results->HitType = TRACE_HitNone;
-		Results->Sector = NULL;
+		Results->HitPos = enter; // Used if TRACE_HitNone occurs
 	}
 
 	Setup3DFloors();
@@ -283,10 +284,11 @@ void FTraceInfo::EnterLinePortal(FPathTraverse &pt, intercept_t *in)
 		Results->Line = li;
 		Results->Side = 0;
 		Results->Sector = li->frontsector;
+		Results->Distance = enterdist;
 		TraceCallback(*Results, TraceCallbackData);
 		Results->HitType = TRACE_HitNone;
-		Results->Sector = NULL;
 		Results->Line = NULL;
+		Results->HitPos = exit; // Used if TRACE_HitNone occurs
 	}
 }
 
@@ -1053,14 +1055,14 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 	// Check for sector portals when no line or thing was crossed
 	if (Results->HitType == TRACE_HitNone)
 	{
-		// Crossed a floor portals?
-		while (Vec.Z < 0 && !CurSector->PortalBlocksMovement(sector_t::floor))
+		// Crossed a floor portal?
+		if (Vec.Z < 0 && !CurSector->PortalBlocksMovement(sector_t::floor))
 		{
-			double dist2 = MaxDist;
-			DVector3 hit2 = Start + Vec * MaxDist;
+			double dist = MaxDist;
+			DVector3 hit = Start + Vec * MaxDist;
 			// calculate position where the portal is crossed
 			double portz = CurSector->GetPortalPlaneZ(sector_t::floor);
-			if (hit2.Z < portz && limitz > portz)
+			if (hit.Z < portz && limitz > portz)
 			{
 				limitz = portz;
 				EnterSectorPortal(it, sector_t::floor, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
@@ -1068,32 +1070,30 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				while ((in = it.Next()))
 				{
 					Trace3DFloors(&lastsplashsector);
-					dist2 = MaxDist * in->frac;
-					hit2 = Start + Vec * dist2;
+					dist = MaxDist * in->frac;
+					hit = Start + Vec * dist;
 					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
 					{
-						if (!ThingCheck(in, dist2, hit2))
+						if (!ThingCheck(in, dist, hit))
 						{
 							actorfound = true;
 							break;
 						}
 					}
 				}
-				if (actorfound) break;
-			}
-			else
-			{
-				break;
+				if (!actorfound) return TraceTraverse(ptflags); // recursive restart
+				// [DVR] Recursive since the two sides of sector portals can have independent decorations
+				// so just because we saw no line intercepts on one side doesn't mean that there won't be
+				// any on the other side.
 			}
 		}
-		// ... or a ceiling portals?
-		while (Vec.Z > 0 && !CurSector->PortalBlocksMovement(sector_t::ceiling))
+		else if (Vec.Z > 0 && !CurSector->PortalBlocksMovement(sector_t::ceiling)) // ... or a ceiling portal?
 		{
-			double dist2 = MaxDist;
-			DVector3 hit2 = Start + Vec * dist2;
+			double dist = MaxDist;
+			DVector3 hit = Start + Vec * MaxDist;
 			// calculate position where the portal is crossed
 			double portz = CurSector->GetPortalPlaneZ(sector_t::ceiling);
-			if (hit2.Z > portz && limitz < portz)
+			if (hit.Z > portz && limitz < portz)
 			{
 				limitz = portz;
 				EnterSectorPortal(it, sector_t::ceiling, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
@@ -1101,22 +1101,21 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				while ((in = it.Next()))
 				{
 					Trace3DFloors(&lastsplashsector);
-					dist2 = MaxDist * in->frac;
-					hit2 = Start + Vec * dist2;
+					dist = MaxDist * in->frac;
+					hit = Start + Vec * dist;
 					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
 					{
-						if (!ThingCheck(in, dist2, hit2))
+						if (!ThingCheck(in, dist, hit))
 						{
 							actorfound = true;
 							break;
 						}
 					}
 				}
-				if (actorfound) break;
-			}
-			else
-			{
-				break;
+				if (!actorfound) return TraceTraverse(ptflags); // recursive restart
+				// [DVR] Recursive since the two sides of sector portals can have independent decorations
+				// so just because we saw no line intercepts on one side doesn't mean that there won't be
+				// any on the other side.
 			}
 		}
 	}

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -68,6 +68,7 @@ struct FTraceInfo
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
 	bool ThingCheck(intercept_t *in, double dist, DVector3 hit);
+	void Trace3DFloors(int *lastsplashsector);
 	bool TraceTraverse (int ptflags);
 	bool CheckPlane(const secplane_t &plane);
 	void EnterLinePortal(FPathTraverse &pt, intercept_t *in);
@@ -171,6 +172,9 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 	inf.limitz = inf.Start.Z;
 	memset(&res, 0, sizeof(res));
 
+	// [DVR] Future person looking at this. These two ReportPortals blocks are necessary for
+	// the for-loop over TArray<SPortalHit> &portalhits argument of P_DrawRailTrail() function
+	// in /src/playsim/p_effect.cpp
 	if ((flags & TRACE_ReportPortals) && callback != NULL)
 	{
 		tempResult.HitType = TRACE_CrossingPortal;
@@ -225,6 +229,11 @@ void FTraceInfo::EnterSectorPortal(FPathTraverse &pt, int position, double frac,
 		Results->HitPos = exit;
 		Results->SrcFromTarget = enter;
 		Results->HitVector = Vec;
+		Results->SrcAngleFromTarget = Vec.Angle();
+		Results->Fraction = frac;
+		Results->Line = NULL;
+		Results->Sector = entersec->GetPortal(position)->mDestination;
+		Results->Distance = enterdist;
 		TraceCallback(*Results, TraceCallbackData);
 	}
 
@@ -267,6 +276,11 @@ void FTraceInfo::EnterLinePortal(FPathTraverse &pt, intercept_t *in)
 		P_TranslatePortalZ(li, exit.Z);
 		Results->SrcFromTarget = exit;
 		Results->HitVector = Vec;
+		Results->SrcAngleFromTarget = Vec.Angle();
+		Results->Fraction = in->frac;
+		Results->Line = li;
+		Results->Side = 0;
+		Results->Sector = li->frontsector;
 		TraceCallback(*Results, TraceCallbackData);
 	}
 }
@@ -305,59 +319,6 @@ void FTraceInfo::Setup3DFloors()
 		{
 			if (!(rover->flags&FF_EXISTS))
 				continue;
-
-			// [DVR] This block seems redundant. I'll leave it commented out instead of deleting it, in case it ends up being needed
-			/*
-			if (Results->Crossed3DWater == NULL || (TraceFlags & TRACE_3DLiquidCallback))
-			{
-				if (Check3DFloorPlane(rover, false) && isLiquid(rover))
-				{
-					// only consider if the plane is above the actual floor.
-					if (rover->top.plane->ZatPoint(Results->HitPos) > bf)
-					{
-						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-						{
-							Results->Crossed3DWater = rover;
-							Results->Crossed3DWaterPos = Results->HitPos;
-							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-							{
-								Results->HitType = TRACE_HitFloor;
-								Results->HitVector = Vec;
-								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
-								in3DLiquid = rover;
-								TraceCallback(*Results, TraceCallbackData);
-								Results->Crossed3DWater = NULL;
-								Results->HitType = TRACE_HitNone;
-							}
-							Results->Distance = 0;
-						}
-					}
-				}
-				if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true) && isLiquid(rover))
-				{
-					// only consider if the bottom plane is below the actual ceiling.
-					if (rover->bottom.plane->ZatPoint(Results->HitPos) < bc)
-					{
-						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-						{
-							Results->Crossed3DWater = rover;
-							Results->Crossed3DWaterPos = Results->HitPos;
-							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-							{
-								Results->HitType = TRACE_HitCeiling;
-								Results->HitVector = Vec;
-								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
-								in3DLiquid = rover;
-								TraceCallback(*Results, TraceCallbackData);
-								Results->Crossed3DWater = NULL;
-								Results->HitType = TRACE_HitNone;
-							}
-							Results->Distance = 0;
-						}
-					}
-				}
-			}
-			*/
 
 			if (!(rover->flags&FF_SHOOTTHROUGH) || (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 			{
@@ -949,6 +910,75 @@ cont1:
 //
 //==========================================================================
 
+void FTraceInfo::Trace3DFloors (int *lastsplashsector)
+{
+	// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
+	if (Results->Crossed3DWater == NULL && *lastsplashsector != CurSector->sectornum)
+	{
+		for (auto rover : CurSector->e->XFloor.ffloors)
+		{
+			if ((rover->flags & FF_EXISTS) && isLiquid(rover))
+			{
+				if (Check3DFloorPlane(rover, false))
+				{
+					// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+					if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+						&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
+					{
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitFloor;
+								Results->HitVector = Vec;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
+							Results->Distance = 0;
+						}
+					}
+				}
+				if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+				{
+					// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+					if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+						&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+					{
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitCeiling;
+								Results->HitVector = Vec;
+								Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								TraceCallback(*Results, TraceCallbackData);
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
+							Results->Distance = 0;
+						}
+					}
+				}
+			}
+		}
+		*lastsplashsector = CurSector->sectornum;
+	}
+}
+
+//==========================================================================
+//
+//
+//
+//==========================================================================
+
 bool FTraceInfo::TraceTraverse (int ptflags)
 {
 	// Do a 3D floor check in the starting sector
@@ -961,66 +991,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 
 	while ((in = it.Next()))
 	{
-		// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
-		if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
-		{
-			for (auto rover : CurSector->e->XFloor.ffloors)
-			{
-				if ((rover->flags & FF_EXISTS) && isLiquid(rover))
-				{
-					if (Check3DFloorPlane(rover, false))
-					{
-						// only consider if the plane is above the actual floor and not flush with the actual ceiling.
-						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
-							&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
-						{
-							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-							{
-								Results->Crossed3DWater = rover;
-								Results->Crossed3DWaterPos = Results->HitPos;
-								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-								{
-									Results->HitType = TRACE_HitFloor;
-									Results->HitVector = Vec;
-									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
-									in3DLiquid = rover;
-									TraceCallback(*Results, TraceCallbackData);
-									Results->Crossed3DWater = NULL;
-									Results->HitType = TRACE_HitNone;
-								}
-								Results->Distance = 0;
-							}
-						}
-					}
-					if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
-					{
-						// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
-						if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
-							&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
-						{
-							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-							{
-								Results->Crossed3DWater = rover;
-								Results->Crossed3DWaterPos = Results->HitPos;
-								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-								{
-									Results->HitType = TRACE_HitCeiling;
-									Results->HitVector = Vec;
-									Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
-									in3DLiquid = rover;
-									TraceCallback(*Results, TraceCallbackData);
-									Results->Crossed3DWater = NULL;
-									Results->HitType = TRACE_HitNone;
-								}
-								Results->Distance = 0;
-							}
-						}
-					}
-				}
-			}
-			lastsplashsector = CurSector->sectornum;
-		}
-
+		Trace3DFloors(&lastsplashsector);
 		double dist = MaxDist * in->frac;
 		DVector3 hit = Start + Vec * dist;
 
@@ -1060,6 +1031,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 					// The caller cannot handle portals without global offset.
 					if (port->mType == PORTT_LINKED || !(TraceFlags & TRACE_PortalRestrict))
 					{
+						Results->Distance = dist;
 						EnterLinePortal(it, in);
 						continue;
 					}
@@ -1090,65 +1062,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				bool actorfound = false;
 				while ((in = it.Next()))
 				{
-					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
-					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
-					{
-						for (auto rover : CurSector->e->XFloor.ffloors)
-						{
-							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
-							{
-								if (Check3DFloorPlane(rover, false))
-								{
-									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
-										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
-									{
-										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-										{
-											Results->Crossed3DWater = rover;
-											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-											{
-												Results->HitType = TRACE_HitFloor;
-												Results->HitVector = Vec;
-												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
-												in3DLiquid = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->Crossed3DWater = NULL;
-												Results->HitType = TRACE_HitNone;
-											}
-											Results->Distance = 0;
-										}
-									}
-								}
-								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
-								{
-									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
-									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
-										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
-									{
-										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-										{
-											Results->Crossed3DWater = rover;
-											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-											{
-												Results->HitType = TRACE_HitCeiling;
-												Results->HitVector = Vec;
-												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
-												in3DLiquid = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->Crossed3DWater = NULL;
-												Results->HitType = TRACE_HitNone;
-											}
-											Results->Distance = 0;
-										}
-									}
-								}
-							}
-						}
-						lastsplashsector = CurSector->sectornum;
-					}
+					Trace3DFloors(&lastsplashsector);
 					dist2 = MaxDist * in->frac;
 					hit2 = Start + Vec * dist2;
 					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
@@ -1181,65 +1095,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				bool actorfound = false;
 				while ((in = it.Next()))
 				{
-					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
-					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
-					{
-						for (auto rover : CurSector->e->XFloor.ffloors)
-						{
-							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
-							{
-								if (Check3DFloorPlane(rover, false))
-								{
-									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
-										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
-									{
-										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-										{
-											Results->Crossed3DWater = rover;
-											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-											{
-												Results->HitType = TRACE_HitFloor;
-												Results->HitVector = Vec;
-												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
-												in3DLiquid = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->Crossed3DWater = NULL;
-												Results->HitType = TRACE_HitNone;
-											}
-											Results->Distance = 0;
-										}
-									}
-								}
-								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
-								{
-									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
-									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
-										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
-									{
-										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
-										{
-											Results->Crossed3DWater = rover;
-											Results->Crossed3DWaterPos = Results->HitPos;
-											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
-											{
-												Results->HitType = TRACE_HitCeiling;
-												Results->HitVector = Vec;
-												Results->entering3DLiquid = inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
-												in3DLiquid = rover;
-												TraceCallback(*Results, TraceCallbackData);
-												Results->Crossed3DWater = NULL;
-												Results->HitType = TRACE_HitNone;
-											}
-											Results->Distance = 0;
-										}
-									}
-								}
-							}
-						}
-						lastsplashsector = CurSector->sectornum;
-					}
+					Trace3DFloors(&lastsplashsector);
 					dist2 = MaxDist * in->frac;
 					hit2 = Start + Vec * dist2;
 					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -540,6 +540,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		bc = entersector->ceilingplane.ZatPoint(hit);
 	}
 
+	bool thinfloor = (using3DFloorBottom && !!(usedBottom->flags&FF_THINFLOOR));
 	if (CurSector != NULL && hit.Z <= ff && (using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0)
 	{
 		// hit floor in front of wall
@@ -548,7 +549,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		if (using3DFloorTop) Results->ffloor = usedTop;
 		else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 	}
-	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
+	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor && !thinfloor? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
 	{
 		// hit ceiling in front of wall
 		Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
@@ -1275,6 +1276,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 	{
 		while (!lastflathit)
 		{
+			bool thinfloor = (using3DFloorBottom && !!(usedBottom->flags&FF_THINFLOOR));
 			if ((using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
 			{
 				Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
@@ -1284,7 +1286,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 				else Results->ffloor = NULL;
 			}
-			else if ((using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+			else if ((using3DFloorBottom && !inside3DFloor && !thinfloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
 			{
 				Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 				Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -62,6 +62,8 @@ struct FTraceInfo
 	// or ceiling plane coming from a 3D-floor
 	sector_t DummySector[2];
 	int sectorsel;
+	bool using3DFloorTop, using3DFloorBottom, inside3DFloor;
+	F3DFloor *usedTop, *usedBottom;
 
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
@@ -205,7 +207,7 @@ bool Trace(const DVector3 &start, sector_t *sector, const DVector3 &direction, d
 
 void FTraceInfo::EnterSectorPortal(FPathTraverse &pt, int position, double frac, sector_t *entersec)
 {
-	DVector2 displacement = entersec->GetPortalDisplacement(position);;
+	DVector2 displacement = entersec->GetPortalDisplacement(position);
 	double enterdist = MaxDist * frac;
 	DVector3 exit = Start + enterdist * Vec;
 	DVector3 enter = exit + displacement;
@@ -279,6 +281,12 @@ void FTraceInfo::EnterLinePortal(FPathTraverse &pt, intercept_t *in)
 void FTraceInfo::Setup3DFloors()
 {
 	TDeletingArray<F3DFloor*> &ff = CurSector->e->XFloor.ffloors;
+	using3DFloorTop = false;
+	using3DFloorBottom = false;
+	inside3DFloor = false;
+	usedTop = NULL;
+	usedBottom = NULL;
+	Results->ffloor = NULL;
 
 	if (ff.Size())
 	{
@@ -305,9 +313,21 @@ void FTraceInfo::Setup3DFloors()
 					// only consider if the plane is above the actual floor.
 					if (rover->top.plane->ZatPoint(Results->HitPos) > bf)
 					{
-						Results->Crossed3DWater = rover;
-						Results->Crossed3DWaterPos = Results->HitPos;
-						Results->Distance = 0;
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+							{
+								// [DVR] Trace does not halt at 3D water crossings
+								// because we are only catching the crossing of the top surface/flat.
+								// In future, could extend to crossing water from the sides
+								Results->ffloor = rover;
+								TraceCallback(*Results, TraceCallbackData);
+								Results->ffloor = NULL;
+							}
+							Results->Distance = 0;
+						}
 					}
 				}
 			}
@@ -326,6 +346,8 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::floor, *rover->top.texture, false);
 						CurSector->ClearPortal(sector_t::floor);
 						bf = ff_top;
+						using3DFloorTop = true;
+						usedTop = rover;
 					}
 				}
 				else if (pos.Z < ff_bottom)
@@ -337,17 +359,22 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::ceiling, *rover->bottom.texture, false);
 						bc = ff_bottom;
 						CurSector->ClearPortal(sector_t::ceiling);
+						using3DFloorBottom = true;
+						usedBottom = rover;
 					}
 				}
 				else
 				{
 					// inside
+					inside3DFloor = true;
 					if (bf < ff_bottom)
 					{
 						CurSector->floorplane = *rover->bottom.plane;
 						CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
 						CurSector->ClearPortal(sector_t::floor);
 						bf = ff_bottom;
+						using3DFloorBottom = true;
+						usedBottom = rover;
 					}
 
 					if (bc > ff_top)
@@ -356,6 +383,8 @@ void FTraceInfo::Setup3DFloors()
 						CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
 						CurSector->ClearPortal(sector_t::ceiling);
 						bc = ff_top;
+						using3DFloorTop = true;
+						usedTop = rover;
 					}
 					inshootthrough = false;
 				}
@@ -376,7 +405,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 	int lineside;
 	sector_t *entersector;
 
-	double ff, fc, bf = 0, bc = 0;
+	double ff = FLT_MAX, fc = FLT_MIN, bf = 0, bc = 0;
+	bool OoBflag = false;
 
 	if (in->d.line->frontsector->sectornum == CurSector->sectornum)
 	{
@@ -402,7 +432,17 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 
 	if (!(in->d.line->flags & ML_TWOSIDED))
 	{
-		entersector = NULL;
+		lineside = P_PointOnLineSide(Start.XY(), in->d.line);
+		if (lineside == 1) // Trace coming in from Out of Bounds
+		{
+			entersector = in->d.line->frontsector;
+			CurSector = NULL;
+			lineside = 0;
+		}
+		else
+		{
+			entersector = NULL;
+		}
 	}
 	else
 	{
@@ -425,8 +465,33 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		}
 	}
 
-	ff = CurSector->floorplane.ZatPoint(hit);
-	fc = CurSector->ceilingplane.ZatPoint(hit);
+	if (CurSector != NULL)
+	{
+		ff = CurSector->floorplane.ZatPoint(hit);
+		fc = CurSector->ceilingplane.ZatPoint(hit);
+		sector_t *hsec = CurSector->GetHeightSec();
+		if (Results->CrossedWater == NULL &&
+			hsec != NULL &&
+			Start.Z > hsec->floorplane.ZatPoint(Start) &&
+			hit.Z <= hsec->floorplane.ZatPoint(hit))
+		{
+			// hit crossed a water plane
+			if (CheckSectorPlane(hsec, true))
+			{
+				if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+				{
+					Results->CrossedWater = &Level->sectors[CurSector->sectornum];
+					Results->CrossedWaterPos = Results->HitPos;
+					if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+					{
+						// [DVR] Trace does not halt at water crossings even with a callback
+						TraceCallback(*Results, TraceCallbackData);
+					}
+				}
+				Results->Distance = 0;
+			}
+		}
+	}
 
 	if (entersector != NULL)
 	{
@@ -434,44 +499,53 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		bc = entersector->ceilingplane.ZatPoint(hit);
 	}
 
-	sector_t *hsec = CurSector->GetHeightSec();
-	if (Results->CrossedWater == NULL &&
-		hsec != NULL &&
-		Start.Z > hsec->floorplane.ZatPoint(Start) &&
-		hit.Z <= hsec->floorplane.ZatPoint(hit))
-	{
-		// hit crossed a water plane
-		if (CheckSectorPlane(hsec, true))
-		{
-			Results->CrossedWater = &Level->sectors[CurSector->sectornum];
-			Results->CrossedWaterPos = Results->HitPos;
-			Results->Distance = 0;
-		}
-	}
-
-	if (hit.Z <= ff)
+	if (CurSector != NULL && hit.Z <= ff && (using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0)
 	{
 		// hit floor in front of wall
-		Results->HitType = TRACE_HitFloor;
+		Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
 		Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+		if (using3DFloorTop) Results->ffloor = usedTop;
+		else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 	}
-	else if (hit.Z >= fc)
+	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
 	{
 		// hit ceiling in front of wall
-		Results->HitType = TRACE_HitCeiling;
+		Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 		Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+		if (using3DFloorBottom) Results->ffloor = usedBottom;
+		else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
 	}
 	else if (entersector == NULL ||
 		hit.Z < bf || hit.Z > bc ||
 		((in->d.line->flags & WallMask) && !special3dpass))
 	{
 		// hit the wall
-		Results->HitType = TRACE_HitWall;
 		Results->Tier =
 			entersector == NULL ? TIER_Middle :
 			hit.Z <= bf ? TIER_Lower :
 			hit.Z >= bc ? TIER_Upper : TIER_Middle;
-		if ((TraceFlags & TRACE_Impact) && !special3dpass)
+		switch (Results->Tier)
+		{
+		case TIER_Lower:
+			if (CurSector != NULL && hit.Z >= ff) Results->HitType = TRACE_HitWall;
+			else
+			{
+				Results->HitType = TRACE_HitNone;
+				OoBflag = true;
+			}
+			break;
+		case TIER_Upper:
+			if (CurSector != NULL && hit.Z <= fc) Results->HitType = TRACE_HitWall;
+			else
+			{
+				Results->HitType = TRACE_HitNone;
+				OoBflag = true;
+			}
+			break;
+		default:
+			Results->HitType = TRACE_HitWall;
+		}
+		if ((Results->HitType == TRACE_HitWall) && (TraceFlags & TRACE_Impact) && !special3dpass)
 		{
 			P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
 		}
@@ -488,6 +562,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			// We need to make sure that 3D floors clipping underneath the ground/above the ceiling don't
 			// accidentally get ignored.
 			bool setFloor = false, setCeiling = false;
+			using3DFloorBottom = false;
+			using3DFloorTop = false;
 
 			for (auto rover : entersector->e->XFloor.ffloors)
 			{
@@ -520,6 +596,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							entersector->SetTexture(sector_t::floor, *rover->top.texture, false);
 							entersector->ClearPortal(sector_t::floor);
 							bf = ff_top;
+							using3DFloorTop = true;
+							usedTop = rover;
 						}
 					}
 					else if (hit.Z < ff_bottom)
@@ -543,6 +621,8 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							entersector->SetTexture(sector_t::ceiling, *rover->bottom.texture, false);
 							entersector->ClearPortal(sector_t::ceiling);
 							bc = ff_bottom;
+							using3DFloorBottom = true;
+							usedBottom = rover;
 						}
 					}
 					else
@@ -580,10 +660,11 @@ cont:
 	if (Results->HitType != TRACE_HitNone)
 	{
 		// We hit something, so figure out where exactly
-		Results->Sector = &Level->sectors[CurSector->sectornum];
+		if (CurSector != NULL) Results->Sector = &Level->sectors[CurSector->sectornum];
+		else if (entersector != NULL) Results->Sector = &Level->sectors[entersector->sectornum];
 
 		if (Results->HitType != TRACE_HitWall &&
-			!CheckSectorPlane(CurSector, Results->HitType == TRACE_HitFloor))
+			CurSector != NULL && !CheckSectorPlane(CurSector, Results->HitType == (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor)))
 		{ // trace is parallel to the plane (or right on it)
 			if (entersector == NULL)
 			{
@@ -620,6 +701,11 @@ cont:
 			Results->Side = lineside;
 		}
 	}
+	if (CurSector == NULL && entersector)
+	{
+		CurSector = entersector; // Trace probably came in from out of bounds, but we can't let CurSector be NULL after LineCheck() returns
+		Results->Sector = CurSector;
+	}
 
 	if (TraceCallback != NULL && Results->HitType != TRACE_HitNone)
 	{
@@ -629,6 +715,13 @@ cont:
 			return false;
 
 		case TRACE_ContinueOutOfBounds:
+			if (Results->ffloor)
+			{
+				startfrac = Results->Fraction + EQUAL_EPSILON;
+				CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
+				Setup3DFloors();
+				if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+			}
 			return true;
 
 		case TRACE_Abort:
@@ -650,6 +743,11 @@ cont:
 	{
 		CurSector = entersector;
 		EnterDist = dist;
+		if (OoBflag)
+		{
+			startfrac = in->frac + EQUAL_EPSILON;
+			Setup3DFloors();
+		}
 		return true;
 	}
 	else
@@ -708,20 +806,24 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 
 		if (hit.Z > ff_ceiling && CurSector->PortalBlocksMovement(sector_t::ceiling))	// actor is hit above the current ceiling
 		{
-			Results->HitType = TRACE_HitCeiling;
+			Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 			Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+			if (using3DFloorBottom) Results->ffloor = usedBottom;
+			else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
 		}
 		else if (hit.Z < ff_floor && CurSector->PortalBlocksMovement(sector_t::floor))	// actor is hit below the current floor
 		{
-			Results->HitType = TRACE_HitFloor;
+			Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
 			Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+			if (using3DFloorTop) Results->ffloor = usedTop;
+			else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 		}
 		else goto cont1;
 
 		// the trace hit a 3D floor before the thing.
 		// Calculate an intersection and abort.
 		Results->Sector = &Level->sectors[CurSector->sectornum];
-		if (!CheckSectorPlane(CurSector, Results->HitType == TRACE_HitFloor))
+		if (!CheckSectorPlane(CurSector, Results->HitType == (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor)))
 		{
 			Results->HitType = TRACE_HitNone;
 		}
@@ -730,7 +832,15 @@ bool FTraceInfo::ThingCheck(intercept_t *in, double dist, DVector3 hit)
 			switch (TraceCallback(*Results, TraceCallbackData))
 			{
 			case TRACE_Continue: return true;
-			case TRACE_ContinueOutOfBounds: return true;
+			case TRACE_ContinueOutOfBounds:
+				if (Results->ffloor && (Results->HitType != TRACE_HitNone))
+				{
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = Results->Sector;
+					Setup3DFloors();
+					return ThingCheck(in, dist, hit);
+				}
+				return true;
 			case TRACE_Stop:	 return false;
 			case TRACE_Abort:	 Results->HitType = TRACE_HitNone; return false;
 			case TRACE_Skip:	 Results->HitType = TRACE_HitNone; return true;
@@ -781,6 +891,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 	FPathTraverse it(Level, Start.X, Start.Y, Vec.X * MaxDist, Vec.Y * MaxDist, ptflags | PT_DELTA, startfrac);
 	intercept_t *in;
 	int lastsplashsector = -1;
+	bool lastflathit = false;
 
 	while ((in = it.Next()))
 	{
@@ -796,9 +907,21 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 						// only consider if the plane is above the actual floor.
 						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
 						{
-							Results->Crossed3DWater = rover;
-							Results->Crossed3DWaterPos = Results->HitPos;
-							Results->Distance = 0;
+							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+							{
+								Results->Crossed3DWater = rover;
+								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+								{
+									// [DVR] Trace does not halt at 3D water crossings
+									// because we are only catching the crossing of the top surface/flat.
+									// In future, could extend to crossing water from the sides
+									Results->ffloor = rover;
+									TraceCallback(*Results, TraceCallbackData);
+									Results->ffloor = NULL;
+								}
+								Results->Distance = 0;
+							}
 						}
 					}
 				}
@@ -858,17 +981,182 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		}
 	}
 
+	// Check for sector portals when no line or thing was crossed
 	if (Results->HitType == TRACE_HitNone)
 	{
-		if (CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
+		// Crossed a floor portals?
+		while (Vec.Z < 0 && !CurSector->PortalBlocksMovement(sector_t::floor))
 		{
-			Results->HitType = TRACE_HitFloor;
-			Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+			double dist2 = MaxDist;
+			DVector3 hit2 = Start + Vec * MaxDist;
+			// calculate position where the portal is crossed
+			double portz = CurSector->GetPortalPlaneZ(sector_t::floor);
+			if (hit2.Z < portz && limitz > portz)
+			{
+				limitz = portz;
+				EnterSectorPortal(it, sector_t::floor, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
+				bool actorfound = false;
+				while ((in = it.Next()))
+				{
+					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
+					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
+					{
+						for (auto rover : CurSector->e->XFloor.ffloors)
+						{
+							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
+							{
+								if (Check3DFloorPlane(rover, false))
+								{
+									// only consider if the plane is above the actual floor.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+											{
+												// [DVR] Trace does not halt at 3D water crossings
+												// because we are only catching the crossing of the top surface/flat.
+												// In future, could extend to crossing water from the sides
+												Results->ffloor = rover;
+												TraceCallback(*Results, TraceCallbackData);
+												Results->ffloor = NULL;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+							}
+						}
+						lastsplashsector = CurSector->sectornum;
+					}
+					dist2 = MaxDist * in->frac;
+					hit2 = Start + Vec * dist2;
+					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
+					{
+						if (!ThingCheck(in, dist2, hit2))
+						{
+							actorfound = true;
+							break;
+						}
+					}
+				}
+				if (actorfound) break;
+			}
+			else
+			{
+				break;
+			}
 		}
-		else if (CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+		// ... or a ceiling portals?
+		while (Vec.Z > 0 && !CurSector->PortalBlocksMovement(sector_t::ceiling))
 		{
-			Results->HitType = TRACE_HitCeiling;
-			Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+			double dist2 = MaxDist;
+			DVector3 hit2 = Start + Vec * dist2;
+			// calculate position where the portal is crossed
+			double portz = CurSector->GetPortalPlaneZ(sector_t::ceiling);
+			if (hit2.Z > portz && limitz < portz)
+			{
+				limitz = portz;
+				EnterSectorPortal(it, sector_t::ceiling, (portz - Start.Z) / (Vec.Z * MaxDist), CurSector);
+				bool actorfound = false;
+				while ((in = it.Next()))
+				{
+					// Deal with splashes in 3D floors (but only run once per sector, not each iteration - and stop if something was found.)
+					if (Results->Crossed3DWater == NULL && lastsplashsector != CurSector->sectornum)
+					{
+						for (auto rover : CurSector->e->XFloor.ffloors)
+						{
+							if ((rover->flags & FF_EXISTS) && isLiquid(rover))
+							{
+								if (Check3DFloorPlane(rover, false))
+								{
+									// only consider if the plane is above the actual floor.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_WaterCallback) && (TraceCallback != NULL))
+											{
+												// [DVR] Trace does not halt at 3D water crossings
+												// because we are only catching the crossing of the top surface/flat.
+												// In future, could extend to crossing water from the sides
+												Results->ffloor = rover;
+												TraceCallback(*Results, TraceCallbackData);
+												Results->ffloor = NULL;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+							}
+						}
+						lastsplashsector = CurSector->sectornum;
+					}
+					dist2 = MaxDist * in->frac;
+					hit2 = Start + Vec * dist2;
+					if (((in->d.thing->flags & ActorMask) || ActorMask == 0xffffffff) && in->d.thing != IgnoreThis)
+					{
+						if (!ThingCheck(in, dist2, hit2))
+						{
+							actorfound = true;
+							break;
+						}
+					}
+				}
+				if (actorfound) break;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	// Check for intersection with flats when no line or thing was crossed
+	if (Results->HitType == TRACE_HitNone)
+	{
+		while (!lastflathit)
+		{
+			if ((using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
+			{
+				Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
+				Results->HitTexture = CurSector->GetTexture(sector_t::floor);
+				lastflathit = true;
+				if (using3DFloorTop) Results->ffloor = usedTop;
+				else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
+				else Results->ffloor = NULL;
+			}
+			else if ((using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+			{
+				Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
+				Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);
+				lastflathit = true;
+				if (using3DFloorBottom) Results->ffloor = usedBottom;
+				else if (inside3DFloor && using3DFloorTop) Results->ffloor = usedTop;
+				else Results->ffloor = NULL;
+			}
+			if (lastflathit && (TraceCallback != NULL))
+			{
+				// [DVR] Call TraceCallback for the last floor/ceiling hit without crossing a line or thing
+				F3DFloor* Rff = Results->ffloor;
+				Results->Sector = &Level->sectors[CurSector->sectornum];
+				ETraceStatus mytracestatus = TraceCallback(*Results, TraceCallbackData);
+				if ((mytracestatus  == TRACE_ContinueOutOfBounds) && Rff)
+				{
+					lastflathit = false;
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = Results->Sector;
+					Setup3DFloors();
+				}
+			}
+			else
+			{
+				break;
+			}
 		}
 	}
 
@@ -906,40 +1194,6 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 		Results->Fraction = 1.;
 	}
 
-	// [MK] set 3d floor on plane hits (if any)
-	// modders will need this to get accurate plane normals on slopes
-	if (Results->HitType == TRACE_HitFloor)
-	{
-		double secbottom = Results->Sector->floorplane.ZatPoint(Results->HitPos);
-		for (auto rover : Results->Sector->e->XFloor.ffloors)
-		{
-			if (!(rover->flags&FF_EXISTS))
-				continue;
-			double ff_top = rover->top.plane->ZatPoint(Results->HitPos);
-			if (fabs(ff_top-secbottom) < EQUAL_EPSILON)
-				continue;
-			if (fabs(ff_top-Results->HitPos.Z) > EQUAL_EPSILON)
-				continue;
-			Results->ffloor = rover;
-			break;
-		}
-	}
-	else if (Results->HitType == TRACE_HitCeiling)
-	{
-		double sectop = Results->Sector->ceilingplane.ZatPoint(Results->HitPos);
-		for (auto rover : Results->Sector->e->XFloor.ffloors)
-		{
-			if (!(rover->flags&FF_EXISTS))
-				continue;
-			double ff_bottom = rover->bottom.plane->ZatPoint(Results->HitPos);
-			if (fabs(ff_bottom-sectop) < EQUAL_EPSILON)
-				continue;
-			if (fabs(ff_bottom-Results->HitPos.Z) > EQUAL_EPSILON)
-				continue;
-			Results->ffloor = rover;
-			break;
-		}
-	}
 	return Results->HitType != TRACE_HitNone;
 }
 
@@ -1021,6 +1275,7 @@ static bool EditTraceResult (uint32_t flags, FTraceResults &res)
 			}
 		}
 	}
+
 	return true;
 }
 

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -529,6 +529,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		bc = entersector->ceilingplane.ZatPoint(hit);
 	}
 
+	bool thinfloor = (using3DFloorBottom && !!(usedBottom->flags&FF_THINFLOOR));
 	if (CurSector != NULL && hit.Z <= ff && (using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0)
 	{
 		// hit floor in front of wall
@@ -537,7 +538,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 		if (using3DFloorTop) Results->ffloor = usedTop;
 		else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 	}
-	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
+	else if (CurSector != NULL && hit.Z >= fc && (using3DFloorBottom && !inside3DFloor && !thinfloor? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0)
 	{
 		// hit ceiling in front of wall
 		Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
@@ -1264,6 +1265,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 	{
 		while (!lastflathit)
 		{
+			bool thinfloor = (using3DFloorBottom && !!(usedBottom->flags&FF_THINFLOOR));
 			if ((using3DFloorTop && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->floorplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::floor) && CheckSectorPlane(CurSector, true))
 			{
 				Results->HitType = (inside3DFloor ? TRACE_HitCeiling : TRACE_HitFloor);
@@ -1273,7 +1275,7 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				else if (inside3DFloor && using3DFloorBottom) Results->ffloor = usedBottom;
 				else Results->ffloor = NULL;
 			}
-			else if ((using3DFloorBottom && !inside3DFloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
+			else if ((using3DFloorBottom && !inside3DFloor && !thinfloor ? -1.0 : 1.0)*Vec.dot(CurSector->ceilingplane.Normal()) < 0 && CurSector->PortalBlocksMovement(sector_t::ceiling) && CheckSectorPlane(CurSector, false))
 			{
 				Results->HitType = (inside3DFloor ? TRACE_HitFloor : TRACE_HitCeiling);
 				Results->HitTexture = CurSector->GetTexture(sector_t::ceiling);

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -235,6 +235,8 @@ void FTraceInfo::EnterSectorPortal(FPathTraverse &pt, int position, double frac,
 		Results->Sector = entersec->GetPortal(position)->mDestination;
 		Results->Distance = enterdist;
 		TraceCallback(*Results, TraceCallbackData);
+		Results->HitType = TRACE_HitNone;
+		Results->Sector = NULL;
 	}
 
 	Setup3DFloors();
@@ -282,6 +284,9 @@ void FTraceInfo::EnterLinePortal(FPathTraverse &pt, intercept_t *in)
 		Results->Side = 0;
 		Results->Sector = li->frontsector;
 		TraceCallback(*Results, TraceCallbackData);
+		Results->HitType = TRACE_HitNone;
+		Results->Sector = NULL;
+		Results->Line = NULL;
 	}
 }
 

--- a/src/playsim/p_trace.cpp
+++ b/src/playsim/p_trace.cpp
@@ -73,8 +73,8 @@ struct FTraceInfo
 	// or ceiling plane coming from a 3D-floor
 	sector_t DummySector[2];
 	int sectorsel;
-	bool using3DFloorTop, using3DFloorBottom, inside3DFloor;
-	F3DFloor *usedTop, *usedBottom;
+	bool using3DFloorTop, using3DFloorBottom, inside3DFloor, inside3DLiquid;
+	F3DFloor *usedTop, *usedBottom, *in3DLiquid;
 
 	void Setup3DFloors();
 	bool LineCheck(intercept_t *in, double dist, DVector3 hit, bool special3dpass);
@@ -294,6 +294,7 @@ void FTraceInfo::Setup3DFloors()
 	using3DFloorTop = false;
 	using3DFloorBottom = false;
 	inside3DFloor = false;
+	inside3DLiquid = false;
 	usedTop = NULL;
 	usedBottom = NULL;
 	Results->ffloor = NULL;
@@ -316,7 +317,9 @@ void FTraceInfo::Setup3DFloors()
 			if (!(rover->flags&FF_EXISTS))
 				continue;
 
-			if (Results->Crossed3DWater == NULL)
+			// [DVR] This block seems redundant. I'll leave it commented out instead of deleting it, in case it ends up being needed
+			/*
+			if (Results->Crossed3DWater == NULL || (TraceFlags & TRACE_3DLiquidCallback))
 			{
 				if (Check3DFloorPlane(rover, false) && isLiquid(rover))
 				{
@@ -327,18 +330,52 @@ void FTraceInfo::Setup3DFloors()
 						{
 							Results->Crossed3DWater = rover;
 							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitFloor;
+								Results->HitVector = Vec;
+								TraceCallback(*Results, TraceCallbackData);
+								inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
+							Results->Distance = 0;
+						}
+					}
+				}
+				if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true) && isLiquid(rover))
+				{
+					// only consider if the bottom plane is below the actual ceiling.
+					if (rover->bottom.plane->ZatPoint(Results->HitPos) < bc)
+					{
+						if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = Results->HitPos;
+							if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+							{
+								Results->HitType = TRACE_HitCeiling;
+								Results->HitVector = Vec;
+								TraceCallback(*Results, TraceCallbackData);
+								inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+								in3DLiquid = rover;
+								Results->Crossed3DWater = NULL;
+								Results->HitType = TRACE_HitNone;
+							}
 							Results->Distance = 0;
 						}
 					}
 				}
 			}
+			*/
 
-			if (!(rover->flags&FF_SHOOTTHROUGH))
+			if (!(rover->flags&FF_SHOOTTHROUGH) || (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 			{
 				double ff_bottom = rover->bottom.plane->ZatPoint(pos);
 				double ff_top = rover->top.plane->ZatPoint(pos);
 				// clip to the part of the sector we are in
-				if (pos.Z > ff_top)
+				if (pos.Z > ff_top && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 				{
 					// above
 					if (bf < ff_top)
@@ -351,7 +388,7 @@ void FTraceInfo::Setup3DFloors()
 						usedTop = rover;
 					}
 				}
-				else if (pos.Z < ff_bottom)
+				else if (pos.Z < ff_bottom && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 				{
 					//below
 					if (bc > ff_bottom)
@@ -364,30 +401,38 @@ void FTraceInfo::Setup3DFloors()
 						usedBottom = rover;
 					}
 				}
-				else
+				else if (pos.Z < ff_top && pos.Z > ff_bottom)
 				{
 					// inside
-					inside3DFloor = true;
-					if (bf < ff_bottom)
+					if (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover))
 					{
-						CurSector->floorplane = *rover->bottom.plane;
-						CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
-						CurSector->ClearPortal(sector_t::floor);
-						bf = ff_bottom;
-						using3DFloorBottom = true;
-						usedBottom = rover;
+						inside3DLiquid = true;
+						in3DLiquid = rover;
 					}
+					else
+					{
+						inside3DFloor = true;
+						if (bf < ff_bottom)
+						{
+							CurSector->floorplane = *rover->bottom.plane;
+							CurSector->SetTexture(sector_t::floor, *rover->bottom.texture, false);
+							CurSector->ClearPortal(sector_t::floor);
+							bf = ff_bottom;
+							using3DFloorBottom = true;
+							usedBottom = rover;
+						}
 
-					if (bc > ff_top)
-					{
-						CurSector->ceilingplane = *rover->top.plane;
-						CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
-						CurSector->ClearPortal(sector_t::ceiling);
-						bc = ff_top;
-						using3DFloorTop = true;
-						usedTop = rover;
+						if (bc > ff_top)
+						{
+							CurSector->ceilingplane = *rover->top.plane;
+							CurSector->SetTexture(sector_t::ceiling, *rover->top.texture, false);
+							CurSector->ClearPortal(sector_t::ceiling);
+							bc = ff_top;
+							using3DFloorTop = true;
+							usedTop = rover;
+						}
+						inshootthrough = false;
 					}
-					inshootthrough = false;
 				}
 			}
 		}
@@ -565,13 +610,13 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 			{
 				int entershootthrough = !!(rover->flags&FF_SHOOTTHROUGH);
 
-				if (entershootthrough != inshootthrough && rover->flags&FF_EXISTS)
+				if (rover->flags&FF_EXISTS && (entershootthrough != inshootthrough || (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover))))
 				{
 					double ff_bottom = rover->bottom.plane->ZatPoint(hit);
 					double ff_top = rover->top.plane->ZatPoint(hit);
 
 					// clip to the part of the sector we are in
-					if (hit.Z > ff_top)
+					if (hit.Z > ff_top && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 					{
 						// 3D floor height is the same as the floor height or underground. We need to test a second spot to see if it is above or below
 						if ((ff_top < bf && !setFloor) || fabs(bf - ff_top) < EQUAL_EPSILON)
@@ -596,7 +641,7 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							usedTop = rover;
 						}
 					}
-					else if (hit.Z < ff_bottom)
+					else if (hit.Z < ff_bottom && !(TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover)))
 					{
 						// 3D floor height is the same as the ceiling height or above it. We need to test a second spot to see if it is above or below
 						if ((ff_bottom > bc && !setCeiling) || fabs(bc - ff_bottom) < EQUAL_EPSILON)
@@ -621,12 +666,17 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 							usedBottom = rover;
 						}
 					}
-					else
+					else if (hit.Z > ff_bottom && hit.Z < ff_top)
 					{
 						//hit the edge - equivalent to hitting the wall
 						Results->HitType = TRACE_HitWall;
 						Results->Tier = TIER_FFloor;
 						Results->ffloor = rover;
+						if (TraceFlags & TRACE_3DLiquidCallback && isLiquid(rover) && !inside3DLiquid)
+						{
+							Results->Crossed3DWater = rover;
+							Results->Crossed3DWaterPos = hit;
+						}
 						if ((TraceFlags & TRACE_Impact) && in->d.line->special)
 						{
 							P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
@@ -635,6 +685,20 @@ bool FTraceInfo::LineCheck(intercept_t *in, double dist, DVector3 hit, bool spec
 					}
 				}
 			}
+		}
+
+		if (inside3DLiquid && TraceFlags & TRACE_3DLiquidCallback)
+		{
+			Results->HitType = TRACE_HitWall;
+			Results->Tier = TIER_FFloor;
+			Results->ffloor = in3DLiquid;
+			Results->Crossed3DWater = in3DLiquid;
+			Results->Crossed3DWaterPos = hit;
+			if ((TraceFlags & TRACE_Impact) && in->d.line->special)
+			{
+				P_ActivateLine(in->d.line, IgnoreThis, lineside, SPAC_Impact);
+			}
+			goto cont;
 		}
 
 		Results->HitType = TRACE_HitNone;
@@ -705,33 +769,47 @@ cont:
 
 	if (TraceCallback != NULL && Results->HitType != TRACE_HitNone)
 	{
-		switch (TraceCallback(*Results, TraceCallbackData))
+		if (TraceFlags & TRACE_3DLiquidCallback && Results->Crossed3DWater != NULL)
 		{
-		case TRACE_Stop:
-			return false;
-
-		case TRACE_ContinueOutOfBounds:
-			if (Results->ffloor)
+			// Callback and fall through
+			TraceCallback(*Results, TraceCallbackData);
+			Results->Crossed3DWater = NULL;
+			Results->HitType = TRACE_HitNone;
+			Results->ffloor = NULL;
+			Results->Line = NULL;
+			Results->Distance = 0;
+			OoBflag = true;
+		}
+		else
+		{
+			switch (TraceCallback(*Results, TraceCallbackData))
 			{
-				startfrac = Results->Fraction + EQUAL_EPSILON;
-				CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
-				Setup3DFloors();
-				if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+			case TRACE_Stop:
+				return false;
+
+			case TRACE_ContinueOutOfBounds:
+				if (Results->ffloor)
+				{
+					startfrac = Results->Fraction + EQUAL_EPSILON;
+					CurSector = (Results->HitType != TRACE_HitWall ? Results->Sector : entersector);
+					Setup3DFloors();
+					if (Results->HitType != TRACE_HitWall) return LineCheck(in, dist, hit, false);
+				}
+				return true;
+
+			case TRACE_Abort:
+				Results->HitType = TRACE_HitNone;
+				return false;
+
+			case TRACE_Skip:
+				Results->HitType = TRACE_HitNone;
+				if (!special3dpass && (TraceFlags & TRACE_3DCallback) && entersector && entersector->e->XFloor.ffloors.Size())
+					return LineCheck(in, dist, hit, true);
+				break;
+
+			default:
+				break;
 			}
-			return true;
-
-		case TRACE_Abort:
-			Results->HitType = TRACE_HitNone;
-			return false;
-
-		case TRACE_Skip:
-			Results->HitType = TRACE_HitNone;
-			if (!special3dpass && (TraceFlags & TRACE_3DCallback) && entersector && entersector->e->XFloor.ffloors.Size())
-				return LineCheck(in, dist, hit, true);
-			break;
-
-		default:
-			break;
 		}
 	}
 
@@ -900,13 +978,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 				{
 					if (Check3DFloorPlane(rover, false))
 					{
-						// only consider if the plane is above the actual floor.
-						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+						// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+						if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+							&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 						{
 							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 							{
 								Results->Crossed3DWater = rover;
 								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+								{
+									Results->HitType = TRACE_HitFloor;
+									Results->HitVector = Vec;
+									TraceCallback(*Results, TraceCallbackData);
+									inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+									in3DLiquid = rover;
+									Results->Crossed3DWater = NULL;
+									Results->HitType = TRACE_HitNone;
+								}
+								Results->Distance = 0;
+							}
+						}
+					}
+					if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+					{
+						// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+						if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+							&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+						{
+							if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+							{
+								Results->Crossed3DWater = rover;
+								Results->Crossed3DWaterPos = Results->HitPos;
+								if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+								{
+									Results->HitType = TRACE_HitCeiling;
+									Results->HitVector = Vec;
+									TraceCallback(*Results, TraceCallbackData);
+									inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+									in3DLiquid = rover;
+									Results->Crossed3DWater = NULL;
+									Results->HitType = TRACE_HitNone;
+								}
 								Results->Distance = 0;
 							}
 						}
@@ -994,13 +1107,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								if (Check3DFloorPlane(rover, false))
 								{
-									// only consider if the plane is above the actual floor.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 									{
 										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitFloor;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+								{
+									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitCeiling;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
 											Results->Distance = 0;
 										}
 									}
@@ -1050,13 +1198,48 @@ bool FTraceInfo::TraceTraverse (int ptflags)
 							{
 								if (Check3DFloorPlane(rover, false))
 								{
-									// only consider if the plane is above the actual floor.
-									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									// only consider if the plane is above the actual floor and not flush with the actual ceiling.
+									if (rover->top.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos)
+										&& rover->top.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos))
 									{
 										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
 										{
 											Results->Crossed3DWater = rover;
 											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitFloor;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->top.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
+											Results->Distance = 0;
+										}
+									}
+								}
+								if ((TraceFlags & TRACE_3DLiquidCallback) && Check3DFloorPlane(rover, true))
+								{
+									// only consider if the bottom plane is below the actual ceiling and not flush with the actual floor.
+									if (rover->bottom.plane->ZatPoint(Results->HitPos) < CurSector->ceilingplane.ZatPoint(Results->HitPos)
+										&& rover->bottom.plane->ZatPoint(Results->HitPos) > CurSector->floorplane.ZatPoint(Results->HitPos))
+									{
+										if (CurSector->sectornum == Level->PointInSector(Results->HitPos)->sectornum)
+										{
+											Results->Crossed3DWater = rover;
+											Results->Crossed3DWaterPos = Results->HitPos;
+											if ((TraceFlags & TRACE_3DLiquidCallback) && TraceCallback != NULL)
+											{
+												Results->HitType = TRACE_HitCeiling;
+												Results->HitVector = Vec;
+												TraceCallback(*Results, TraceCallbackData);
+												inside3DLiquid = Vec.dot(rover->bottom.plane->Normal()) > 0.0;
+												in3DLiquid = rover;
+												Results->Crossed3DWater = NULL;
+												Results->HitType = TRACE_HitNone;
+											}
 											Results->Distance = 0;
 										}
 									}

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -81,6 +81,7 @@ struct FTraceResults
 	uint8_t Side;
 	uint8_t Tier;
 	bool unlinked;		// passed through a portal without static offset.
+	bool entering3DLiquid;		// For callback when TRACE_3DLiquidCallback is set
 	ETraceResult HitType;
 	F3DFloor *ffloor;
 

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -90,6 +90,7 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_WaterCallback = 0x0080,	// Reports crossing of top surface of liquids to and calls TraceCallback
 };
 
 // return values from callback

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -100,7 +100,6 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
-	TRACE_WaterCallback = 0x0080,	// Reports crossing of top surface of liquids to and calls TraceCallback
 };
 
 // return values from callback

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -90,6 +90,7 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_3DLiquidCallback	= 0x0080,	// Hitting any surface of 3D-floor that is liquid (either from outside or inside) returns TRACE_HitWall/TRACE_HitFloor/TRACE_HitCeiling, Crossed3DWater and Crossed3DWaterPos get populated and the TraceCallback is called if present
 };
 
 // return values from callback

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -100,6 +100,7 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_WaterCallback = 0x0080,	// Reports crossing of top surface of liquids to and calls TraceCallback
 };
 
 // return values from callback

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -71,6 +71,7 @@ struct FTraceResults
 	uint8_t Side;
 	uint8_t Tier;
 	bool unlinked;		// passed through a portal without static offset.
+	bool entering3DLiquid;		// For callback when TRACE_3DLiquidCallback is set
 	ETraceResult HitType;
 	F3DFloor *ffloor;
 

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -90,7 +90,6 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
-	TRACE_WaterCallback = 0x0080,	// Reports crossing of top surface of liquids to and calls TraceCallback
 };
 
 // return values from callback

--- a/src/playsim/p_trace.h
+++ b/src/playsim/p_trace.h
@@ -100,6 +100,7 @@ enum
 	TRACE_ReportPortals = 0x0010,	// Report any portal crossing to the TraceCallback
 	TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
 	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_3DLiquidCallback	= 0x0080,	// Hitting any surface of 3D-floor that is liquid (either from outside or inside) returns TRACE_HitWall/TRACE_HitFloor/TRACE_HitCeiling, Crossed3DWater and Crossed3DWaterPos get populated and the TraceCallback is called if present
 };
 
 // return values from callback

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -723,7 +723,8 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 	case TRACE_HitWall:
 		{
 			sector_t* linesec = res.Line->sidedef[res.Side]->sector;
-			if (linesec && linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection])
+			if (linesec && linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection]
+				&& res.HitVector.XY().dot(DVector2(res.Line->Delta().Y, -res.Line->Delta().X)) < 0.0)
 			{
 				bf = res.Line->sidedef[res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY()) - EQUAL_EPSILON;
 				bc = res.Line->sidedef[res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY()) + EQUAL_EPSILON;

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -718,19 +718,29 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 	case TRACE_HitWall:
 		{
 			sector_t* linesec = res.Line->sidedef[res.Side]->sector;
-			if (linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection])
+			if (linesec && linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection])
 			{
-				bf = res.Line->sidedef[res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY());
-				bc = res.Line->sidedef[res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY());
+				bf = res.Line->sidedef[res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY()) - EQUAL_EPSILON;
+				bc = res.Line->sidedef[res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY()) + EQUAL_EPSILON;
 				if (res.Line->sidedef[!res.Side])
 				{
 					// Two sided line! So let's find out if mid, top, or bottom texture needs dithered transparency
-					bf = max(bf, res.Line->sidedef[!res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY()));
-					bc = min(bc, res.Line->sidedef[!res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY()));
-					if (res.HitPos.Z <= bf) res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_BOTTOM;
-					else if (res.HitPos.Z < bc) res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_MID;
-					else res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_TOP;
-
+					switch(res.Tier)
+					{
+					case TIER_Middle:
+					case TIER_FFloor:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_MID;
+						break;
+					case TIER_Upper:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_TOP;
+						break;
+					case TIER_Lower:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_BOTTOM;
+						break;
+					default:
+						break;
+					}
+					// TODO: Find a way to make only some of 3DFloor sidewalls transparent instead of all in this line segment
 					res.Line->sidedef[res.Side]->dithertranscount = max<int>(1, res.Line->sidedef[!res.Side]->sector->e->XFloor.ffloors.Size());
 				}
 				else if ((res.HitPos.Z <= bc) && (res.HitPos.Z >= bf))
@@ -742,54 +752,28 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 		}
 		break;
 	case TRACE_HitFloor:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->floorplane.Normal()) < 0.0)
+		if ((*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->floorplane.Normal()) < 0.0)
 		{
-			if (res.HitPos.Z == res.Sector->floorplane.ZatPoint(res.HitPos))
+			if (res.ffloor)
+			{
+				res.ffloor->top.plane->dithertransflag = true;
+			}
+			else if ((res.Sector->Level->PointInSector(res.HitPos)->sectornum == res.Sector->sectornum) && res.Sector->Level->PointInRenderSubsector(FLOAT2FIXED(res.HitPos.X), FLOAT2FIXED(res.HitPos.Y))) // make sure that hitpos is not within void or some other sector
 			{
 				res.Sector->floorplane.dithertransflag = true;
-			}
-			else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
-			{
-				F3DFloor *rover;
-				int kk;
-				for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
-				{
-					rover = res.Sector->e->XFloor.ffloors[kk];
-					if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
-					{
-						if (res.HitPos.Z == rover->top.plane->ZatPoint(res.HitPos))
-						{
-							rover->top.plane->dithertransflag = true;
-							break; // Out of for loop
-						}
-					}
-				}
 			}
 		}
 		break;
 	case TRACE_HitCeiling:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->ceilingplane.Normal()) < 0.0)
+		if ((*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->ceilingplane.Normal()) < 0.0)
 		{
-			if (res.HitPos.Z == res.Sector->ceilingplane.ZatPoint(res.HitPos))
+			if (res.ffloor)
+			{
+				res.ffloor->bottom.plane->dithertransflag = true;
+			}
+			else if ((res.Sector->Level->PointInSector(res.HitPos)->sectornum == res.Sector->sectornum) && res.Sector->Level->PointInRenderSubsector(FLOAT2FIXED(res.HitPos.X), FLOAT2FIXED(res.HitPos.Y))) // make sure that hitpos is not within void or some other sector
 			{
 				res.Sector->ceilingplane.dithertransflag = true;
-			}
-			else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
-			{
-				F3DFloor *rover;
-				int kk;
-				for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
-				{
-					rover = res.Sector->e->XFloor.ffloors[kk];
-					if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
-					{
-						if (res.HitPos.Z == rover->bottom.plane->ZatPoint(res.HitPos))
-						{
-							rover->bottom.plane->dithertransflag = true;
-							break; // Out of for loop
-						}
-					}
-				}
 			}
 		}
 		break;
@@ -826,24 +810,12 @@ void HWDrawInfo::SetDitherTransFlags(AActor* actor)
 		{
 			startsec = Level->PointInRenderSubsector(campos)->sector;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				  0, 0, actor, results, TRACE_3DCallback, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z += actor->Height * 0.5;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				  0, 0, actor, results, TRACE_3DCallback, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z -= actor->Height * 0.5;
 			campos.X += horix; campos.Y -= horiy;
-		}
-
-		// Tracers don't work on 3D floors when you are starting in the same sector (standing under them, for example)
-		if (actor->Sector->e->XFloor.ffloors.Size()) // 3D floor
-		{
-			F3DFloor *rover;
-			for (int kk = 0; kk < (int)actor->Sector->e->XFloor.ffloors.Size(); kk++)
-			{
-				rover = actor->Sector->e->XFloor.ffloors[kk];
-				rover->top.plane->dithertransflag = true;
-				rover->bottom.plane->dithertransflag = true;
-			}
 		}
 	}
 }

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -723,19 +723,29 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 	case TRACE_HitWall:
 		{
 			sector_t* linesec = res.Line->sidedef[res.Side]->sector;
-			if (linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection])
+			if (linesec && linesec->subsectorcount > 0 && (*CurMapSections)[linesec->subsectors[0]->mapsection])
 			{
-				bf = res.Line->sidedef[res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY());
-				bc = res.Line->sidedef[res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY());
+				bf = res.Line->sidedef[res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY()) - EQUAL_EPSILON;
+				bc = res.Line->sidedef[res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY()) + EQUAL_EPSILON;
 				if (res.Line->sidedef[!res.Side])
 				{
 					// Two sided line! So let's find out if mid, top, or bottom texture needs dithered transparency
-					bf = max(bf, res.Line->sidedef[!res.Side]->sector->floorplane.ZatPoint(res.HitPos.XY()));
-					bc = min(bc, res.Line->sidedef[!res.Side]->sector->ceilingplane.ZatPoint(res.HitPos.XY()));
-					if (res.HitPos.Z <= bf) res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_BOTTOM;
-					else if (res.HitPos.Z < bc) res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_MID;
-					else res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_TOP;
-
+					switch(res.Tier)
+					{
+					case TIER_Middle:
+					case TIER_FFloor:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_MID;
+						break;
+					case TIER_Upper:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_TOP;
+						break;
+					case TIER_Lower:
+						res.Line->sidedef[res.Side]->Flags |= WALLF_DITHERTRANS_BOTTOM;
+						break;
+					default:
+						break;
+					}
+					// TODO: Find a way to make only some of 3DFloor sidewalls transparent instead of all in this line segment
 					res.Line->sidedef[res.Side]->dithertranscount = max<int>(1, res.Line->sidedef[!res.Side]->sector->e->XFloor.ffloors.Size());
 				}
 				else if ((res.HitPos.Z <= bc) && (res.HitPos.Z >= bf))
@@ -747,54 +757,28 @@ static ETraceStatus TraceCallbackForDitherTransparency(FTraceResults& res, void*
 		}
 		break;
 	case TRACE_HitFloor:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->floorplane.Normal()) < 0.0)
+		if ((*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->floorplane.Normal()) < 0.0)
 		{
-			if (res.HitPos.Z == res.Sector->floorplane.ZatPoint(res.HitPos))
+			if (res.ffloor)
+			{
+				res.ffloor->top.plane->dithertransflag = true;
+			}
+			else if ((res.Sector->Level->PointInSector(res.HitPos)->sectornum == res.Sector->sectornum) && res.Sector->Level->PointInRenderSubsector(FLOAT2FIXED(res.HitPos.X), FLOAT2FIXED(res.HitPos.Y))) // make sure that hitpos is not within void or some other sector
 			{
 				res.Sector->floorplane.dithertransflag = true;
-			}
-			else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
-			{
-				F3DFloor *rover;
-				int kk;
-				for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
-				{
-					rover = res.Sector->e->XFloor.ffloors[kk];
-					if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
-					{
-						if (res.HitPos.Z == rover->top.plane->ZatPoint(res.HitPos))
-						{
-							rover->top.plane->dithertransflag = true;
-							break; // Out of for loop
-						}
-					}
-				}
 			}
 		}
 		break;
 	case TRACE_HitCeiling:
-		if (res.Sector->subsectorcount > 0 && (*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->ceilingplane.Normal()) < 0.0)
+		if ((*CurMapSections)[res.Sector->subsectors[0]->mapsection] && res.HitVector.dot(res.Sector->ceilingplane.Normal()) < 0.0)
 		{
-			if (res.HitPos.Z == res.Sector->ceilingplane.ZatPoint(res.HitPos))
+			if (res.ffloor)
+			{
+				res.ffloor->bottom.plane->dithertransflag = true;
+			}
+			else if ((res.Sector->Level->PointInSector(res.HitPos)->sectornum == res.Sector->sectornum) && res.Sector->Level->PointInRenderSubsector(FLOAT2FIXED(res.HitPos.X), FLOAT2FIXED(res.HitPos.Y))) // make sure that hitpos is not within void or some other sector
 			{
 				res.Sector->ceilingplane.dithertransflag = true;
-			}
-			else if (res.Sector->e->XFloor.ffloors.Size()) // Maybe it was 3D floors
-			{
-				F3DFloor *rover;
-				int kk;
-				for (kk = 0; kk < (int)res.Sector->e->XFloor.ffloors.Size(); kk++)
-				{
-					rover = res.Sector->e->XFloor.ffloors[kk];
-					if ((rover->flags&(FF_EXISTS | FF_RENDERPLANES | FF_THISINSIDE)) == (FF_EXISTS | FF_RENDERPLANES))
-					{
-						if (res.HitPos.Z == rover->bottom.plane->ZatPoint(res.HitPos))
-						{
-							rover->bottom.plane->dithertransflag = true;
-							break; // Out of for loop
-						}
-					}
-				}
 			}
 		}
 		break;
@@ -831,24 +815,12 @@ void HWDrawInfo::SetDitherTransFlags(AActor* actor)
 		{
 			startsec = Level->PointInRenderSubsector(campos)->sector;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				  0, 0, actor, results, TRACE_3DCallback, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z += actor->Height * 0.5;
 			Trace(campos, startsec, vvec, distance,
-				  0, 0, actor, results, TRACE_PortalRestrict, TraceCallbackForDitherTransparency, &CurrentMapSections);
+				  0, 0, actor, results, TRACE_3DCallback, TraceCallbackForDitherTransparency, &CurrentMapSections);
 			campos.Z -= actor->Height * 0.5;
 			campos.X += horix; campos.Y -= horiy;
-		}
-
-		// Tracers don't work on 3D floors when you are starting in the same sector (standing under them, for example)
-		if (actor->Sector->e->XFloor.ffloors.Size()) // 3D floor
-		{
-			F3DFloor *rover;
-			for (int kk = 0; kk < (int)actor->Sector->e->XFloor.ffloors.Size(); kk++)
-			{
-				rover = actor->Sector->e->XFloor.ffloors[kk];
-				rover->top.plane->dithertransflag = true;
-				rover->bottom.plane->dithertransflag = true;
-			}
 		}
 	}
 }

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -325,7 +325,8 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_WaterCallback	= 0x0080	// Reports crossing of top surface of liquids to and calls TraceCallback
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -325,7 +325,8 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_3DLiquidCallback	= 0x0080	// Hitting any surface of 3D-floor that is liquid (either from outside or inside) returns TRACE_HitWall/TRACE_HitFloor/TRACE_HitCeiling, Crossed3DWater and Crossed3DWaterPos get populated and the TraceCallback is called if present
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -343,8 +343,7 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
-	TRACE_WaterCallback	= 0x0080	// Reports crossing of top surface of liquids to and calls TraceCallback
+	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -367,6 +367,7 @@ struct TraceResults native
 	native uint8 Side;
 	native uint8 Tier;		// see Tracer.ELineTier
 	native bool unlinked;		// passed through a portal without static offset.
+	native bool entering3DLiquid;	// For callback when TRACE_3DLiquidCallback is set
 
 	native ETraceResult HitType;
 	native F3DFloor ffloor;

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -325,8 +325,7 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
-	TRACE_WaterCallback	= 0x0080	// Reports crossing of top surface of liquids to and calls TraceCallback
+	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -343,7 +343,8 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_WaterCallback	= 0x0080	// Reports crossing of top surface of liquids to and calls TraceCallback
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -343,7 +343,8 @@ enum ETraceFlags
 	TRACE_PortalRestrict	= 0x0008,	// Cannot go through portals without a static link offset.
 	TRACE_ReportPortals	= 0x0010,	// Report any portal crossing to the TraceCallback
 	//TRACE_3DCallback	= 0x0020,	// [ZZ] use TraceCallback to determine whether we need to go through a line to do 3D floor check, or not. without this, only line flag mask is used
-	TRACE_HitSky		= 0x0040	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_HitSky		= 0x0040,	// Hitting the sky returns TRACE_HasHitSky
+	TRACE_3DLiquidCallback	= 0x0080	// Hitting any surface of 3D-floor that is liquid (either from outside or inside) returns TRACE_HitWall/TRACE_HitFloor/TRACE_HitCeiling, Crossed3DWater and Crossed3DWaterPos get populated and the TraceCallback is called if present
 }
 
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -385,6 +385,7 @@ struct TraceResults native
 	native uint8 Side;
 	native uint8 Tier;		// see Tracer.ELineTier
 	native bool unlinked;		// passed through a portal without static offset.
+	native bool entering3DLiquid;	// For callback when TRACE_3DLiquidCallback is set
 
 	native ETraceResult HitType;
 	native F3DFloor ffloor;


### PR DESCRIPTION
Engine internal was unkludged. `FPathTraverse::Next()` now actually advances to next intercept. Somehow it was made to mostly work, so I had to remove all workarounds and make it work again.

- Fixed trace behavior when crossing flats without crossing lines when passing through sector portals. 
- Properly populate `Results->ffloor` when hitting 3D-floor flat. 
- Crossing liquid top surfaces only populates `Results->Crossing[3D]Water` when intercept is within sector.
- Also fixed OoB usage of trace  on 3D floors (which is not exposed to zscript).

`Crossing3DWater` only populates with the first top surface of liquid that is crossed. I assume that this is intended behavior.

[edit]
Added a `TRACE_3DLiquidCallback` flag to run callback function when a 3DFloor liquid-surface crossing occurs.

`HitType` will be `TRACE_HitFloor` for top crossing, `TRACE_HitCeiling` for bottom crossing, and `TRACE_HitWall` for side-wall crossing. `Crossed3DWater` and `Crossed3DWaterPos` will get populated. ~~It is left to the modder to calculate if the 3D-liquid volume is being entered or exited.~~ Added a `bool entering3DLiquid` field to tell whether entering or exiting 3D-liquid volume when callback is triggered from `TRACE_3DLiquidCallback` flag.
The return from callback will be ignored and assumed to be `TRACE_Continue`, just like for `TRACE_ReportPortals`.
The callback is not triggered if the 3D-liquid volume crossing surface is flush with map geometry. So starting inside a swimming pool and pointing a trace at the floor will not be reported as a 3D-liquid crossing (unless the pool bottom surface is magically floating in mid-air above the actual sector floor). Same with swimming pool walls.
[/edit]

~~Keeping this a draft until after 4.13.3 releases.~~
~~UZD can't afford new playsim bugs in a debut release version.~~

Test map uses m8f's code for laser sight as a base. Look for color changes in particle beam and some console messages: 
[tracer_visualizer_v5.zip](https://github.com/user-attachments/files/31335754/tracer_visualizer_v5.zip)
Test map without new flags (`TRACE_3DLiquidCallback`) or features (checking the `entering3DLiquid` field) for comparing against current trunk (two implementations of tracer visualization):
[tracer_visualizer_v5_no_new_flags.zip](https://github.com/user-attachments/files/31335767/tracer_visualizer_v5_no_new_flags.zip)
[tracer_visualizer_v2.zip](https://github.com/user-attachments/files/31335768/tracer_visualizer_v2.zip)

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
