### PR TITLE
Update Linux path handling to follow XDG spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ function( add_pk3 PK3_NAME PK3_DIR )
 	if( WIN32 )
 		set( INSTALL_PK3_PATH . CACHE STRING "Directory where zdoom.pk3 will be placed during install." )
 	else()
-		set( INSTALL_PK3_PATH share/games/doom CACHE STRING "Directory where zdoom.pk3 will be placed during install." )
+		set( INSTALL_PK3_PATH share/games/${ZDOOM_EXE_NAME} CACHE STRING "Directory where zdoom.pk3 will be placed during install." )
 	endif()
 	install(FILES "${PROJECT_BINARY_DIR}/${PK3_NAME}"
 			DESTINATION ${INSTALL_PK3_PATH}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1454,7 +1454,7 @@ endif()
 if( WIN32 )
 	set( INSTALL_SOUNDFONT_PATH . CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )
 else()
-	set( INSTALL_SOUNDFONT_PATH share/games/doom CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )
+	set( INSTALL_SOUNDFONT_PATH share/games/${ZDOOM_EXE_NAME} CACHE STRING "Directory where soundfonts and WOPL/WOPN banks will be placed during install." )
 endif()
 install(DIRECTORY "${PROJECT_BINARY_DIR}/soundfonts" "${PROJECT_BINARY_DIR}/fm_banks"
 		DESTINATION ${INSTALL_SOUNDFONT_PATH}

--- a/src/common/engine/i_specialpaths.h
+++ b/src/common/engine/i_specialpaths.h
@@ -4,7 +4,11 @@
 
 #if defined(__unix__) || defined(__HAIKU__)
 FString GetUserFile (const char *path);
+const char * GetConfigPath();
+const char * GetCachePath();
+const char * GetDataPath();
 #endif
+
 FString M_GetAppDataPath(bool create);
 FString M_GetCachePath(bool create);
 FString M_GetAutoexecPath();
@@ -15,7 +19,6 @@ FString M_GetDocumentsPath();
 FString M_GetDemoPath();
 
 FString M_GetNormalizedPath(const char* path);
-
 
 #ifdef __APPLE__
 FString M_GetMacAppSupportPath(const bool create = true);

--- a/src/common/platform/posix/i_system.h
+++ b/src/common/platform/posix/i_system.h
@@ -17,7 +17,7 @@ struct WadStuff;
 struct FStartupSelectionInfo;
 
 #ifndef SHARE_DIR
-#define SHARE_DIR "/usr/local/share/"
+#define SHARE_DIR "/usr/local/share"
 #endif
 
 void CalculateCPUSpeed(void);

--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -123,7 +123,7 @@ FString GetUserFile (const char *file)
 
 FString M_GetAppDataPath(bool create)
 {
-	static FString path = FStringf("%s/" GAMENAMELOWERCASE, GetDataPath());
+	static FString path = FStringf("%s/games/" GAMENAMELOWERCASE, GetDataPath());
 	path = NicePath(path.GetChars());
 
 	if (create)
@@ -191,8 +191,7 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetDocumentsPath()
 {
-	static FString path = FStringf("%s/" GAMENAMELOWERCASE "/", GetDataPath());
-	return NicePath(path.GetChars());
+	return M_GetAppDataPath(false) + "/";
 }
 
 

--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -35,15 +35,13 @@
 
 #include <sys/stat.h>
 #include <sys/types.h>
-#include "i_system.h"
-#include "cmdlib.h"
-#include "printf.h"
-#include "engineerrors.h"
 
-#include "version.h"	// for GAMENAME
+#include "cmdlib.h"
+#include "engineerrors.h"
+#include "printf.h"
+#include "version.h"
 
 extern bool netgame;
-
 
 FString GetUserFile (const char *file)
 {
@@ -70,22 +68,7 @@ FString GetUserFile (const char *file)
 			I_FatalError ("$HOME/.config must be a directory");
 		}
 
-		// This can be removed after a release or two
-		// Transfer the old zdoom directory to the new location
-		bool moved = false;
-		FString oldpath = NicePath("$HOME/." GAMENAMELOWERCASE "/");
-		if (stat (oldpath.GetChars(), &extrainfo) != -1)
-		{
-			if (rename(oldpath.GetChars(), path.GetChars()) == -1)
-			{
-				I_Error ("Failed to move old " GAMENAMELOWERCASE " directory (%s) to new location (%s).",
-					oldpath.GetChars(), path.GetChars());
-			}
-			else
-				moved = true;
-		}
-
-		if (!moved && mkdir (path.GetChars(), S_IRUSR | S_IWUSR | S_IXUSR) == -1)
+		if (mkdir (path.GetChars(), S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 		{
 			I_FatalError ("Failed to create %s directory:\n%s",
 				path.GetChars(), strerror (errno));
@@ -242,4 +225,3 @@ FString M_GetNormalizedPath(const char* path)
 	FString fullpath = actualpath;
 	return fullpath;
 }
-

--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -5,6 +5,8 @@
 **---------------------------------------------------------------------------
 ** Copyright 2013-2016 Randy Heit
 ** Copyright 2016 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -40,38 +42,64 @@
 #include "engineerrors.h"
 #include "printf.h"
 #include "version.h"
+#include "zstring.h"
 
 extern bool netgame;
 
+#ifdef __APPLE
+#define DEFGETPATH(name, var, fallback) \
+	const char * Get##name##Path()      \
+	{                                   \
+		return fallback;                \
+	}
+#else
+#define DEFGETPATH(name, var, fallback) \
+	const char * Get##name##Path()      \
+	{                                   \
+		static const char *path;        \
+		static bool tested;             \
+		if (!tested)                    \
+		{                               \
+			path = getenv(var);         \
+			tested = true;              \
+			if (!path) path = fallback; \
+		}                               \
+		return path;                    \
+	}
+#endif
+DEFGETPATH(Config, "XDG_CONFIG_HOME", "$HOME/.config");
+DEFGETPATH(Cache, "XDG_CACHE_HOME", "$HOME/.cache");
+DEFGETPATH(Data, "XDG_DATA_HOME", "$HOME/.local/share");
+#undef DEFGETPATH
+
 FString GetUserFile (const char *file)
 {
-	FString path;
 	struct stat info;
 
-	path = NicePath("$HOME/" GAME_DIR "/");
+	FString path = FStringf("%s/" GAMENAMELOWERCASE "/", GetConfigPath());
+	path = NicePath(path.GetChars());
 
 	if (stat (path.GetChars(), &info) == -1)
 	{
 		struct stat extrainfo;
 
 		// Sanity check for $HOME/.config
-		FString configPath = NicePath("$HOME/.config/");
+		FString configPath = NicePath(GetConfigPath());
 		if (stat (configPath.GetChars(), &extrainfo) == -1)
 		{
 			if (mkdir (configPath.GetChars(), S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 			{
-				I_FatalError ("Failed to create $HOME/.config directory:\n%s", strerror(errno));
+				I_FatalError ("Failed to create %s directory:\n%s", GetConfigPath(), strerror(errno));
 			}
 		}
 		else if (!S_ISDIR(extrainfo.st_mode))
 		{
-			I_FatalError ("$HOME/.config must be a directory");
+			I_FatalError ("%s must be a directory", GetConfigPath());
 		}
 
 		if (mkdir (path.GetChars(), S_IRUSR | S_IWUSR | S_IXUSR) == -1)
 		{
-			I_FatalError ("Failed to create %s directory:\n%s",
-				path.GetChars(), strerror (errno));
+			I_FatalError ("Failed to create %s directory:\n%s", path.GetChars(), strerror (errno));
 		}
 	}
 	else
@@ -95,9 +123,9 @@ FString GetUserFile (const char *file)
 
 FString M_GetAppDataPath(bool create)
 {
-	// Don't use GAME_DIR and such so that ZDoom and its child ports can
-	// share the node cache.
-	FString path = NicePath("$HOME/.config/" GAMENAMELOWERCASE);
+	static FString path = FStringf("%s/" GAMENAMELOWERCASE, GetDataPath());
+	path = NicePath(path.GetChars());
+
 	if (create)
 	{
 		CreatePath(path.GetChars());
@@ -115,9 +143,9 @@ FString M_GetAppDataPath(bool create)
 
 FString M_GetCachePath(bool create)
 {
-	// Don't use GAME_DIR and such so that ZDoom and its child ports can
-	// share the node cache.
-	FString path = NicePath("$HOME/.config/zdoom/cache");
+	static FString path = FStringf("%s/" GAMENAMELOWERCASE, GetCachePath());
+	path = NicePath(path.GetChars());
+
 	if (create)
 	{
 		CreatePath(path.GetChars());
@@ -155,6 +183,21 @@ FString M_GetConfigPath(bool for_reading)
 
 //===========================================================================
 //
+// M_GetDocumentsPath												Unix
+//
+// Returns the path to the default documents directory.
+//
+//===========================================================================
+
+FString M_GetDocumentsPath()
+{
+	static FString path = FStringf("%s/" GAMENAMELOWERCASE "/", GetDataPath());
+	return NicePath(path.GetChars());
+}
+
+
+//===========================================================================
+//
 // M_GetScreenshotsPath													Unix
 //
 // Returns the path to the default screenshots directory.
@@ -163,7 +206,7 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetScreenshotsPath()
 {
-	return NicePath("$HOME/" GAME_DIR "/screenshots/");
+	return M_GetDocumentsPath() + "screenshots/";
 }
 
 //===========================================================================
@@ -176,23 +219,10 @@ FString M_GetScreenshotsPath()
 
 FString M_GetSavegamesPath()
 {
-	FString pName = "$HOME/" GAME_DIR "/savegames/";
 	if (netgame)
-		pName << "netgame/";
-	return NicePath(pName.GetChars());
-}
-
-//===========================================================================
-//
-// M_GetDocumentsPath												Unix
-//
-// Returns the path to the default documents directory.
-//
-//===========================================================================
-
-FString M_GetDocumentsPath()
-{
-	return NicePath("$HOME/" GAME_DIR "/");
+		return M_GetDocumentsPath() + "savegames/netgame/";
+	else
+		return M_GetDocumentsPath() + "savegames/";
 }
 
 //===========================================================================
@@ -223,5 +253,6 @@ FString M_GetNormalizedPath(const char* path)
 	if (!actualpath) // error ?
 		return nullptr;
 	FString fullpath = actualpath;
+	// free(actualpath); // this needs to be freed, I think
 	return fullpath;
 }

--- a/src/playsim/bots/b_game.cpp
+++ b/src/playsim/bots/b_game.cpp
@@ -5,6 +5,8 @@
 ** Copyright 1999 Martin Colberg
 ** Copyright 1999-2016 Randy Heit
 ** Copyright 2005-2016 Christoph Oelckers
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
 ** All rights reserved.
 **
 ** Redistribution and use in source and binary forms, with or without
@@ -77,22 +79,20 @@ What I know has to be done. in near future.
 Everything that is changed is marked (maybe commented) with "Added by MC"
 */
 
-#include "doomdef.h"
-#include "p_local.h"
 #include "b_bot.h"
-#include "g_game.h"
-#include "doomstat.h"
 #include "cmdlib.h"
-#include "m_misc.h"
-#include "sbar.h"
-#include "p_acs.h"
-#include "teaminfo.h"
 #include "d_net.h"
 #include "d_netinf.h"
 #include "d_player.h"
+#include "doomstat.h"
 #include "events.h"
-#include "vm.h"
+#include "g_game.h"
 #include "g_levellocals.h"
+#include "i_specialpaths.h"
+#include "p_acs.h"
+#include "p_local.h"
+#include "sbar.h"
+#include "teaminfo.h"
 
 #if !defined _WIN32 && !defined __APPLE__
 #include "i_system.h"  // for SHARE_DIR
@@ -500,7 +500,7 @@ FString M_GetCajunPath(const char* botfilename)
 	{
 		// Then check in SHARE_DIR/botfilename.
 		path = SHARE_DIR;
-		path << botfilename;
+		path << "/" << botfilename;
 		if (!FileExists(path))
 		{
 			path = "";

--- a/tools/AppImageBuilder.yml
+++ b/tools/AppImageBuilder.yml
@@ -13,7 +13,7 @@ AppDir:
 
   runtime:
     path_mappings:
-      - /usr/share/games/doom:$APPDIR/usr/share/games/doom
+      - /usr/share/games:$APPDIR/usr/share/games
 
   files:
     include:


### PR DESCRIPTION
The following are now respected and used:
- XDG_DATA_HOME (~/.local/share by default)
- XDG_CONFIG_HOME (~/.config by default)
- XDG_CACHE_HOME (~/.cache by default)

Default install location of engine data has been updated to not conflict with other ports.