### PR TITLE
Updated vanilla transparency handling

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1124,7 +1124,6 @@ void D_Display ()
 	cycles.Reset();
 	cycles.Clock();
 
-	r_UseVanillaTransparency = UseVanillaTransparency(); // [SP] Cache UseVanillaTransparency() call
 	r_renderercaps = GetCaps(); // [SP] Get the current capabilities of the renderer
 
 	if (players[consoleplayer].camera == NULL)
@@ -3764,9 +3763,6 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 			return 0;
 		}
 	}
-
-	// [SP] Force vanilla transparency auto-detection to re-detect our game lumps now
-	UpdateVanillaTransparency();
 
 	// [RH] Lock any cvars that should be locked now that we're
 	// about to begin the game.

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -67,6 +67,7 @@
 #include "vmbuilder.h"
 
 extern TArray<PalEntry> TranslationColors;
+extern TMap<FName, bool> AutoTrans;
 
 void JitDumpLog(FILE *file, VMScriptFunction *func);
 
@@ -141,6 +142,7 @@ static PClassActor* FindInfoName(int index, bool mustexist = false)
 			cls = static_cast<PClassActor*>(RUNTIME_CLASS(AActor)->CreateDerivedClass(name.GetChars(), (unsigned)sizeof(AActor)));
 			NewClassType(cls, -1);	// This needs a VM type to work as intended.
 			cls->InitializeDefaults();
+			AutoTrans[cls->TypeName] = true;
 			PClassActor::AllActorClasses.Push(cls);
 		}
 		if (cls)
@@ -3806,6 +3808,7 @@ void FinishDehPatch ()
 			if (newlycreated)
 			{
 				subclass->InitializeDefaults();
+				AutoTrans[subclass->TypeName] = true;
 				PClassActor::AllActorClasses.Push(subclass);
 			}
 		} 

--- a/src/r_data/r_vanillatrans.cpp
+++ b/src/r_data/r_vanillatrans.cpp
@@ -45,7 +45,8 @@
 #endif
 
 bool r_UseVanillaTransparency;
-CVAR (Int, r_vanillatrans, 0, CVAR_ARCHIVE)
+CVAR(Int, r_vanillatrans, 0, CVAR_ARCHIVE)
+TMap<FName, bool> AutoTrans = {};
 
 namespace
 {

--- a/src/r_data/r_vanillatrans.h
+++ b/src/r_data/r_vanillatrans.h
@@ -36,3 +36,5 @@
 void UpdateVanillaTransparency();
 bool UseVanillaTransparency();
 extern bool r_UseVanillaTransparency;
+extern TMap<FName, bool> AutoTrans;
+EXTERN_CVAR(Int, r_vanillatrans)

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1331,11 +1331,11 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		trans = 1.f;
 	}
-	if (r_UseVanillaTransparency)
+	if (r_vanillatrans && (thing->renderflags & RF_ZDOOMTRANS))
 	{
 		// [SP] "canonical transparency" - with the flip of a CVar, disable transparency for Doom objects,
 		//   and disable 'additive' translucency for certain objects from other games.
-		if (thing->renderflags & RF_ZDOOMTRANS)
+		if (r_vanillatrans == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
 		{
 			trans = 1.f;
 			RenderStyle.BlendOp = STYLEOP_Add;

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -167,9 +167,9 @@ namespace swrenderer
 		if (thing->flags5 & MF5_BRIGHT)
 			vis->renderflags |= RF_FULLBRIGHT;
 		vis->RenderStyle = thing->RenderStyle;
-		if (r_UseVanillaTransparency)
+		if (r_vanillatrans && (thing->renderflags & RF_ZDOOMTRANS))
 		{
-			if (thing->renderflags & RF_ZDOOMTRANS)
+			if (r_vanillatrans == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
 				vis->RenderStyle = LegacyRenderStyles[STYLE_Normal];
 		}
 		vis->FillColor = thing->fillcolor;

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -949,8 +949,7 @@ OptionValue VanillaTrans
 {
 	0.0, "$OPTVAL_VTFZDOOM"
 	1.0, "$OPTVAL_VTFVANILLA"
-	2.0, "$OPTVAL_VTAZDOOM"
-	3.0, "$OPTVAL_VTAVANILLA"
+	2.0, "$OPTVAL_AUTO"
 }
 
 OptionValue PreferBackend


### PR DESCRIPTION
Previously there were two auto options decided on whether or not there was dehacked or DECORATE present. This has been reworked so that only dehacked Actors and Actors in the core ZScript lump are now considered for it as these are the only safe options. All other Actors should default to transparency since this is likely what they were designed for given it was the existing default and so many Actors in the pk3 use it.