### PR TITLE
Allowed spotlights to update angles in real time

### DIFF
--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -115,7 +115,8 @@ void AttachLight(AActor *self)
 	light->pSpotInnerAngle = &self->AngleVar(NAME_SpotInnerAngle);
 	light->pSpotOuterAngle = &self->AngleVar(NAME_SpotOuterAngle);
 	light->lightDefIntensity = 1.0;
-	light->pPitch = &self->Angles.Pitch;
+	light->Yaw = self->Angles.Yaw;
+	light->Pitch = self->Angles.Pitch;
 	light->pLightFlags = (LightFlags*)&self->IntVar(NAME_lightflags);
 	light->pArgs = self->args;
 	light->specialf1 = DAngle::fromDeg(double(self->SpawnAngle)).Normalized360().Degrees();
@@ -384,6 +385,12 @@ void FDynamicLight::UpdateLocation()
 		DAngle angle = target->Angles.Yaw;
 		double s = angle.Sin();
 		double c = angle.Cos();
+		if (IsSpot())
+		{
+			Yaw = angle;
+			if (!explicitpitch)
+				Pitch = target->Angles.Pitch;
+		}
 
 		Pos = target->Vec3Offset(m_off.X * c + m_off.Y * s, m_off.X * s - m_off.Y * c, m_off.Z + target->GetBobOffset());
 		Sector = target->subsector->sector;	// Get the render sector. target->Sector is the sector according to play logic.

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -262,7 +262,6 @@ public:
 	// To avoid having to copy these around every tic, these are pointers to the source data.
 	const DAngle *pSpotInnerAngle;
 	const DAngle *pSpotOuterAngle;
-	const DAngle *pPitch;	// This is to handle pitch overrides through GLDEFS, it can either point to the target's pitch or the light definition.
 	const int *pArgs;
 	const LightFlags *pLightFlags;
 
@@ -271,6 +270,7 @@ public:
 	sector_t *Sector;
 	FLevelLocals *Level;
 	TObjPtr<AActor *> target;
+	DAngle            Yaw, Pitch;
 
 	float radius;			// The maximum size the light can be with its current settings.
 	float m_currentRadius;	// The current light size.

--- a/src/r_data/a_dynlightdata.cpp
+++ b/src/r_data/a_dynlightdata.cpp
@@ -133,8 +133,10 @@ void FLightDefaults::ApplyProperties(FDynamicLight * light) const
 	{
 		light->pSpotInnerAngle = &m_spotInnerAngle;
 		light->pSpotOuterAngle = &m_spotOuterAngle;
-		if (m_explicitPitch) light->pPitch = &m_pitch;
-		else light->pPitch = &light->target->Angles.Pitch;
+		light->explicitpitch   = m_explicitPitch;
+		light->Yaw             = light->target->Angles.Yaw;
+		if (m_explicitPitch) light->Pitch = m_pitch;
+		else light->Pitch = light->target->Angles.Pitch;
 	}
 	light->m_tickCount = 0;
 	if (m_type == PulseLight)

--- a/src/rendering/hwrenderer/hw_dynlightdata.cpp
+++ b/src/rendering/hwrenderer/hw_dynlightdata.cpp
@@ -134,8 +134,8 @@ void AddLightToList(FDynLightData &dld, int group, FDynamicLight * light, bool f
 		spotInnerAngle = (float)light->pSpotInnerAngle->Cos();
 		spotOuterAngle = (float)light->pSpotOuterAngle->Cos();
 
-		DAngle negPitch = -*light->pPitch;
-		DAngle Angle = light->target->Angles.Yaw;
+		DAngle negPitch = -light->Pitch;
+		DAngle Angle = light->Yaw;
 		double xzLen = negPitch.Cos();
 		spotDirX = float(-Angle.Cos() * xzLen);
 		spotDirY = float(-negPitch.Sin());

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -168,8 +168,8 @@ void HWDrawInfo::GetDynSpriteLight(AActor *self, float x, float y, float z, FSec
 					if (light->IsSpot())
 					{
 						L *= -1.0f / dist;
-						DAngle negPitch = -*light->pPitch;
-						DAngle Angle = light->target->Angles.Yaw;
+						DAngle negPitch = -light->Pitch;
+						DAngle Angle = light->Yaw;
 						double xyLen = negPitch.Cos();
 						double spotDirX = -Angle.Cos() * xyLen;
 						double spotDirY = -Angle.Sin() * xyLen;

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -59,6 +59,7 @@
 #include "v_draw.h"
 #include "v_video.h"
 #include "vm.h"
+#include "a_dynlight.h"
 
 const float MY_SQRT2    = float(1.41421356237309504880); // sqrt(2)
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
@@ -1095,6 +1096,17 @@ void R_SetupFrame(FRenderViewpoint& viewPoint, const FViewWindow& viewWindow, AA
 	}
 
 	R_InterpolateView(viewPoint, player, viewPoint.TicFrac, iView);
+
+	// Update any spotlights to offset the camera's actual angle.
+	for (auto l : viewPoint.camera->AttachedLights)
+	{
+		if (l->IsSpot() && l->IsActive())
+		{
+			l->Yaw = viewPoint.Angles.Yaw;
+			if (!l->explicitpitch)
+				l->Pitch = viewPoint.Angles.Pitch;
+		}
+	}
 
 	viewPoint.SetViewAngle(viewWindow);
 


### PR DESCRIPTION
If the spotlight is anchored to a camera actor, use the camera's current render angle instead of the Actor's angle for better accuracy.