### PR TITLE
Some Haiku fixes for UZDoom

### DIFF
--- a/src/common/platform/posix/i_system.h
+++ b/src/common/platform/posix/i_system.h
@@ -17,7 +17,11 @@ struct WadStuff;
 struct FStartupSelectionInfo;
 
 #ifndef SHARE_DIR
+#ifdef __HAIKU__
+#define SHARE_DIR "/boot/system/data"
+#else
 #define SHARE_DIR "/usr/local/share"
+#endif
 #endif
 
 void CalculateCPUSpeed(void);

--- a/src/common/platform/posix/sdl/i_system.cpp
+++ b/src/common/platform/posix/sdl/i_system.cpp
@@ -424,7 +424,11 @@ void I_OpenShellFolder(const char* infolder)
 	{
 		if (longsavemessages)
 			Printf("Opening folder: %s\n", infolder);
-		std::system("xdg-open .");
+		#ifdef __HAIKU__
+			std::system("open .");
+		#else
+			std::system("xdg-open .");
+		#endif
 		chdir(curdir);
 	}
 	else

--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -67,9 +67,15 @@ extern bool netgame;
 		return path;                    \
 	}
 #endif
+#ifdef __HAIKU__
+DEFGETPATH(Config, "XDG_CONFIG_HOME", "$HOME/config/settings");
+DEFGETPATH(Cache, "XDG_CACHE_HOME", "$HOME/config/cache");
+DEFGETPATH(Data, "XDG_DATA_HOME", "$HOME/config/non-packaged/data");
+#else
 DEFGETPATH(Config, "XDG_CONFIG_HOME", "$HOME/.config");
 DEFGETPATH(Cache, "XDG_CACHE_HOME", "$HOME/.cache");
 DEFGETPATH(Data, "XDG_DATA_HOME", "$HOME/.local/share");
+#endif
 #undef DEFGETPATH
 
 FString GetUserFile (const char *file)

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -101,8 +101,13 @@ FGameConfigFile::FGameConfigFile ()
 	M_GetMacSearchDirectories(user_docs, user_app_support, local_app_support);
 #endif
 
-#if defined(__unix__) && !defined(__APPLE__)
-	bool shareDirChanged = 0 != strcmp(SHARE_DIR, "/usr/local/share");
+#if defined(__HAIKU__) || ( defined(__unix__) && !defined(__APPLE__) )
+#   ifdef __HAIKU__
+#       define DEFAULT_SHARE_DIR "/boot/system/data"
+#   else
+#       define DEFAULT_SHARE_DIR "/usr/local/share"
+#   endif
+	bool shareDirChanged = 0 != strcmp(SHARE_DIR, DEFAULT_SHARE_DIR);
 	FString dataDir = GetDataPath();
 #endif
 
@@ -131,7 +136,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", user_app_support.GetChars(), true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 		SetValueForKey ("Path", local_app_support.GetChars(), true);
-#elif !defined(__unix__)
+#elif !defined(__unix__) && !defined(__HAIKU__)
 		SetValueForKey ("Path", "$HOME", true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
@@ -143,13 +148,19 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", SHARE_DIR "/doom", true);
 		if (shareDirChanged)
 		{
-			SetValueForKey ("Path", "/usr/local/share/games/" GAMENAMELOWERCASE, true);
-			SetValueForKey ("Path", "/usr/local/share/games/doom", true);
-			SetValueForKey ("Path", "/usr/local/share/doom", true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/games/" GAMENAMELOWERCASE, true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/games/doom", true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/doom", true);
 		}
+	#ifdef __HAIKU__
+		SetValueForKey ("Path", "$HOME/config/data/games/" GAMENAMELOWERCASE, true);
+		SetValueForKey ("Path", "$HOME/config/data/games/doom", true);
+		SetValueForKey ("Path", "$HOME/config/data/doom", true);
+	#else
 		SetValueForKey ("Path", "/usr/share/games/" GAMENAMELOWERCASE, true);
 		SetValueForKey ("Path", "/usr/share/games/doom", true);
 		SetValueForKey ("Path", "/usr/share/doom", true);
+	#endif
 #endif
 	}
 
@@ -163,7 +174,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", user_app_support.GetChars(), true);
 		SetValueForKey ("Path", "$PROGDIR", true);
 		SetValueForKey ("Path", local_app_support.GetChars(), true);
-#elif !defined(__unix__)
+#elif !defined(__unix__) && !defined(__HAIKU__)
 		SetValueForKey ("Path", "$PROGDIR", true);
 #else
 		SetValueForKey ("Path", dataDir + "/games/" GAMENAMELOWERCASE, true);
@@ -174,13 +185,19 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey ("Path", SHARE_DIR "/doom", true);
 		if (shareDirChanged)
 		{
-			SetValueForKey ("Path", "/usr/local/share/games/" GAMENAMELOWERCASE, true);
-			SetValueForKey ("Path", "/usr/local/share/games/doom", true);
-			SetValueForKey ("Path", "/usr/local/share/doom", true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/games/" GAMENAMELOWERCASE, true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/games/doom", true);
+			SetValueForKey ("Path", DEFAULT_SHARE_DIR "/doom", true);
 		}
+	#ifdef __HAIKU__
+		SetValueForKey ("Path", "$HOME/config/data/games/" GAMENAMELOWERCASE, true);
+		SetValueForKey ("Path", "$HOME/config/data/games/doom", true);
+		SetValueForKey ("Path", "$HOME/config/data/doom", true);
+	#else
 		SetValueForKey ("Path", "/usr/share/games/" GAMENAMELOWERCASE, true);
 		SetValueForKey ("Path", "/usr/share/games/doom", true);
 		SetValueForKey ("Path", "/usr/share/doom", true);
+	#endif
 #endif
 	}
 
@@ -197,7 +214,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey("Path", "$PROGDIR/fm_banks", true);
 		SetValueForKey("Path", (local_app_support + "/soundfonts").GetChars(), true);
 		SetValueForKey("Path", (local_app_support + "/fm_banks").GetChars(), true);
-#elif !defined(__unix__)
+#elif !defined(__unix__) && !defined(__HAIKU__)
 		SetValueForKey("Path", "$PROGDIR/soundfonts", true);
 		SetValueForKey("Path", "$PROGDIR/fm_banks", true);
 #else
@@ -215,13 +232,21 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey("Path", SHARE_DIR "/doom/fm_banks", true);
 		if (shareDirChanged)
 		{
-			SetValueForKey("Path", "/usr/local/share/games/" GAMENAMELOWERCASE "/soundfonts", true);
-			SetValueForKey("Path", "/usr/local/share/games/" GAMENAMELOWERCASE "/fm_banks", true);
-			SetValueForKey("Path", "/usr/local/share/games/doom/soundfonts", true);
-			SetValueForKey("Path", "/usr/local/share/games/doom/fm_banks", true);
-			SetValueForKey("Path", "/usr/local/share/doom/soundfonts", true);
-			SetValueForKey("Path", "/usr/local/share/doom/fm_banks", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/games/" GAMENAMELOWERCASE "/soundfonts", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/games/" GAMENAMELOWERCASE "/fm_banks", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/games/doom/soundfonts", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/games/doom/fm_banks", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/doom/soundfonts", true);
+			SetValueForKey("Path", DEFAULT_SHARE_DIR "/doom/fm_banks", true);
 		}
+	#ifdef __HAIKU__
+		SetValueForKey ("Path", "$HOME/config/data/games/" GAMENAMELOWERCASE "/soundfonts", true);
+		SetValueForKey ("Path", "$HOME/config/data/games/" GAMENAMELOWERCASE "/fm_banks", true);
+		SetValueForKey ("Path", "$HOME/config/data/games/doom/soundfonts", true);
+		SetValueForKey ("Path", "$HOME/config/data/games/doom/fm_banks", true);
+		SetValueForKey ("Path", "$HOME/config/data/doom/soundfonts", true);
+		SetValueForKey ("Path", "$HOME/config/data/doom/fm_banks", true);
+	#else
 		SetValueForKey("Path", "/usr/share/games/" GAMENAMELOWERCASE "/soundfonts", true);
 		SetValueForKey("Path", "/usr/share/games/" GAMENAMELOWERCASE "/fm_banks", true);
 		SetValueForKey("Path", "/usr/share/games/doom/soundfonts", true);
@@ -231,6 +256,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetValueForKey("Path", "$HOME/.local/share/soundfonts", true);
 		SetValueForKey("Path", "/usr/local/share/soundfonts", true);
 		SetValueForKey("Path", "/usr/share/soundfonts", true);
+	#endif
 #endif
 	}
 
@@ -245,6 +271,10 @@ FGameConfigFile::FGameConfigFile ()
 	SetSectionNote("SoundfontSearch.Directories",
 		"# These are the directories to search for soundfonts that let listed in the menu.\n"
 		"# Layout is the same as for IWADSearch.Directories\n");
+
+#ifdef DEFAULT_SHARE_DIR
+#   undef DEFAULT_SHARE_DIR
+#endif
 }
 
 FGameConfigFile::~FGameConfigFile ()


### PR DESCRIPTION
Follow-up to #344, includes:

- Changing xdg-open to open to fix the "Browse (folder)" menu options
- Patches to paths on Haiku

With this patch "dataDir" will point at non-packaged data, "SHARE_DIR" at system-wide install data and the 3rd install option, packaged local data, is covered by the additions in "gameconfigfile.cpp".

The block in gameconfigfile.cpp is also meant to avoid adding "/usr" or ".local" entries in the config file as those paths are invalid on the system.