### PR TITLE
Fixed duplicate splash spawns

### DIFF
--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -1768,7 +1768,7 @@ class Actor : Thinker native
 				A_StartSound("*grunt", CHAN_VOICE, CHANF_NORUMBLE);
 				grunted = true;
 			}
-			bool isliquid = (pos.Z <= floorz) && HitFloor ();
+			bool isliquid = (pos.Z <= floorz) && GetFloorTerrain().IsLiquid;
 			if (onmobj != NULL || !isliquid)
 			{
 				if (!grunted)
@@ -1823,7 +1823,7 @@ class Actor : Thinker native
 	{
 		if (!CVar.GetCVar("haptics_do_world").GetBool()) return;
 
-		bool isliquid = (pos.Z <= floorz) && HitFloor ();
+		bool isliquid = (pos.Z <= floorz) && GetFloorTerrain().IsLiquid;
 		if (onmobj != NULL || !isliquid)
 		{
 			Haptics.Rumble("*land");


### PR DESCRIPTION
These were being spawned from cosmetic functions through HitFloor calls (this function has side effects).