### PR TITLE
Resolve ZScript Floor(x) call ambiguity by determining if 'x' resolves to an object.

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -8572,13 +8572,30 @@ FxExpression *FxFunctionCall::Resolve(FCompileContext& ctx)
 		}
 	}
 
-	for (size_t i = 0; i < countof(FxFlops); ++i)
+	// [RaveYard] resolve expression ahead to differentiate between `floor(object)` and `floor(numeric)`
+	bool singleParamIsObject = false;
+	if (ArgList.size() == 1)
 	{
-		if (MethodName == FxFlops[i].Name)
+		ArgList[0] = ArgList[0]->Resolve(ctx);
+		if (ArgList[0] == nullptr)
 		{
-			FxExpression *x = new FxFlopFunctionCall(i, ArgList, ScriptPosition);
 			delete this;
-			return x->Resolve(ctx);
+			return nullptr;
+		}
+
+		singleParamIsObject = ArgList[0]->IsObject();
+	}
+
+	if (!singleParamIsObject)
+	{
+		for (size_t i = 0; i < countof(FxFlops); ++i)
+		{
+			if (MethodName == FxFlops[i].Name)
+			{
+				FxExpression *x = new FxFlopFunctionCall(i, ArgList, ScriptPosition);
+				delete this;
+				return x->Resolve(ctx);
+			}
 		}
 	}
 


### PR DESCRIPTION
```cpp
void FreeYourselfFromGrossHackMentality()
{
	let f = Floor(self); // cast
	int x = Floor(pos.x); // flop
}
```

```
Disassembly @ 0000022F02BDC0B0:

00000000: 57010000 dyncast a1,a0,0000022CE6D8CB10       ;1,0,0
00000004: 19000000 ldp     f0,a0,88                     ;0,0,0

00000008: bf000007 flop    f0,f0,7 [floor]              ;0,0,7
0000000c: 54000004 cast    d0,f0                        ;0,0,4

00000010: 65808000 ret                                  ;128,128,0
```

Memory leaks? Hopefully not.
Should be fine since there is a guard against duplicate `Resolve` calls in the codegen.