### PR TITLE
Dynamic quitsound sleep-lengths when quitting game

### DIFF
--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -417,10 +417,10 @@ CCMD (menu_quit)
 	{
 		if (!netgame)
 		{
-			if (gameinfo.quitSound.IsNotEmpty())
+			if (gameinfo.quitSound.IsNotEmpty() && S_FindSound(gameinfo.quitSound).isvalid())
 			{
 				S_Sound(CHAN_VOICE, CHANF_UI|(haptics_do_menus?CHANF_RUMBLE:CHANF_NORUMBLE), gameinfo.quitSound, snd_menuvolume, ATTN_NONE);
-				I_WaitVBL(105);
+				I_WaitVBL(clamp(S_GetMSLength(S_FindSound(gameinfo.quitSound))*0.0735, 105.0, 350.0)); // Aim for 5% over length of sound, to a maximum 5 seconds
 			}
 		}
 		M_Quit();


### PR DESCRIPTION
Just allowing for longer (up to 5 seconds) `gameinfo.quitSound` sound effects that are played when quitting the game.

The engine was only sleeping for 105/70 seconds for any sound effect being played, resulting in cutoffs.