### PR TITLE
Made BobWeapon functions server-side

### DIFF
--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -651,18 +651,14 @@ void P_BringUpWeapon (player_t *player)
 //============================================================================
 
 EPSPBobType BobType = PSPB_None;
-FWeaponBobInfo BobInfo = {}, PrevBobInfo = {};
+FPlayerBob PlayerBob[MAXPLAYERS] = {};
 
 void P_BobWeapon(player_t* player)
 {
-	const bool isConsolePlayer = player == &players[consoleplayer];
+	auto& bob = PlayerBob[player - players];
 	IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, BobWeapon)
 	{
-		if (isConsolePlayer)
-		{
-			BobInfo.Clear3D();
-			PrevBobInfo = BobInfo;
-		}
+		bob.UpdateInterpolation(true);
 
 		DVector2 result = CallVM<DVector2>(func, player->mo, 1.0);
 
@@ -678,32 +674,18 @@ void P_BobWeapon(player_t* player)
 			inv = nextinv;
 		}
 
-		if (isConsolePlayer)
-		{
-			BobInfo.Tic2D = player->BobTimer;
-			BobInfo.Bob2D = FVector2(result);
-			if (PrevBobInfo.Tic2D < 0 || BobInfo.Tic2D - PrevBobInfo.Tic2D != 1)
-				PrevBobInfo = BobInfo;
-		}
+		bob.SetBob2D(player->BobTimer, FVector2(result));
 		return;
 	}
-	if (isConsolePlayer)
-	{
-		BobInfo.Clear();
-		PrevBobInfo.Clear();
-	}
+	bob.ResetInterpolation();
 }
 
 void P_BobWeapon3D(player_t* player)
 {
-	const bool isConsolePlayer = player == &players[consoleplayer];
+	auto& bob = PlayerBob[player - players];
 	IFVIRTUALPTRNAME(player->mo, NAME_PlayerPawn, BobWeapon3D)
 	{
-		if (isConsolePlayer)
-		{
-			BobInfo.Clear2D();
-			PrevBobInfo = BobInfo;
-		}
+		bob.UpdateInterpolation(false);
 
 		auto [t, r] = CallVM<DVector3, DVector3>(func, player->mo, 1.0);
 
@@ -720,21 +702,10 @@ void P_BobWeapon3D(player_t* player)
 			inv = nextinv;
 		}
 
-		if (isConsolePlayer)
-		{
-			BobInfo.Tic3D = player->BobTimer;
-			BobInfo.Translation = FVector3(t);
-			BobInfo.Rotation = FVector3(r);
-			if (PrevBobInfo.Tic3D < 0 || BobInfo.Tic3D - PrevBobInfo.Tic3D != 1)
-				PrevBobInfo = BobInfo;
-		}
+		bob.SetBob3D(player->BobTimer, FVector3(t), FVector3(r));
 		return;
 	}
-	if (isConsolePlayer)
-	{
-		BobInfo.Clear();
-		PrevBobInfo.Clear();
-	}
+	bob.ResetInterpolation();
 }
 
 //---------------------------------------------------------------------------

--- a/src/playsim/p_pspr.h
+++ b/src/playsim/p_pspr.h
@@ -86,9 +86,55 @@ enum PSPAlign
 	PSPA_RIGHT = 2
 };
 
+enum EPSPBobType
+{
+	PSPB_None,
+	PSPB_2D,
+	PSPB_3D,
+};
+
 struct WeaponInterp
 {
 	FVector2 v[4];
+};
+
+struct FWeaponBobInfo
+{
+	int Tic2D = -1;
+	FVector2 Bob2D = {};
+
+	int Tic3D = -1;
+	FVector3 Translation = {};
+	FVector3 Rotation = {};
+
+	void Clear2D()
+	{
+		Tic2D = -1;
+		Bob2D = {};
+	}
+
+	void Clear3D()
+	{
+		Tic3D = -1;
+		Translation = Rotation = {};
+	}
+
+	void Clear()
+	{
+		Clear2D();
+		Clear3D();
+	}
+
+	FVector2 Interpolate2D(const FWeaponBobInfo& prev, double ticFrac) const
+	{
+		return prev.Bob2D * (1.0 - ticFrac) + Bob2D * ticFrac;
+	}
+
+	void Interpolate3D(const FWeaponBobInfo& prev, FVector3& t, FVector3& r, double ticFrac) const
+	{
+		t = prev.Translation * (1.0 - ticFrac) + Translation * ticFrac;
+		r = prev.Rotation * (1.0 - ticFrac) + Rotation * ticFrac;
+	}
 };
 
 class DPSprite : public DObject
@@ -156,8 +202,8 @@ void P_CalcSwing (player_t *player);
 void P_SetPsprite(player_t *player, PSPLayers id, FState *state, bool pending = false);
 void P_BringUpWeapon (player_t *player);
 void P_FireWeapon (player_t *player);
-void P_BobWeapon (player_t *player, float *x, float *y, double ticfrac);
-void P_BobWeapon3D (player_t *player, FVector3 *translation, FVector3 *rotation, double ticfrac);
+void P_BobWeapon(player_t* player);
+void P_BobWeapon3D(player_t* player);
 DAngle P_BulletSlope (AActor *mo, FTranslatedLineTarget *pLineTarget = NULL, int aimflags = 0);
 AActor *P_AimTarget(AActor *mo);
 
@@ -166,5 +212,9 @@ void DoReadyWeaponToFire(AActor *self, bool primary = true, bool secondary = tru
 void DoReadyWeaponToSwitch(AActor *self, bool switchable = true);
 
 void A_ReFire(AActor *self, FState *state = NULL);
+
+extern EPSPBobType BobType;
+extern FWeaponBobInfo BobInfo;
+extern FWeaponBobInfo PrevBobInfo;
 
 #endif	// __P_PSPR_H__

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1307,6 +1307,7 @@ void P_PlayerThink (player_t *player)
 		player->angleOffsetTargets[i] = nullAngle;
 	}
 
+	// TODO: Should this be moved to the client-side logic like inventory tics?
 	if (player->SubtitleCounter > 0)
 	{
 		player->SubtitleCounter--;
@@ -1352,6 +1353,11 @@ void P_PlayerThink (player_t *player)
 		VMValue param = player->mo;
 		VMCall(func, &param, 1, nullptr, 0);
 	}
+
+	if (BobType == PSPB_2D)
+		P_BobWeapon(player);
+	else if (BobType == PSPB_3D)
+		P_BobWeapon3D(player);
 
 	// Moved this to directly after player thinking to get more accurate velocity values. Also takes
 	// 3D vs 2D movement into account now.

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -166,7 +166,7 @@ static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 {
 	WeaponPosition2D w;
 	BobType = PSPB_2D;
-	FVector2 interp = BobInfo.Interpolate2D(PrevBobInfo, Net_ModifyFrac(ticFrac));
+	FVector2 interp = PlayerBob[player - players].Interpolate2D(Net_ModifyFrac(ticFrac));
 	w.bobx = interp.X;
 	w.boby = interp.Y;
 
@@ -197,7 +197,7 @@ static WeaponPosition3D GetWeaponPosition3D(player_t *player, double ticFrac)
 {
 	WeaponPosition3D w;
 	BobType = PSPB_3D;
-	BobInfo.Interpolate3D(PrevBobInfo, w.translation, w.rotation, Net_ModifyFrac(ticFrac));
+	PlayerBob[player - players].Interpolate3D(w.translation, w.rotation, Net_ModifyFrac(ticFrac));
 
 	// Interpolate the main weapon layer once so as to be able to add it to other layers.
 	if ((w.weapon = player->FindPSprite(PSP_WEAPON)) != nullptr)

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -165,7 +165,10 @@ static bool isBright(DPSprite *psp)
 static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 {
 	WeaponPosition2D w;
-	P_BobWeapon(player, &w.bobx, &w.boby, Net_ModifyFrac(ticFrac));
+	BobType = PSPB_2D;
+	FVector2 interp = BobInfo.Interpolate2D(PrevBobInfo, Net_ModifyFrac(ticFrac));
+	w.bobx = interp.X;
+	w.boby = interp.Y;
 
 	// Interpolate the main weapon layer once so as to be able to add it to other layers.
 	if ((w.weapon = player->FindPSprite(PSP_WEAPON)) != nullptr)
@@ -193,7 +196,8 @@ static WeaponPosition2D GetWeaponPosition2D(player_t *player, double ticFrac)
 static WeaponPosition3D GetWeaponPosition3D(player_t *player, double ticFrac)
 {
 	WeaponPosition3D w;
-	P_BobWeapon3D(player, &w.translation, &w.rotation, Net_ModifyFrac(ticFrac));
+	BobType = PSPB_3D;
+	BobInfo.Interpolate3D(PrevBobInfo, w.translation, w.rotation, Net_ModifyFrac(ticFrac));
 
 	// Interpolate the main weapon layer once so as to be able to add it to other layers.
 	if ((w.weapon = player->FindPSprite(PSP_WEAPON)) != nullptr)

--- a/src/rendering/swrenderer/things/r_playersprite.cpp
+++ b/src/rendering/swrenderer/things/r_playersprite.cpp
@@ -155,7 +155,7 @@ namespace swrenderer
 			viewport->CenterY = viewheight / 2;
 
 			BobType = PSPB_2D;
-			FVector2 interp = BobInfo.Interpolate2D(PrevBobInfo, Net_ModifyFrac(viewport->viewpoint.TicFrac));
+			FVector2 interp = PlayerBob[Thread->Viewport->viewpoint.camera->player - players].Interpolate2D(Net_ModifyFrac(viewport->viewpoint.TicFrac));
 			bobx = interp.X;
 			boby = interp.Y;
 

--- a/src/rendering/swrenderer/things/r_playersprite.cpp
+++ b/src/rendering/swrenderer/things/r_playersprite.cpp
@@ -154,7 +154,10 @@ namespace swrenderer
 
 			viewport->CenterY = viewheight / 2;
 
-			P_BobWeapon(viewport->viewpoint.camera->player, &bobx, &boby, Net_ModifyFrac(viewport->viewpoint.TicFrac));
+			BobType = PSPB_2D;
+			FVector2 interp = BobInfo.Interpolate2D(PrevBobInfo, Net_ModifyFrac(viewport->viewpoint.TicFrac));
+			bobx = interp.X;
+			boby = interp.Y;
 
 			// Interpolate the main weapon layer once so as to be able to add it to other layers.
 			if ((weapon = viewport->viewpoint.camera->player->FindPSprite(PSP_WEAPON)) != nullptr)


### PR DESCRIPTION
Sit down around the campfire and get your marshmellows out because this one requires a novel to explain what the issue is and what's being fixed. Once upon a time, P_BobWeapon was located in A_WeaponReady, specifically its bob handling. This was how the original Doom did it, but it presented a huge issue: the Chainsaw. While the functionality worked perfectly fine for weapons that called the function every tick, the Chainsaw only called it every 4 ticks, giving it the iconic choppy swaying. On a lesser note this also meant it didn't have interpolation, so a decision was made to move it to the renderer.

This worked fine and fixed both the above issues because the tic fraction could be passed, but then the large ZScript export rolled around for 2.3. It was decided it would be exported as a function on the player itself as a virtual, allowing it to be overridden. This was fine until 2.4 when the scoping system was added. This set a separation of logic between the ui and play scopes, limiting how these two accessed each other in order to make designing for multiplayer much simpler. One problem, however, is that BobWeapon was never changed to ui scope and was kept as play scoped (perhaps for backwards compatibility?). This makes it the only play scoped function in the engine to be called from the renderer, breaking this principle.

To make things worse, it also breaks how the rollback works. The rollback code relies on snapshotting the player's state after the server logic is finished but before the renderer is ran. This fundamentally means that it could not work with this solution as BobWeapon is always called after this snapshot: any changes made to fields in it will never be saved. For the default logic that wasn't a big deal, but mods like Lithium use custom fields to further tune the bobbing. Future plans for the rollback include ignoring ui scoped fields when backing up, but this means BobWeapon is fundamentally impossible to solve in its current state since the fields it modifies must necessarily be play scoped.

With the addition of client-side Actors, I wanted to keep their behavior consistent between singleplayer and multiplayer, so I enabled the rollback in singleplayer as well. That unfortunately made this problem start occurring in singleplayer games. After a lot of deliberating, I decided the best solution here was to move BobWeapon (and its other play scoped parts) over to the server logic. To help prevent desyncs, these are now ran for every player who calls P_PlayerThink when doing the server loop, modifying it at the end to best try and preserve how the renderer would call it afterwards. The tic fraction passed is now always 1 and instead the engine itself will handle interpolating from previous values. This manages to work as a 2-for-1 as now the functionality is synchronized _and_ it's applied before the rollback, allowing it to properly iterate.

Currently it relies on a bit of a gross render hack to determine which function should be called, but I couldn't see a better way of handling this. This will require a lot of testing and @RicardoLuis0 has future plans to allow the function to be returned to the renderer by safely making the function ui scoped, but this PR will always be necessary for backwards compatibility with mods that exist with the current play scoped version.