### PR TITLE
allow explicit object type casts (for Floor/etc)

### DIFF
--- a/src/common/scripting/frontend/ast.cpp
+++ b/src/common/scripting/frontend/ast.cpp
@@ -648,6 +648,16 @@ static void PrintExprClassCast(FLispString &out, const ZCC_TreeNode *node)
 	out.Close();
 }
 
+static void PrintExprExplicitCast(FLispString &out, const ZCC_TreeNode *node)
+{
+	ZCC_ExplicitCast *enode = (ZCC_ExplicitCast *)node;
+	assert(enode->Operation == PEX_ExplicitCast);
+	out.Open("expr-explicit-cast");
+	out.AddName(enode->ClassName);
+	PrintNodes(out, enode->Parameters, false);
+	out.Close();
+}
+
 static void PrintExprFunctionPtrCast(FLispString &out, const ZCC_TreeNode *node)
 {
 	ZCC_FunctionPtrCast *enode = (ZCC_FunctionPtrCast *)node;
@@ -1100,6 +1110,7 @@ static const NodePrinterFunc TreeNodePrinter[] =
 	PrintTwoArgIterationStmt,
 	PrintThreeArgIterationStmt,
 	PrintTypedIterationStmt,
+	PrintExprExplicitCast,
 };
 
 FString ZCC_PrintAST(const ZCC_TreeNode *root)

--- a/src/common/scripting/frontend/zcc-parse.lemon
+++ b/src/common/scripting/frontend/zcc-parse.lemon
@@ -1545,6 +1545,7 @@ primary(X) ::= primary(A) LPAREN func_expr_list(B) RPAREN. [DOT]		// Function ca
 	expr->Parameters = B;
 	X = expr;
 }
+
 primary(X) ::= LPAREN CLASS LT IDENTIFIER(A) GT RPAREN LPAREN func_expr_list(B) RPAREN. [DOT]		// class type cast
 {
 	NEW_AST_NODE(ClassCast, expr, A);
@@ -1553,6 +1554,16 @@ primary(X) ::= LPAREN CLASS LT IDENTIFIER(A) GT RPAREN LPAREN func_expr_list(B) 
 	expr->Parameters = B;
 	X = expr;
 }
+
+primary(X) ::= LPAREN LT IDENTIFIER(A) GT RPAREN LPAREN func_expr_list(B) RPAREN. [DOT]		// explicit type cast
+{
+	NEW_AST_NODE(ExplicitCast, expr, A);
+	expr->Operation = PEX_ExplicitCast;
+	expr->ClassName = ENamedName(A.Int);
+	expr->Parameters = B;
+	X = expr;
+}
+
 
 primary(X) ::= LPAREN func_ptr_type(A) GT RPAREN LPAREN expr(B) RPAREN. [DOT]		// function pointer type cast
 {

--- a/src/common/scripting/frontend/zcc_compile.cpp
+++ b/src/common/scripting/frontend/zcc_compile.cpp
@@ -3128,6 +3128,23 @@ FxExpression *ZCCCompiler::ConvertNode(ZCC_TreeNode *ast, bool substitute)
 		return new FxClassPtrCast(cls, ConvertNode(cc->Parameters));
 	}
 
+	case AST_ExplicitCast:
+	{
+		auto cc = static_cast<ZCC_ExplicitCast *>(ast);
+		if (cc->Parameters == nullptr || cc->Parameters->SiblingNext != cc->Parameters)
+		{
+			Error(cc, "Explicit type cast requires exactly one parameter");
+			return new FxNop(*ast);	// return something so that the compiler can continue.
+		}
+		auto cls = PClass::FindClass(cc->ClassName);
+		if (cls == nullptr || cls->VMType == nullptr)
+		{
+			Error(cc, "Unknown class %s", FName(cc->ClassName).GetChars());
+			return new FxNop(*ast);	// return something so that the compiler can continue.
+		}
+		return new FxDynamicCast(cls, ConvertNode(cc->Parameters));
+	}
+
 	case AST_FunctionPtrCast:
 	{
 		auto cast = static_cast<ZCC_FunctionPtrCast *>(ast);

--- a/src/common/scripting/frontend/zcc_exprlist.h
+++ b/src/common/scripting/frontend/zcc_exprlist.h
@@ -75,4 +75,6 @@ xx(Trinary,			'?')
 
 xx(Cast,			TK_Coerce)
 
+xx(ExplicitCast,	'(')
+
 #undef xx

--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -1452,6 +1452,20 @@ ZCC_TreeNode *TreeNodeDeepCopy_Internal(ZCC_AST *ast, ZCC_TreeNode *orig, bool c
 
 		break;
 	}
+
+	case AST_ExplicitCast:
+	{
+		TreeNodeDeepCopy_Start(ExplicitCast);
+
+		// ZCC_Expression
+		copy->Operation = origCasted->Operation;
+		copy->Type = origCasted->Type;
+		// ZCC_ExplicitCast
+		copy->ClassName = origCasted->ClassName;
+		copy->Parameters = static_cast<ZCC_FuncParm *>(TreeNodeDeepCopy_Internal(ast, origCasted->Parameters, true, copiedNodesList));
+
+		break;
+	}
 	
 	case AST_FunctionPtrCast:
 	{

--- a/src/common/scripting/frontend/zcc_parser.h
+++ b/src/common/scripting/frontend/zcc_parser.h
@@ -151,6 +151,7 @@ enum EZCCTreeNodeType
 	AST_TwoArgIterationStmt,
 	AST_ThreeArgIterationStmt,
 	AST_TypedIterationStmt,
+	AST_ExplicitCast,
 
 	NUM_AST_NODE_TYPES
 };
@@ -446,6 +447,12 @@ struct ZCC_ExprFuncCall : ZCC_Expression
 };
 
 struct ZCC_ClassCast : ZCC_Expression
+{
+	ENamedName ClassName;
+	ZCC_FuncParm *Parameters;
+};
+
+struct ZCC_ExplicitCast : ZCC_Expression
 {
 	ENamedName ClassName;
 	ZCC_FuncParm *Parameters;


### PR DESCRIPTION
partially fixes #199

needs to be done as `(<TYPE>)(...)` instead of `(TYPE)(...)` due to parsing conflicts though, so:
```
SectorEffect FloorD = CurSector.FloorData;
if(FloorD is 'Floor' && (<Floor>)(FloorD).m_Direction == Ceiling.DirWait)
{
    return true;
}
```

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.