### PR TITLE
Use Steam libraryfolders.vdf on Linux & Mac

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -799,6 +799,7 @@ set (PCH_SOURCES
 	d_net.cpp
 	d_netinfo.cpp
 	d_protocol.cpp
+	d_steam.cpp
 	doomstat.cpp
 	g_cvars.cpp
 	g_dumpinfo.cpp

--- a/src/common/platform/posix/i_system.h
+++ b/src/common/platform/posix/i_system.h
@@ -47,7 +47,7 @@ bool I_PickIWad (bool showwin, FStartupSelectionInfo& info);
 
 // [RH] Checks the registry for Steam's install path, so we can scan its
 // directories for IWADs if the user purchased any through Steam.
-TArray<FString> I_GetSteamPath();
+FString I_GetSteamPath();
 
 TArray<FString> I_GetGogPaths();
 

--- a/src/common/platform/win32/i_system.h
+++ b/src/common/platform/win32/i_system.h
@@ -45,7 +45,7 @@ bool I_WriteIniFailed (const char* filename);
 
 // [RH] Checks the registry for Steam's install path, so we can scan its
 // directories for IWADs if the user purchased any through Steam.
-TArray<FString> I_GetSteamPath();
+FString I_GetSteamPath();
 
 // [GZ] Same deal for GOG paths
 TArray<FString> I_GetGogPaths();

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -38,6 +38,7 @@
 #include "c_cvars.h"
 #include "cmdlib.h"
 #include "d_main.h"
+#include "d_steam.h"
 #include "engineerrors.h"
 #include "filesystem.h"
 #include "findfile.h"
@@ -94,7 +95,7 @@ void FIWadManager::ParseIWadInfo(const char *fn, const char *data, int datasize,
 				// Skip the rest.
 				break;
 			}
-				
+
 			FIWADInfo *iwad = result ? result : &mIWadInfos[mIWadInfos.Reserve(1)];
 			sc.MustGetStringName("{");
 			while (!sc.CheckString("}"))
@@ -484,7 +485,7 @@ void FIWadManager::CollectSearchPaths()
 		}
 	}
 	mSearchPaths.Append(I_GetGogPaths());
-	mSearchPaths.Append(I_GetSteamPath());
+	mSearchPaths.Append(D_GetSteamGamePaths());
 	mSearchPaths.Append(I_GetBethesdaPath());
 
 	// Unify and remove trailing slashes

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -66,6 +66,9 @@ CVAR(Bool, i_loadsupportwad, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG) // Disabled i
 CVAR(Bool, i_is_new_release, true, 0)
 CVAR(Int, i_display_new_release, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG) // 0:no, 1: yes, 2: always for testing
 
+// Search game distributors' (Steam, GOG, Bethesda) paths for installed IWADs
+CVAR(Bool, i_searchdistributors, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+
 EXTERN_FARG(iwad);
 EXTERN_FARG(host);
 EXTERN_FARG(join);
@@ -484,9 +487,13 @@ void FIWadManager::CollectSearchPaths()
 			}
 		}
 	}
-	mSearchPaths.Append(I_GetGogPaths());
-	mSearchPaths.Append(D_GetSteamGamePaths());
-	mSearchPaths.Append(I_GetBethesdaPath());
+
+	if (i_searchdistributors)
+	{
+		mSearchPaths.Append(I_GetGogPaths());
+		mSearchPaths.Append(D_GetSteamGamePaths());
+		mSearchPaths.Append(I_GetBethesdaPath());
+	}
 
 	// Unify and remove trailing slashes
 	for (auto &str : mSearchPaths)

--- a/src/d_steam.cpp
+++ b/src/d_steam.cpp
@@ -45,8 +45,37 @@
 **
 */
 
+#include "cmdlib.h"
 #include "d_steam.h"
+#include "engineerrors.h"
+#include "i_system.h"
 #include "sc_man.h"
+
+static inline constexpr struct SteamAppInfo
+{
+	const char* const BasePath;
+	const int AppID;
+} SteamAppInfoList[] = {
+	{"Doom 2/base", 2300},
+	{"Final Doom/base", 2290},
+	{"Heretic Shadow of the Serpent Riders/base", 2390},
+	{"Hexen/base", 2360},
+	{"Hexen Deathkings of the Dark Citadel/base", 2370},
+	{"Ultimate Doom/base", 2280},
+	{"Ultimate Doom/base/doom2", 2280},
+	{"Ultimate Doom/base/tnt", 2280},
+	{"Ultimate Doom/base/plutonia", 2280},
+	{"DOOM 3 BFG Edition/base/wads", 208200},
+	{"Strife", 317040},
+	{"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets", 2280},
+	{"Ultimate Doom/rerelease", 2280},
+	{"Doom 2/rerelease/DOOM II_Data/StreamingAssets", 2300},
+	{"Doom 2/finaldoombase", 2300},
+    {"Master Levels of Doom/doom2", 9160},
+	{"Heretic + Hexen/dos/base/heretic", 3286930},
+	{"Heretic + Hexen/dos/base/hexen", 3286930},
+	{"Heretic + Hexen/dos/base/hexendk", 3286930}
+};
 
 static void PSR_FindEndBlock(FScanner &sc)
 {
@@ -101,5 +130,57 @@ TArray<FString> D_ParseSteamRegistry(const char* path)
 			}
 		}
 	}
+	return result;
+}
+
+TArray<FString> D_GetSteamGamePaths()
+{
+	TArray<FString> result;
+
+	// Get the install location of Steam on our system
+	FString SteamPath = I_GetSteamPath();
+	if (SteamPath.IsEmpty() || !DirExists(SteamPath.GetChars()))
+	{
+		// Steam is not installed
+		return result;
+	}
+
+	// Parse libraryfolders.vdf to figure out where the user has
+	// their games installed to.
+	TArray<FString> SteamLibraryFolders;
+	try
+	{
+		FString RegPath = SteamPath + "/config/libraryfolders.vdf";
+		SteamLibraryFolders = D_ParseSteamRegistry(RegPath.GetChars());
+	}
+	catch (const CRecoverableError &error)
+	{
+		// If we can't parse for some reason just pretend we can't find anything.
+		return result;
+	}
+
+	for (FString& folder : SteamLibraryFolders)
+	{
+		folder.ReplaceChars('\\', '/');
+		folder += "/";
+	}
+
+	// Always add the "canon" Steam library path, just in case
+	// libraryfolders.vdf does not exist.
+	SteamLibraryFolders.Push(SteamPath + "/steamapps/common/");
+
+	for (unsigned int i = 0; i < std::size(SteamAppInfoList); ++i)
+	{
+		for (const FString& folder : SteamLibraryFolders)
+		{
+			FString candidate(folder + SteamAppInfoList[i].BasePath);
+
+			if (DirExists(candidate.GetChars()))
+			{
+				result.Push(candidate);
+			}
+		}
+	}
+
 	return result;
 }

--- a/src/d_steam.h
+++ b/src/d_steam.h
@@ -1,0 +1,83 @@
+/*
+** d_steam.h
+** Detection for IWADs installed by Steam (or other distributors)
+**
+**---------------------------------------------------------------------------
+** Copyright 1998-2009 Randy Heit
+** Copyright 2007-2012 Skulltag Development Team
+** Copyright 2007-2016 Zandronum Development Team
+** Copyright 2017-2025 GZDoom Maintainers and Contributors
+** Copyright 2025 UZDoom Maintainers and Contributors
+** All rights reserved.
+**
+** Redistribution and use in source and binary forms, with or without
+** modification, are permitted provided that the following conditions
+** are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+**    notice, this list of conditions and the following disclaimer.
+** 2. Redistributions in binary form must reproduce the above copyright
+**    notice, this list of conditions and the following disclaimer in the
+**    documentation and/or other materials provided with the distribution.
+** 3. The name of the author may not be used to endorse or promote products
+**    derived from this software without specific prior written permission.
+** 4. Redistributions in any form must be accompanied by information on how to
+**    obtain complete source code for the software and any accompanying software
+**    that uses the software. The source code must either be included in the
+**    distribution or be available for no more than the cost of distribution plus
+**    a nominal fee, and must be freely redistributable under reasonable
+**    conditions. For an executable file, complete source code means the source
+**    code for all modules it contains. It does not include source code for
+**    modules or files that typically accompany the major components of the
+**    operating system on which the executable file runs.
+**
+** THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+** IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+** OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+** IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+** INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+** NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+** DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+** THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+** (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+** THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**---------------------------------------------------------------------------
+**
+*/
+
+
+#ifndef __D_STEAM_H__
+#define __D_STEAM_H__
+
+struct SteamAppInfo
+{
+	const char* const BasePath;
+	const int AppID;
+};
+
+inline constexpr SteamAppInfo SteamAppInfoList[] =
+{
+	{"Doom 2/base", 2300},
+	{"Final Doom/base", 2290},
+	{"Heretic Shadow of the Serpent Riders/base", 2390},
+	{"Hexen/base", 2360},
+	{"Hexen Deathkings of the Dark Citadel/base", 2370},
+	{"Ultimate Doom/base", 2280},
+	{"Ultimate Doom/base/doom2", 2280},
+	{"Ultimate Doom/base/tnt", 2280},
+	{"Ultimate Doom/base/plutonia", 2280},
+	{"DOOM 3 BFG Edition/base/wads", 208200},
+	{"Strife", 317040},
+	{"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets", 2280},
+	{"Ultimate Doom/rerelease", 2280},
+	{"Doom 2/rerelease/DOOM II_Data/StreamingAssets", 2300},
+	{"Doom 2/finaldoombase", 2300},
+    {"Master Levels of Doom/doom2", 9160},
+	{"Heretic + Hexen/dos/base/heretic", 3286930},
+	{"Heretic + Hexen/dos/base/hexen", 3286930},
+	{"Heretic + Hexen/dos/base/hexendk", 3286930}
+};
+
+TArray<FString> D_ParseSteamRegistry(const char* path);
+
+#endif // __D_STEAM_H__

--- a/src/d_steam.h
+++ b/src/d_steam.h
@@ -49,35 +49,6 @@
 #ifndef __D_STEAM_H__
 #define __D_STEAM_H__
 
-struct SteamAppInfo
-{
-	const char* const BasePath;
-	const int AppID;
-};
-
-inline constexpr SteamAppInfo SteamAppInfoList[] =
-{
-	{"Doom 2/base", 2300},
-	{"Final Doom/base", 2290},
-	{"Heretic Shadow of the Serpent Riders/base", 2390},
-	{"Hexen/base", 2360},
-	{"Hexen Deathkings of the Dark Citadel/base", 2370},
-	{"Ultimate Doom/base", 2280},
-	{"Ultimate Doom/base/doom2", 2280},
-	{"Ultimate Doom/base/tnt", 2280},
-	{"Ultimate Doom/base/plutonia", 2280},
-	{"DOOM 3 BFG Edition/base/wads", 208200},
-	{"Strife", 317040},
-	{"Ultimate Doom/rerelease/DOOM_Data/StreamingAssets", 2280},
-	{"Ultimate Doom/rerelease", 2280},
-	{"Doom 2/rerelease/DOOM II_Data/StreamingAssets", 2300},
-	{"Doom 2/finaldoombase", 2300},
-    {"Master Levels of Doom/doom2", 9160},
-	{"Heretic + Hexen/dos/base/heretic", 3286930},
-	{"Heretic + Hexen/dos/base/hexen", 3286930},
-	{"Heretic + Hexen/dos/base/hexendk", 3286930}
-};
-
-TArray<FString> D_ParseSteamRegistry(const char* path);
+TArray<FString> D_GetSteamGamePaths();
 
 #endif // __D_STEAM_H__

--- a/src/posix/i_steam.cpp
+++ b/src/posix/i_steam.cpp
@@ -55,7 +55,7 @@ FString I_GetSteamPath()
 	if (home != NULL && *home != '\0')
 	{
 		FString regPath;
-		regPath.Format("%s/.steam/steam", home);
+		regPath.Format("%s/.local/share/Steam", home);
 		return regPath;
 	}
 	return "";

--- a/src/posix/i_steam.cpp
+++ b/src/posix/i_steam.cpp
@@ -42,67 +42,24 @@
 #endif // __APPLE__
 
 #include "d_main.h"
-#include "d_steam.h"
 #include "engineerrors.h"
 #include "sc_man.h"
 #include "cmdlib.h"
 
-TArray<FString> I_GetSteamPath()
+FString I_GetSteamPath()
 {
-	TArray<FString> result;
-	TArray<FString> SteamInstallFolders;
-
-	// Linux and OS X actually allow the user to install to any location, so
-	// we need to figure out on an app-by-app basis where the game is installed.
-	// To do so, we read the virtual registry.
 #ifdef __APPLE__
-	const FString appSupportPath = M_GetMacAppSupportPath();
-	FString regPath = appSupportPath + "/Steam/config/libraryfolders.vdf";
-	try
-	{
-		SteamInstallFolders = D_ParseSteamRegistry(regPath.GetChars());
-	}
-	catch(class CRecoverableError &error)
-	{
-		// If we can't parse for some reason just pretend we can't find anything.
-		return result;
-	}
-
-	SteamInstallFolders.Push(appSupportPath + "/Steam/steamapps/common");
+	return M_GetMacAppSupportPath() + "/Steam";
 #else
 	char* home = getenv("HOME");
-	if(home != NULL && *home != '\0')
+	if (home != NULL && *home != '\0')
 	{
 		FString regPath;
-		regPath.Format("%s/.steam/steam/config/libraryfolders.vdf", home);
-
-		try
-		{
-			SteamInstallFolders = D_ParseSteamRegistry(regPath.GetChars());
-		}
-		catch(class CRecoverableError &error)
-		{
-			// If we can't parse for some reason just pretend we can't find anything.
-			return result;
-		}
-
-		regPath.Format("%s/.steam/steam/steamapps/common", home);
-		SteamInstallFolders.Push(regPath);
+		regPath.Format("%s/.steam/steam", home);
+		return regPath;
 	}
+	return "";
 #endif
-
-	for (unsigned int i = 0; i < SteamInstallFolders.Size(); ++i)
-	{
-		for (unsigned int app = 0; app < std::size(SteamAppInfoList); ++app)
-		{
-			struct stat st;
-			FString candidate(SteamInstallFolders[i] + "/" + SteamAppInfoList[app].BasePath);
-			if(DirExists(candidate.GetChars()))
-				result.Push(candidate);
-		}
-	}
-
-	return result;
 }
 
 TArray<FString> I_GetGogPaths()

--- a/src/win32/i_steam.cpp
+++ b/src/win32/i_steam.cpp
@@ -72,7 +72,6 @@
 
 #include "d_main.h"
 #include "d_net.h"
-#include "d_steam.h"
 #include "g_game.h"
 #include "c_dispatch.h"
 
@@ -233,43 +232,17 @@ TArray<FString> I_GetGogPaths()
 //
 //==========================================================================
 
-TArray<FString> I_GetSteamPath()
+FString I_GetSteamPath()
 {
-	TArray<FString> result;
-	FString steamPath;
+	FString SteamPath;
 
-	if (!QueryPathKey(HKEY_CURRENT_USER, L"Software\\Valve\\Steam", L"SteamPath", steamPath))
+	if (!QueryPathKey(HKEY_CURRENT_USER, L"Software\\Valve\\Steam", L"SteamPath", SteamPath))
 	{
-		if (!QueryPathKey(HKEY_LOCAL_MACHINE, L"Software\\Valve\\Steam", L"InstallPath", steamPath))
-			return result;
+		if (!QueryPathKey(HKEY_LOCAL_MACHINE, L"Software\\Valve\\Steam", L"InstallPath", SteamPath))
+			return "";
 	}
 
-	try
-	{
-		TArray<FString> paths = D_ParseSteamRegistry((steamPath + "/config/libraryfolders.vdf").GetChars());
-
-		for (FString& path : paths)
-		{
-			path.ReplaceChars('\\', '/');
-			path += "/";
-		}
-
-		paths.Push(steamPath + "/steamapps/common/");
-
-		for (unsigned int i = 0; i < std::size(SteamAppInfoList); ++i)
-		{
-			for (const FString& path : paths)
-			{
-				result.Push(path + SteamAppInfoList[i].BasePath);
-			}
-		}
-	}
-	catch (const CRecoverableError&)
-	{
-		// don't abort on errors in here. Just return an empty path.
-	}
-
-	return result;
+	return SteamPath;
 }
 
 //==========================================================================


### PR DESCRIPTION
I was annoyed that UZDoom didn't detect my Steam games and ended up down a rabbit hole...

For a while I had simply thought that separate library folders was not supported in Linux, but as it turns out: it did at one point, but Steam updated how it's handled, and then the Windows' code was updated without looking at other platforms (business as usual, lol)

I considered letting it look at `config.vdf` as a fallback, but decided against it because:
- The Windows version of this code doesn't look for this file at all.
- I looked at my system's own `config.vdf` and it does not have the "BaseInstallFolder" stuff that the old ParseSteamRegistry was trying to look for.
- I blame'd this code and it was around 2-11 years old, so I think it was just really dated in general.

The code already had a TODO for removing the duplication, so I went ahead and fixed that to try and prevent this from happening again in the future. The platform-specific code is only for getting the path to the file now.

**I changed it for Mac because I'm assuming Steam would do this for all 3 platforms if it did it for the other 2, but I'm not able to confirm for certain if this actually is the case or not.**