### PR TITLE
Disabled all mipmapping on Intel if in None filter modes

### DIFF
--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -52,6 +52,7 @@ struct SystemCallbacks
 	FConfigFile* (*GetConfig)();
 	bool (*WantEscape)();
 	FTranslationID(*RemapTranslation)(FTranslationID trans);
+	bool (*DisableAnisotropicFiltering)();
 };
 
 extern SystemCallbacks sysCallbacks;

--- a/src/common/rendering/gl/gl_samplers.cpp
+++ b/src/common/rendering/gl/gl_samplers.cpp
@@ -120,12 +120,13 @@ void FSamplerManager::SetTextureFilterMode()
 	}
 
 	int filter = sysCallbacks.DisableTextureFilter && sysCallbacks.DisableTextureFilter() ? 0 : gl_texture_filter;
+	float aniso  = filter <= 0 || (sysCallbacks.DisableAnisotropicFiltering && sysCallbacks.DisableAnisotropicFiltering()) ? 1.0f : gl_texture_filter_anisotropic;
 
 	for (int i = 0; i < 4; i++)
 	{
 		glSamplerParameteri(mSamplers[i], GL_TEXTURE_MIN_FILTER, TexFilter[filter].minfilter);
 		glSamplerParameteri(mSamplers[i], GL_TEXTURE_MAG_FILTER, TexFilter[filter].magfilter);
-		glSamplerParameterf(mSamplers[i], GL_TEXTURE_MAX_ANISOTROPY_EXT, filter > 0? gl_texture_filter_anisotropic : 1.0);
+		glSamplerParameterf(mSamplers[i], GL_TEXTURE_MAX_ANISOTROPY_EXT, aniso);
 	}
 	glSamplerParameteri(mSamplers[CLAMP_XY_NOMIP], GL_TEXTURE_MIN_FILTER, TexFilter[filter].magfilter);
 	glSamplerParameteri(mSamplers[CLAMP_XY_NOMIP], GL_TEXTURE_MAG_FILTER, TexFilter[filter].magfilter);

--- a/src/common/rendering/gles/gles_samplers.cpp
+++ b/src/common/rendering/gles/gles_samplers.cpp
@@ -67,7 +67,9 @@ uint8_t FSamplerManager::Bind(int texunit, int num, int lastval)
 {
 
 	int filter = sysCallbacks.DisableTextureFilter && sysCallbacks.DisableTextureFilter() ? 0 : gl_texture_filter;
-	bool anisoAvailable = gles.anistropicFilterAvailable && (!sysCallbacks.DisableTextureFilter || !sysCallbacks.DisableTextureFilter());
+	bool anisoAvailable = gles.anistropicFilterAvailable &&
+	                      (!sysCallbacks.DisableTextureFilter || !sysCallbacks.DisableTextureFilter()) &&
+	                      (!sysCallbacks.DisableAnisotropicFiltering || !sysCallbacks.DisableAnisotropicFiltering());
 
 	glActiveTexture(GL_TEXTURE0 + texunit);
 	switch (num)

--- a/src/common/rendering/hwrenderer/hw_draw2d.cpp
+++ b/src/common/rendering/hwrenderer/hw_draw2d.cpp
@@ -72,7 +72,7 @@ void Draw2D(F2DDrawer* drawer, FRenderState& state, int x, int y, int width, int
 	state.EnableMultisampling(false);
 	state.EnableLineSmooth(gl_aalines);
 
-	bool cache_hw_2dmip = hw_2dmip; // cache cvar lookup so it's not done in a loop
+	bool cache_hw_2dmip = hw_2dmip && (!sysCallbacks.DisableAnisotropicFiltering || !sysCallbacks.DisableAnisotropicFiltering()); // cache cvar lookup so it's not done in a loop
 
 	auto &vertices = drawer->mVertices;
 	auto &indices = drawer->mIndices;

--- a/src/common/rendering/vulkan/textures/vk_samplers.cpp
+++ b/src/common/rendering/vulkan/textures/vk_samplers.cpp
@@ -86,6 +86,7 @@ void VkSamplerManager::ResetHWSamplers()
 void VkSamplerManager::CreateHWSamplers()
 {
 	int filter = sysCallbacks.DisableTextureFilter && sysCallbacks.DisableTextureFilter()? 0 : gl_texture_filter;
+	bool anisoAvailable = !sysCallbacks.DisableAnisotropicFiltering || !sysCallbacks.DisableAnisotropicFiltering();
 
 	for (int i = CLAMP_NONE; i <= CLAMP_XY; i++)
 	{
@@ -94,7 +95,7 @@ void VkSamplerManager::CreateHWSamplers()
 		builder.MinFilter(TexFilter[filter].minFilter);
 		builder.AddressMode(TexClamp[i].clamp_u, TexClamp[i].clamp_v, VK_SAMPLER_ADDRESS_MODE_REPEAT);
 		builder.MipmapMode(TexFilter[filter].mipfilter);
-		if (TexFilter[filter].mipmapping)
+		if (TexFilter[filter].mipmapping && anisoAvailable)
 		{
 			builder.Anisotropy(gl_texture_filter_anisotropic);
 			builder.MaxLod(100.0f); // According to the spec this value is clamped so something high makes it usable for all textures.

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3052,6 +3052,11 @@ static bool System_DisableTextureFilter()
 	return !V_IsHardwareRenderer();
 }
 
+static bool System_DisableAnisotropicFiltering()
+{
+	return V_DisableIntelMipmap();
+}
+
 static void System_OnScreenSizeChanged()
 {
 	if (StatusBar != NULL)
@@ -3956,7 +3961,8 @@ static int D_DoomMain_Internal (void)
 		OkForLocalization,
 		[]() ->FConfigFile* { return GameConfig; },
 		nullptr,
-		RemapUserTranslation
+		RemapUserTranslation,
+		System_DisableAnisotropicFiltering
 	};
 
 	std::set_new_handler(NewFailure);

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -34,6 +34,7 @@
 #include "m_argv.h"
 #include "startupinfo.h"
 #include "c_cvars.h"
+#include "v_video.h"
 #include <csignal>
 
 extern bool		advancedemo;
@@ -172,6 +173,7 @@ public:
 
 };
 
+EXTERN_CVAR(Int, gl_texture_filter)
 #ifndef NO_SWRENDERER
 EXTERN_CVAR(Int, vid_rendermode)
 #else
@@ -181,6 +183,14 @@ constexpr int vid_rendermode = 4;
 inline bool V_IsHardwareRenderer()
 {
 	return vid_rendermode == 4;
+}
+
+// Unfortunately Intel forces on filtering if mipmapping is enabled, so None modes of filtering
+// need to outright disable it.
+inline bool V_DisableIntelMipmap()
+{
+	constexpr char Intel[] = "Intel";
+	return !stricmp(screen->vendorstring, Intel) && (gl_texture_filter == 1 || gl_texture_filter == 5 || gl_texture_filter == 6);
 }
 
 inline bool V_IsTrueColor()


### PR DESCRIPTION
This is an attempt to work around #194. See the discussion in this issue for more details on the problem, but as a quick summary, Intel GPUs always force on filtering when mipmapping is enabled, making the non-standard None texture filter options functionally broken.

As none of us have Intel cards on us to test this, it will need verification. It tries to resolve both menu and texture filtering at the same time, so testing on all 3 backends (OpenGL, GLES, and Vulkan) would be greatly appreciated. This can't really be merged until all 3 cases are resolved.