### PR TITLE
Add support for $DOOMWADPATH environment variable in default config

### DIFF
--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -304,6 +304,24 @@ const char* BaseFileSearch(const char* file, const char* ext, bool lookfirstinpr
 					}
 				}
 			}
+			else if (stricmp(key, "PathList") == 0)
+			{
+				FString dir;
+				TArray<FString> dirlist = ExpandEnvVars(value).Split(';', FString::TOK_SKIPEMPTY);
+
+				for (FString& dirname : dirlist)
+				{
+					dir = NicePath(dirname.GetChars());
+					if (dir.IsNotEmpty())
+					{
+						BFSwad.Format("%s%s%s", dir.GetChars(), dir.Back() == '/' ? "" : "/", file);
+						if (DirEntryExists(BFSwad.GetChars()))
+						{
+							return BFSwad.GetChars();
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -51,6 +51,12 @@ CUSTOM_CVARD(Int, i_exit_on_not_found, REQUIRE_DEFAULT, CVAR_ARCHIVE|CVAR_GLOBAL
 	if (self != masked) self = masked;
 };
 
+#ifdef _WIN32
+static constexpr char PATH_SEPARATOR = ';';
+#else
+static constexpr char PATH_SEPARATOR = ':';
+#endif
+
 //==========================================================================
 //
 // D_AddFile
@@ -307,7 +313,7 @@ const char* BaseFileSearch(const char* file, const char* ext, bool lookfirstinpr
 			else if (stricmp(key, "PathList") == 0)
 			{
 				FString dir;
-				TArray<FString> dirlist = ExpandEnvVars(value).Split(';', FString::TOK_SKIPEMPTY);
+				TArray<FString> dirlist = ExpandEnvVars(value).Split(PATH_SEPARATOR, FString::TOK_SKIPEMPTY);
 
 				for (FString& dirname : dirlist)
 				{

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -245,7 +245,7 @@ FGameConfigFile::FGameConfigFile ()
 	{
 		SetSection ("FileSearch.Directories", true);
 		SetValueForKey ("Path", "$DOOMWADDIR", true);
-
+		SetValueForKey ("PathList", "$DOOMWADPATH", true);
 		for (unsigned int i = 0; i < DefaultSearchPaths.Size(); i++)
 		{
 			SetValueForKey ("Path", DefaultSearchPaths[i].GetChars(), true);

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -233,7 +233,7 @@ FGameConfigFile::FGameConfigFile ()
 		SetSection ("IWADSearch.Directories", true);
 		SetValueForKey ("Path", ".", true);
 		SetValueForKey ("Path", "$DOOMWADDIR", true);
-
+		SetValueForKey ("PathList", "$DOOMWADPATH", true);
 		for (unsigned int i = 0; i < DefaultSearchPaths.Size(); i++)
 		{
 			SetValueForKey ("Path", DefaultSearchPaths[i].GetChars(), true);


### PR DESCRIPTION
Closes #340

It dawned on me when generating a brand-new UZDoom config that the engine doesn't support [$DOOMWADPATH](https://doomwiki.org/wiki/Environment_variables) (basically $DOOMWADDIR that lets you specify multiple folders via semicolon separator). Past-me had just hacked around this in GZD's config by adding a bunch of lines manually to my config file, which is a bit tedious, so I wrote a PR this time instead. :P

This PR also adds a new `PathList` config keyword to the `FileSearch.Directories` section, since I didn't want to muck with the behavior of `Path` (for backwards-compat) and the semantics are too different from `RecursivePath` to use that one. Though if y'all would rather just update how `Path` works (which currently just fails if a semicolon is present), I'll gladly rework it.