### PR TITLE
Add UZDoom's default paths to an ini from GZDoom

### DIFF
--- a/src/common/utility/configfile.cpp
+++ b/src/common/utility/configfile.cpp
@@ -493,6 +493,37 @@ void FConfigFile::SetValueForKey (const char *key, const char *value, bool dupli
 
 //====================================================================
 //
+// FConfigFile :: EnsureValueForKey
+//
+// Creates a duplicated key, but only if the value is not present
+// across any of the other duplicated keys.
+//
+//====================================================================
+
+void FConfigFile::EnsureValueForKey (const char *key, const char *value)
+{
+	if (CurrentSection != NULL)
+	{
+		FConfigEntry *probe = CurrentSection->RootEntry;
+
+		while (probe != NULL)
+		{
+			if (stricmp(probe->Key, key) == 0
+				&& stricmp(probe->Value, value) == 0)
+			{
+				// Already exists exactly, don't duplicate
+				return;
+			}
+
+			probe = probe->Next;
+		}
+
+		NewConfigEntry (CurrentSection, key, value);
+	}
+}
+
+//====================================================================
+//
 // FConfigFile :: FindSection
 //
 //====================================================================

--- a/src/common/utility/configfile.h
+++ b/src/common/utility/configfile.h
@@ -71,6 +71,12 @@ public:
 		SetValueForKey(key, value.GetChars(), duplicates);
 	}
 
+	void EnsureValueForKey (const char *key, const char *value);
+	void EnsureValueForKey(const char* key, const FString& value)
+	{
+		EnsureValueForKey(key, value.GetChars());
+	}
+
 	const char *GetPathName () const { return PathName.GetChars(); }
 	void ChangePathName (const char *path);
 

--- a/src/version.h
+++ b/src/version.h
@@ -60,7 +60,7 @@ const char *GetVersionString();
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "226"
+#define LASTRUNVERSION "227"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.


### PR DESCRIPTION
Kinda done in a brute-force-y way: it just double-checks all of the system-related default paths exist, instead of only the ones related to the "uzdoom" folder(s). I just wanted to avoid adding even more edge-cases to how paths are defined (the path definitions are already really clustered). Plus GZDoom didn't have XDG stuff so I do think it'd be good to double-check all of the paths. But if need-be, I can make a separate table for the "game name" paths.

Should resolve #425, will need cherry-picked to 4.14.3 as well.