### PR TITLE
Default addrocketexplosion to true, as this is more consistent with e…

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -161,7 +161,7 @@ CUSTOM_CVAR (Float, sv_gravity, 800.f, CVAR_SERVERINFO|CVAR_NOSAVE|CVAR_NOINITCA
 }
 
 CVAR (Bool, cl_missiledecals, true, CVAR_ARCHIVE)
-CVAR (Bool, addrocketexplosion, false, CVAR_ARCHIVE)
+CVAR (Bool, addrocketexplosion, true, CVAR_ARCHIVE)
 CVAR (Int, cl_pufftype, 0, CVAR_ARCHIVE);
 CVAR (Int, cl_bloodtype, 0, CVAR_ARCHIVE);
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -902,6 +902,12 @@ OptionValue RocketTrailTypes
 	3.0, "$OPTVAL_SPRITESPARTICLES"
 }
 
+OptionValue RocketExplosionStyles
+{
+	0, "$OPTVAL_ROCKETEXP_STYLE_TRANS"
+	1, "$OPTVAL_ROCKETEXP_STYLE_ADD"
+}
+
 OptionValue BloodTypes
 {
 	0.0, "$OPTVAL_SPRITES"
@@ -1010,6 +1016,7 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_OLDTRANS",				"r_vanillatrans", "VanillaTrans"
 	Option "$DSPLYMNU_FAKECONTRAST",			"r_fakecontrast", "Contrast"
 	Option "$DSPLYMNU_ROCKETTRAILS",			"cl_rockettrails", "RocketTrailTypes"
+	Option "$DSPLYMNU_ROCKETEXPSTYLE",			"addrocketexplosion", "RocketExplosionStyles"
 	Option "$DSPLYMNU_BLOODTYPE",				"cl_bloodtype", "BloodTypes"
 	Option "$DSPLYMNU_PUFFTYPE",				"cl_pufftype", "PuffTypes"
 	Slider "$DSPLYMNU_MAXPARTICLES",			"r_maxparticles", 100, 10000, 100, 0


### PR DESCRIPTION
…very other explosion actors' renderstyles. Also expose it to the menu.

This option has been completely hidden and undocumented for god-knows-how-long (decades?) and my argument for it to be enabled is that stylistically, it being enabled makes the rocket explosions' aesthetics consistent with every other explosion actor defined in uzdoom.pk3 who all have the additive render style applied.

~~Personally, I'd remove this CVar completely and move all the renderstyle scripting to the Actor itself, but as has been recently discussed, it's too late to change stuff significantly like this...~~

Image comparisons: `addrocketexplosion` off versus on.

<img width="1920" height="1080" alt="Screenshot_Doom_20251031_172946" src="https://github.com/user-attachments/assets/85bac5a5-7caa-4a8e-9038-6d6b0023dddf" />

<img width="1920" height="1080" alt="Screenshot_Doom_20251031_173014" src="https://github.com/user-attachments/assets/bbf2ca14-dac5-4487-adf4-b033c588e694" />
