### PR TITLE
Fix "archimage" skill level name

### DIFF
--- a/libraries/Translation/zdoom_engine_strings/en_US.po
+++ b/libraries/Translation/zdoom_engine_strings/en_US.po
@@ -3007,7 +3007,7 @@ msgid "MNU_WARLOCK"
 msgstr "Warlock"
 
 msgid "MNU_ARCHMAGE"
-msgstr "Archmage"
+msgstr "Archimage"
 
 msgid "MNU_CHOOSECLASS"
 msgstr "Choose Class:"


### PR DESCRIPTION
It is archimage, with an i, in vanilla Hexen. Not the eyeless archmage.