### PR TITLE
Fixes for menuing

### DIFF
--- a/src/common/audio/music/i_music.cpp
+++ b/src/common/audio/music/i_music.cpp
@@ -70,7 +70,7 @@ int		nomusic = 0;
 // Maximum volume of MOD/stream music.
 //==========================================================================
 
-CUSTOM_CVARD(Float, snd_musicvolume, 0.5, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "controls music volume")
+CUSTOM_CVARD(Float, snd_musicvolume, 1.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL, "controls music volume")
 {
 	if (self < 0.f)
 		self = 0.f;
@@ -97,7 +97,7 @@ CUSTOM_CVARD(Float, snd_musicvolume, 0.5, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "contr
 	}
 }
 
-CUSTOM_CVARD(Bool, mus_enabled, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "enables/disables music")
+CUSTOM_CVARD(Bool, mus_enabled, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL, "enables/disables music")
 {
 	if (self) S_RestartMusic();
 	else S_StopMusic(true);
@@ -222,6 +222,7 @@ void I_InitMusic(int musicstate)
     I_InitSoundFonts();
 
 	snd_musicvolume->Callback ();
+	mus_enabled->Callback();
 
 	nomusic = musicstate;
 

--- a/src/common/engine/d_eventbase.h
+++ b/src/common/engine/d_eventbase.h
@@ -29,6 +29,7 @@ struct event_t
 // Ignore minor mouse movements if it hasn't updated in a while.
 struct mousestate_t
 {
+	TArray<EGUIEvent> HeldButtons = {};
 	int LastUpdate = -1;
 	float LastX = 0.0f;
 	float LastY = 0.0f;

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -680,18 +680,35 @@ bool M_Responder (event_t *ev)
 				{
 					if (!m_use_mouse)
 					{
+						LastMousePos.HeldButtons.Clear();
 						LastMousePos.LastUpdate = -1;
 						return true;
+					}
+
+					const EGUIEvent t = static_cast<EGUIEvent>(ev->subtype);
+					if (t == EV_GUI_LButtonDown || t == EV_GUI_MButtonDown || t == EV_GUI_RButtonDown ||
+						t == EV_GUI_BackButtonDown || t == EV_GUI_FwdButtonDown)
+					{
+						if (LastMousePos.HeldButtons.Find(t) >= LastMousePos.HeldButtons.Size())
+						{
+							LastMousePos.HeldButtons.Push(t);
+						}
+					}
+					else if (t == EV_GUI_LButtonUp || t == EV_GUI_MButtonUp || t == EV_GUI_RButtonUp ||
+					         t == EV_GUI_BackButtonUp || t == EV_GUI_FwdButtonUp)
+					{
+						LastMousePos.HeldButtons.Delete(LastMousePos.HeldButtons.Find(static_cast<EGUIEvent>(ev->subtype - 1)));
 					}
 
 					// Ignore subtle mouse movements to make the menu less finnicky.
 					if (ev->subtype == EV_GUI_MouseMove)
 					{
-						static const int DormantTimer = int(GameTicRate * 0.5);
+						static const int DormantTimer = GameTicRate * 3;
 						// If the mouse moved < 1% of the screen's height, it's probably the mouse itself bugging out.
 						const float limit = screen->GetHeight() * 0.01f;
-						if (LastMousePos.LastUpdate < 0 || MenuTime - LastMousePos.LastUpdate <= DormantTimer
-							|| fabs(LastMousePos.LastX - ev->data1) >= limit || fabs(LastMousePos.LastY - ev->data2) >= limit)
+						if (LastMousePos.LastUpdate < 0 || LastMousePos.HeldButtons.Size() ||
+							MenuTime - LastMousePos.LastUpdate <= DormantTimer ||
+							fabs(LastMousePos.LastX - ev->data1) >= limit || fabs(LastMousePos.LastY - ev->data2) >= limit)
 						{
 							LastMousePos.LastX = ev->data1;
 							LastMousePos.LastY = ev->data2;

--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -216,6 +216,7 @@ void S_Init()
 
 	I_InitSound();
 	I_InitMusic(Args->CheckParm(FArg_nomusic) || Args->CheckParm(FArg_nosound));
+	snd_mastervolume->Callback();
 
 	// Heretic and Hexen have sound curve lookup tables. Doom does not.
 	int curvelump = fileSystem.CheckNumForName("SNDCURVE");


### PR DESCRIPTION
* Properly account for holding mouse buttons down when checking its dormant state
* Made the dormant check timer longer so it's more lenient
* Fixed music not being properly initialized, forcing the master volume to need to be reset to get it to proper audio levels
* Set music volume default to 1 to account for the master volume being fixed