### PR TITLE
PRINT_NOCONSOLE

### DIFF
--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -451,7 +451,7 @@ int PrintString (int iprintlevel, const char *outline)
 				}
 			}
 		}
-		if (Logfile != nullptr && !(iprintlevel & (PRINT_NOLOG|PRINT_NOCONSOLE)))
+		if (Logfile != nullptr && !(iprintlevel & PRINT_NOLOG))
 		{
 			WriteLineToLog(Logfile, outline);
 		}

--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -441,8 +441,8 @@ int PrintString (int iprintlevel, const char *outline)
 		if (printlevel != PRINT_LOG)
 		{
 			I_PrintStr(outline);
-
-			conbuffer->AddText(printlevel, outline);
+			if (!(iprintlevel & PRINT_NOCONSOLE))
+				conbuffer->AddText(printlevel, outline);
 			if (vidactive && screen && !(iprintlevel & PRINT_NONOTIFY) && NotifyStrings)
 			{
 				if (printlevel >= msglevel)
@@ -451,7 +451,7 @@ int PrintString (int iprintlevel, const char *outline)
 				}
 			}
 		}
-		if (Logfile != nullptr && !(iprintlevel & PRINT_NOLOG))
+		if (Logfile != nullptr && !(iprintlevel & (PRINT_NOLOG|PRINT_NOCONSOLE)))
 		{
 			WriteLineToLog(Logfile, outline);
 		}

--- a/src/common/engine/printf.h
+++ b/src/common/engine/printf.h
@@ -66,6 +66,8 @@ enum
 	PRINT_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
 	PRINT_NODAPEVENT = 8192, // Flag - do not emit the message as DAP debugger output.
 	PRINT_NOCONSOLE = 16384,// Flag - Don't add to console
+
+	PRINT_NOLOGCONSOLE = PRINT_NOLOG|PRINT_NOCONSOLE,
 };
 
 enum

--- a/src/common/engine/printf.h
+++ b/src/common/engine/printf.h
@@ -65,6 +65,7 @@ enum
 	PRINT_NOLOG = 2048,		// Flag - do not print to log file
 	PRINT_NOTIFY = 4096,	// Flag - add to game-native notify display - messages without this only go to the generic notification buffer.
 	PRINT_NODAPEVENT = 8192, // Flag - do not emit the message as DAP debugger output.
+	PRINT_NOCONSOLE = 16384,// Flag - Don't add to console
 };
 
 enum

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -175,6 +175,7 @@ enum EPrintLevel
 	PRINT_TYPES = 1023,		// Bitmask.
 	PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
 	PRINT_NOLOG = 2048,		// Flag - do not print to log file
+	PRINT_NOCONSOLE = 16384 // Flag - Don't add to console (implies nolog)
 };
 
 enum EDebugLevel

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -175,7 +175,9 @@ enum EPrintLevel
 	PRINT_TYPES = 1023,		// Bitmask.
 	PRINT_NONOTIFY = 1024,	// Flag - do not add to notify buffer
 	PRINT_NOLOG = 2048,		// Flag - do not print to log file
-	PRINT_NOCONSOLE = 16384 // Flag - Don't add to console (implies nolog)
+	PRINT_NOCONSOLE = 16384, // Flag - Don't add to console
+
+	PRINT_NOLOGCONSOLE = PRINT_NOLOG|PRINT_NOCONSOLE,
 };
 
 enum EDebugLevel


### PR DESCRIPTION
Prevents messages from being added to the open console's display. Very useful for functions like [ProcessNotify](https://zdoom.org/wiki/ProcessNotify) so I can disable item pickup message spam whenever I need to debug and print other information to the console.