### PR TITLE
Fix string OOB in some VM functions

### DIFF
--- a/src/common/scripting/interface/stringformat.cpp
+++ b/src/common/scripting/interface/stringformat.cpp
@@ -146,7 +146,8 @@ FString FStringFormat(VM_ARGS, int offset)
 						ThrowAbortException(X_FORMAT_ERROR, "Cannot mix explicit and implicit arguments.");
 					in_fmt = false;
 					// append
-					if (fmt_current[1] == '*' || fmt_current[2] == '*')
+					if ((fmt_current.Len() > 1 && fmt_current[1] == '*')
+						|| (fmt_current.Len() > 2 && fmt_current[2] == '*'))
 					{
 						// fail if something was found, but it's not an int
 						if (argnum+1 >= numparam) ThrowAbortException(X_FORMAT_ERROR, "Not enough arguments for format.");
@@ -184,7 +185,8 @@ FString FStringFormat(VM_ARGS, int offset)
 					if (argnum < 0 && haveargnums)
 						ThrowAbortException(X_FORMAT_ERROR, "Cannot mix explicit and implicit arguments.");
 					in_fmt = false;
-					if (fmt_current[1] == '*' || fmt_current[2] == '*')
+					if ((fmt_current.Len() > 1 && fmt_current[1] == '*')
+						|| (fmt_current.Len() > 2 && fmt_current[2] == '*'))
 					{
 						// fail if something was found, but it's not an int
 						if (argnum + 1 >= numparam) ThrowAbortException(X_FORMAT_ERROR, "Not enough arguments for format.");
@@ -282,9 +284,12 @@ DEFINE_ACTION_FUNCTION(FStringStruct, DeleteLastCharacter)
 
 static void LocalizeString(const FString &label, bool prefixed, FString *result)
 {
-	if (!prefixed) *result = GStrings.GetString(label);
-	else if (label[0] != '$') *result = label;
-	else *result = GStrings.GetString(&label[1]);
+	if (!prefixed)
+		*result = GStrings.GetString(label);
+	else if (label.Len() >= 2 && label[0] == '$')
+		*result = GStrings.GetString(label.GetChars() + 1);
+	else
+		*result = label;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(FStringTable, Localize, LocalizeString)
@@ -714,5 +719,3 @@ DEFINE_ACTION_FUNCTION_NATIVE(FStringStruct, GetNextCodePoint, StringNextCodePoi
 	if (numret > 1) ret[1].SetInt(pos);
 	return numret;
 }
-
-

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -32,7 +32,7 @@
 **---------------------------------------------------------------------------
 **
 **
-*/ 
+*/
 
 
 #include "texturemanager.h"
@@ -382,7 +382,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DStatusBarCore, BeginHUD, BeginHUD)
 
 //=====================================================================================
 //
-// 
+//
 //
 //=====================================================================================
 
@@ -670,7 +670,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetBottomAlignOffset, GetBottomAlignOffset)
 
 static int StringWidth(FFont *font, const FString &str, int localize)
 {
-	const char *txt = (localize && str[0] == '$') ? GStrings.GetString(&str[1]) : str.GetChars();
+	const char *txt = (localize && str.Len() >= 2 && str[0] == '$') ? GStrings.GetString(str.GetChars() + 1) : str.GetChars();
 	return font->StringWidth(txt);
 }
 
@@ -684,7 +684,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, StringWidth, StringWidth)
 
 static int GetMaxAscender(FFont* font, const FString& str, int localize)
 {
-	const char* txt = (localize && str[0] == '$') ? GStrings.GetString(&str[1]) : str.GetChars();
+	const char *txt = (localize && str.Len() >= 2 && str[0] == '$') ? GStrings.GetString(str.GetChars() + 1) : str.GetChars();
 	return font->GetMaxAscender(txt);
 }
 
@@ -698,7 +698,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(FFont, GetMaxAscender, GetMaxAscender)
 
 static int CanPrint(FFont *font, const FString &str, int localize)
 {
-	const char *txt = (localize && str[0] == '$') ? GStrings.GetString(&str[1]) : str.GetChars();
+	const char *txt = (localize && str.Len() >= 2 && str[0] == '$') ? GStrings.GetString(str.GetChars() + 1) : str.GetChars();
 	return font->CanPrint(txt);
 }
 
@@ -964,7 +964,7 @@ DEFINE_ACTION_FUNCTION(_CVar, SetInt)
 	{
 		auto realCVar = (FBaseCVar*)(self->GetExtraDataPointer());
 		assert(realCVar->GetFlags() & CVAR_ZS_CUSTOM);
-		
+
 		v = realCVar->GenericZSCVarCallback(v, CVAR_Int);
 		self->SetGenericRep(v, realCVar->GetRealType());
 


### PR DESCRIPTION
- StringTable.Localize when prefixed
- Font.StringWidth, Font.GetMaxAscender, and Font.CanPrint when attempting to localize
- String.Format (and derivatives) when using an integer/double format