### PR TITLE
Fix null access in DoDim

### DIFF
--- a/src/common/2d/v_draw.cpp
+++ b/src/common/2d/v_draw.cpp
@@ -1715,7 +1715,7 @@ DEFINE_ACTION_FUNCTION(FCanvas, Clear)
 
 void DoDim(F2DDrawer *drawer, PalEntry color, float amount, int x1, int y1, int w, int h, FRenderStyle *style)
 {
-	if (amount < 0 || (amount == 0.f && *style != LegacyRenderStyles[STYLE_Source]))
+	if (amount < 0 || (amount == 0.f && (!style || *style != LegacyRenderStyles[STYLE_Source])))
 	{
 		return;
 	}
@@ -1846,9 +1846,9 @@ DEFINE_ACTION_FUNCTION(_Screen, GetTextureWidth)
 	PARAM_PROLOGUE;
 	PARAM_INT(textureId);
 	PARAM_BOOL(animated);
-	
+
 	FGameTexture *tex = textureId >= 1 ? TexMan.GetGameTexture(FSetTextureID(textureId), animated) : nullptr;
-	
+
 	ACTION_RETURN_FLOAT(tex ? tex->GetDisplayWidth() : -1);
 }
 


### PR DESCRIPTION
`style` can be null here, and the equivalence operators for FRenderStyle doesn't handle null.

I'm not sure if this is the correct way to fix this, I'm pretty unfamiliar with this code. Could possibly be addressed by changing how the operators work, but this seems like the only place that this situation can happen anyways.
