### PR TITLE
Added lighting accessibility options

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -187,7 +187,7 @@ float GetFogDensity(FLevelLocals* Level, ELightMode lightmode, int lightlevel, P
 		// case 2: black fog
 		if ((!isDoomSoftwareLighting(lightmode) || blendfactor > 0) && !(Level->flags3 & LEVEL3_NOLIGHTFADE))
 		{
-			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight(lightlevel)];
+			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight(lightlevel, false)];
 		}
 		else
 		{

--- a/src/rendering/hwrenderer/scene/hw_lighting.h
+++ b/src/rendering/hwrenderer/scene/hw_lighting.h
@@ -7,9 +7,11 @@
 
 struct Colormap;
 
-inline int hw_ClampLight(int lightlevel)
+EXTERN_CVAR(Int, r_extralight)
+
+inline int hw_ClampLight(int lightlevel, bool addExtra = true)
 {
-	return clamp(lightlevel, 0, 255);
+	return clamp(lightlevel + r_extralight * addExtra, 0, 255);
 }
 
 EXTERN_CVAR(Int, gl_weaponlight);

--- a/src/rendering/hwrenderer/scene/hw_setcolor.cpp
+++ b/src/rendering/hwrenderer/scene/hw_setcolor.cpp
@@ -51,7 +51,7 @@ void SetColor(FRenderState &state, FLevelLocals* Level, ELightMode lightmode, in
 		int hwlightlevel = CalcLightLevel(lightmode, sectorlightlevel, rellight, weapon, cm.BlendFactor);
 		PalEntry pe = CalcLightColor(lightmode, hwlightlevel, cm.LightColor, cm.BlendFactor);
 		state.SetColorAlpha(pe, alpha, cm.Desaturation);
-		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight(sectorlightlevel + rellight), cm.BlendFactor);
+		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight(sectorlightlevel + rellight, false), cm.BlendFactor);
 		else state.SetNoSoftLightLevel();
 	}
 }

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -321,19 +321,30 @@ double R_ClampVisibility(double vis)
 	return clamp(vis, -204.7, 204.7);	// (205 and larger do not work in 5:4 aspect ratio)
 }
 
-CUSTOM_CVAR(Float, r_visibility, 8.0f, CVAR_NOINITCALL)
+CUSTOM_CVAR(Float, r_visibility, 8.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
-	if (netgame && self != 8.0f)
-	{
-		Printf("Visibility cannot be changed in net games.\n");
-		self = 8.0f;
-	}
-	else
-	{
-		float clampValue = (float)R_ClampVisibility(self);
-		if (self != clampValue)
-			self = clampValue;
-	}
+	if (self < 0.0f)
+		self = 0.0f;
+	else if (self > 16.0f)
+		self = 16.0f;
+}
+
+//==========================================================================
+//
+// r_extralight
+//
+// Amount of sector lighting to add on top of existing sector light levels.
+// This is just an additional amount to add so that the existing lighting mode
+// is preserved.
+//
+//==========================================================================
+
+CUSTOM_CVAR(Int, r_extralight, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self < -8)
+		self = -8;
+	else if (self > 8)
+		self = 8;
 }
 
 //==========================================================================

--- a/src/rendering/swrenderer/scene/r_light.cpp
+++ b/src/rendering/swrenderer/scene/r_light.cpp
@@ -45,6 +45,7 @@
 #include "swrenderer/viewport/r_viewport.h"
 
 EXTERN_CVAR(Bool, r_fullbrightignoresectorcolor)
+EXTERN_CVAR(Int, r_extralight)
 
 namespace swrenderer
 {
@@ -146,6 +147,7 @@ namespace swrenderer
 
 	fixed_t LightVisibility::LightLevelToShadeImpl(RenderViewport *viewport, int lightlevel, bool foggy)
 	{
+		lightlevel += r_extralight;
 		bool nolightfade = !foggy && ((viewport->Level()->flags3 & LEVEL3_NOLIGHTFADE));
 		if (nolightfade)
 		{

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2385,6 +2385,13 @@ OptionMenu ModReplayerOptions protected
 	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
 	Option "$ACCMNU_TOOLIP_SCALE", "m_tooltip_small", "OffOn"
 	Tooltip "$ACCMNU_TOOLTIP_EXAMPLE"
+	
+	StaticText ""
+	StaticText "$ACCMNU_LIGHT"
+	Slider "$ACCMNU_LIGHT_EXTRA", "r_extralight", -8, 8, 1, 0
+	Tooltip "$ACCMNU_TOOLTIP_LIGHT_EXTRA"
+	Slider "$ACCMNU_LIGHT_RADIUS", "r_visibility", 0.0, 16.0, 1.0, 1
+	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"
  }
 
 /*=======================================


### PR DESCRIPTION
This includes the ability to both control the light radius around the player and a new option that adds a flat amount of light to the world, trying to preserve the overall lighting model while making it brighter. Meant to be a replacement for the lightmodes as requested by #4. Can be found in the accessibility options menu.

I'm still not entirely sure if this implementation is correct for r_extralight, but it seems to give at least vaguely expected results. Fog is a bit questionable in Hexen but I'm not sure on how that's supposed to interact with the light level.