### PR TITLE
disable weapon bob when set to 0

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2550,7 +2550,7 @@ class PlayerPawn : Actor
 		if (!player) return (0, 0);
 		let weapon = player.ReadyWeapon;
 
-		if (weapon == null || weapon.bDontBob)
+		if (weapon == null || weapon.bDontBob || player.GetWBobSpeed() == 0)
 		{
 			return (0, 0);
 		}


### PR DESCRIPTION
Resolves #333 with changes suggested by @RicardoLuis0

The subtle side-to-side sway of weapons is eliminated by this check. Apologies if I've missed a requirement for opening a pull request, I didn't see any contributor guidelines in the repo and most existing PRs seem to follow a fairly informal format.