### PR TITLE
Made the mouse less finnicky in menus

### DIFF
--- a/src/common/engine/d_event.cpp
+++ b/src/common/engine/d_event.cpp
@@ -51,6 +51,7 @@ extern bool ToggleFullscreen;
 int eventhead;
 int eventtail;
 event_t events[MAXEVENTS];
+mousestate_t LastMousePos = {};
 
 CVAR(Float, m_sensitivity_x, 2.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Float, m_sensitivity_y, 2.f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)

--- a/src/common/engine/d_eventbase.h
+++ b/src/common/engine/d_eventbase.h
@@ -26,6 +26,14 @@ struct event_t
 	float 		y;			// mouse/joystick y move
 };
 
+// Ignore minor mouse movements if it hasn't updated in a while.
+struct mousestate_t
+{
+	int LastUpdate = -1;
+	float LastX = 0.0f;
+	float LastY = 0.0f;
+};
+
 
 
 // Called by IO functions when input is detected.
@@ -40,6 +48,7 @@ enum
 };
 
 extern	event_t 		events[MAXEVENTS];
+extern mousestate_t		LastMousePos;
 extern int eventhead;
 extern int eventtail;
 

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -678,8 +678,31 @@ bool M_Responder (event_t *ev)
 				// do we want mouse input?
 				if (ev->subtype >= EV_GUI_FirstMouseEvent && ev->subtype <= EV_GUI_LastMouseEvent)
 				{
-						if (!m_use_mouse)
+					if (!m_use_mouse)
+					{
+						LastMousePos.LastUpdate = -1;
+						return true;
+					}
+
+					// Ignore subtle mouse movements to make the menu less finnicky.
+					if (ev->subtype == EV_GUI_MouseMove)
+					{
+						static const int DormantTimer = int(GameTicRate * 0.5);
+						// If the mouse moved < 1% of the screen's height, it's probably the mouse itself bugging out.
+						const float limit = screen->GetHeight() * 0.01f;
+						if (LastMousePos.LastUpdate < 0 || MenuTime - LastMousePos.LastUpdate <= DormantTimer
+							|| fabs(LastMousePos.LastX - ev->data1) >= limit || fabs(LastMousePos.LastY - ev->data2) >= limit)
+						{
+							LastMousePos.LastX = ev->data1;
+							LastMousePos.LastY = ev->data2;
+						}
+						else
+						{
 							return true;
+						}
+					}
+
+					LastMousePos.LastUpdate = MenuTime;
 				}
 
 				// pass everything else on to the current menu


### PR DESCRIPTION
Previously this would "wake up" at the slightest amount of motion, making the mouse a detriment if something caused it to do a minor input in the menu. Now it requires a small amount of motion (based on the screen's height) before it will start registering motion inputs regularly if it has been dormant.