### PR TITLE
Updated CI to release rotating dev builds based on latest commit to trunk

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -109,6 +109,9 @@ jobs:
             cp ../fm_banks/GENMIDI.GS.wopl ../fm_banks/gs-by-papiezak-and-sneakernets.wopn package/fm_banks
 
             cp ${{ matrix.config.build_type }}/uzdoom.exe ${{ matrix.config.build_type }}/*.pk3 package
+            
+            cd package
+            7z a "../${{ matrix.config.name }}-${{ matrix.config.build_type }}.zip" *
 
         elif [[ "${{ runner.os }}" == 'macOS' ]]; then
 
@@ -118,6 +121,9 @@ jobs:
             mv package/licenses.zip uzdoom.app
             # copy fm_banks + soundfonts ?
             cp -r uzdoom.app package
+            
+            cd package
+            zip -r "../${{ matrix.config.name }}-${{ matrix.config.build_type }}.zip" ./*
 
         elif [[ "${{ runner.os }}" == 'Linux' ]]; then
 
@@ -137,15 +143,31 @@ jobs:
             ./appimage-builder --skip-tests --recipe ../tools/AppImageBuilder.yml
             cp *.AppImage package
 
-            rm package/licenses.zip
+            cd package
+            zip -r "../${{ matrix.config.name }}-${{ matrix.config.build_type }}.zip" ./*
+
+            rm ../package/licenses.zip
 
         fi
 
-    - name: Upload
+    - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         path: build/package
         name: ${{ matrix.config.name }} ${{ matrix.config.build_type }}
+
+    - name: Update dev build
+      uses: softprops/action-gh-release@v2
+      if: github.ref == 'refs/heads/trunk'
+      with:
+        tag_name: uDev
+        name: UZDoom - Latest Dev Build # name of the release
+        draft: false
+        prerelease: true
+        body: This is an automatically generated development version based on the latest commit ${{ github.sha }} pushed to trunk # release description
+        files: build/${{ matrix.config.name }}-${{ matrix.config.build_type }}.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: List
       if: always()


### PR DESCRIPTION
This PR updates the CI to zip the compiled builds of UZDoom and upload them to a release. Release is rotating, meaning only the latest version will be available for download. The job is only ran if pushed to trunk so the release always represents the latest available dev build of the port. Two things will need to be done if this PR were to be merged:
  1. Create a tag named "uDev".
  2. Create a _pre-release_ named "UZDoom - Latest Dev Build"

The tag and release names are not final and can be changed as needed. The release description will say: 

> This is an automatically generated development version based on the latest commit ${{ github.sha }} pushed to trunk

Where ${{ github.sha }} will be a hyperlink to the last pushed commit. Of course the description can also be changed and expanded to include more information if needed.

I am marking this as a draft until the pre-requisites and requests (if any) are met. The functionality is very versatile and can even be used to set up scheduled nightly builds if desired. If anyone would like to dive deeper into what we can do with this I will include links to documentation on triggers and the `github` context that can be used to apply more specific filters or include more information in the release.

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows

- [ ] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.