### PR TITLE
Fix am_cheat 4-6 behavior for textured automap mode

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -2083,6 +2083,12 @@ void DAutomap::drawSubsectors()
 			continue;
 		}
 
+		// [XA] don't draw hidden subsectors for am_cheat 4 and up
+		if (am_cheat >= 4 && (sub->render_sector->MoreFlags & SECMF_HIDDEN))
+		{
+			continue;
+		}
+
 		if (am_portaloverlay && sub->render_sector->PortalGroup != MapPortalGroup && sub->render_sector->PortalGroup != 0)
 		{
 			continue;
@@ -2200,7 +2206,8 @@ void DAutomap::drawSubsectors()
 
 		// If this subsector has not actually been seen yet (because you are cheating
 		// to see it on the map), tint and desaturate it.
-		if (!(sub->flags & SSECMF_DRAWN))
+		// [XA] show it at its true color on am_cheat 4 though, since that's the intent of the feature.
+		if (!(sub->flags & SSECMF_DRAWN) && am_cheat < 4)
 		{
 			colormap.LightColor = PalEntry(
 				(colormap.LightColor.r + 255) / 2,


### PR DESCRIPTION
The `am_cheat` cvar's modes 4 thru 6 are intended to show the automap as if the player has viewed every sector ([source](https://forum.zdoom.org/viewtopic.php?t=35959)), as a debug aid for automap cleanup. Turns out that textured mode wasn't quite respecting the intent here, so I made a couple of changes to true it up.

I've had Supplice on the brain lately so here's a couple of example screenshots from Supp E1M1 with `am_cheat` = 4 -- the northernmost sectors (and the signatures :P ) here are flagged as "not shown on textured automap" in UDB.

Old (latest `trunk`) -- hidden sectors still appear and are discolored a bit (which is intended behavior for am_cheat = 2, but not 4+):
<img width="1520" height="825" alt="Screenshot_Supplice_20251112_020138" src="https://github.com/user-attachments/assets/b5fd4d5b-483e-4ca6-b376-1b3bd48ab11d" />

New (with this PR) -- hidden sectors are hidden, and everything appears as the "seen" color, as if the player has viewed every sector:
<img width="1520" height="825" alt="Screenshot_Doom_20251112_020335" src="https://github.com/user-attachments/assets/5e18c987-2f50-4df4-a1a8-f158f7d24d96" />

`am_cheat` modes 1 through 3 are the same as before. No monkey business there.

