### PR TITLE
Sidedef "alpha" UDMF field

### DIFF
--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -1259,6 +1259,7 @@ struct side_t
 	int16_t		Light;
 	int16_t		TierLights[3];	// per-tier light levels
 	uint16_t	Flags;
+	double		alpha;
 	int			UDMFIndex;		// needed to access custom UDMF fields which are stored in loading order.
 	LightmapSurface* lightmap;
 	seg_t **segs;	// all segs belonging to this sidedef in ascending order. Used for precise rendering
@@ -1279,6 +1280,22 @@ struct side_t
 		TierLights[which] = l;
 	}
 
+	void SetAlpha(double a)
+	{
+		alpha = a;
+	}
+
+	void ClearAlpha()
+	{
+		// [XA] use DBL_MAX as a sentinel value for "alpha not set",
+		// instructing the renderer to use the linedef's alpha instead
+		alpha = DBL_MAX;
+	}
+
+	bool HasAlpha()
+	{
+		return alpha != DBL_MAX;
+	}
 
 	FLevelLocals *GetLevel()
 	{

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -2171,6 +2171,7 @@ void MapLoader::LoadSideDefs2 (MapData *map, FMissingTextureTracker &missingtex)
 		sd->SetTextureYOffset(LittleShort(msd->rowoffset));
 		sd->SetTextureXScale(1.);
 		sd->SetTextureYScale(1.);
+		sd->ClearAlpha();
 		sd->linedef = nullptr;
 		sd->Flags = 0;
 		sd->UDMFIndex = i;

--- a/src/maploader/udmf.cpp
+++ b/src/maploader/udmf.cpp
@@ -1258,6 +1258,7 @@ public:
 		sdt->midtexture = "-";
 		sd->SetTextureXScale(1.);
 		sd->SetTextureYScale(1.);
+		sd->ClearAlpha();
 		sd->UDMFIndex = index;
 
 		sc.MustGetToken('{');
@@ -1373,6 +1374,10 @@ public:
 
 			case NAME_light_bottom:
 				sd->SetLight(CheckInt(key), side_t::bottom);
+				continue;
+
+			case NAME_Alpha:
+				sd->SetAlpha(CheckFloat(key));
 				continue;
 
 			case NAME_lightabsolute_bottom:

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -1640,7 +1640,8 @@ void HWWall::DoMidTexture(HWWallDispatcher *di, seg_t * seg, bool drawfogboundar
 	// set up alpha blending
 	//
 	// 
-	if (seg->linedef->alpha != 0)
+	bool sideHasAlpha = seg->sidedef->HasAlpha();
+	if (sideHasAlpha || seg->linedef->alpha != 0)
 	{
 		bool translucent = false;
 
@@ -1648,13 +1649,13 @@ void HWWall::DoMidTexture(HWWallDispatcher *di, seg_t * seg, bool drawfogboundar
 		{
 		case 0:
 			RenderStyle=STYLE_Translucent;
-			alpha = seg->linedef->alpha;
+			alpha = sideHasAlpha ? seg->sidedef->alpha : seg->linedef->alpha;
 			translucent =alpha < 1. || (texture && texture->GetTranslucency());
 			break;
 
 		case ML_ADDTRANS:
 			RenderStyle=STYLE_Add;
-			alpha = seg->linedef->alpha;
+			alpha = sideHasAlpha ? seg->sidedef->alpha : seg->linedef->alpha;
 			translucent=true;
 			break;
 		}

--- a/src/rendering/swrenderer/line/r_renderdrawsegment.cpp
+++ b/src/rendering/swrenderer/line/r_renderdrawsegment.cpp
@@ -188,7 +188,7 @@ namespace swrenderer
 		sector_t tempsec;
 		const sector_t* lightsector = Thread->OpaquePass->FakeFlat(frontsector, &tempsec, nullptr, nullptr, nullptr, 0, 0, 0, 0);
 
-		fixed_t alpha = FLOAT2FIXED((float)min(curline->linedef->alpha, 1.));
+		fixed_t alpha = FLOAT2FIXED((float)min(curline->sidedef->HasAlpha() ? curline->sidedef->alpha : curline->linedef->alpha, 1.));
 		bool additive = (curline->linedef->flags & ML_ADDTRANS) != 0;
 
 		RenderWallPart renderWallpart(Thread);


### PR DESCRIPTION
Pretty self-explanatory: this adds an "alpha" UDMF field to sidedefs, which takes precedence over the linedef alpha if set. Pairs well with #405 for making one-way glass.

If desired, I could also do a similar thing to #405 and replace the linedef "alpha" field entirely in the internal struct and save a couple of branch instructions, but I'd like to wait until after #405 is all settled before attempting it since it'd touch the same areas of code and lead to conflicts if I were to do it now. Would rather not couple 'em too tightly together just yet.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.