### PR TITLE
Interpret and strip comments in response files

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -269,3 +269,4 @@ RageSpark
 Phil "Shadsy" Salvador
 Charles the Thobe
 Leah Anderson
+wallabra

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -17,11 +17,15 @@
 **
 */
 
+#include <cctype>
+#include <cstdint>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sstream>
 #include <stdlib.h>
 #include <errno.h>
 #include <time.h>
+#include <valarray>
 
 #include "r_defs.h"
 
@@ -78,6 +82,77 @@ static size_t ParseCommandLine (const char *args, int *argc, char **argv);
 //
 //---------------------------------------------------------------------------
 
+// Change this if you want to use a different token to open comments inside a response file.
+static const char *const COMMENT_TOKEN = "#";
+
+static const uint16_t UF_STRIP_WHITESPACE = 1;
+static const uint16_t UF_SKIP_EMPTY = 2;
+static const uint16_t UF_ALLOW_TRAILING = 4;
+
+static std::string Uncomment(const char* from, const uint16_t uncomment_flags = 0)
+{
+	std::stringstream outstream;
+
+	{
+		std::stringstream instream(from);
+		std::string line;
+
+		const bool strip_whitespace = (uncomment_flags & UF_STRIP_WHITESPACE) != 0;
+		const bool skip_empty = (uncomment_flags & UF_SKIP_EMPTY) != 0;
+		const bool allow_trailing = (uncomment_flags & UF_ALLOW_TRAILING) != 0;
+
+		while (std::getline(instream, line)) {
+			// skip comments
+			auto cidx = line.find(COMMENT_TOKEN); // comment token position
+
+			if (cidx == 0) {
+				// starts with token
+				continue;
+			}
+
+			// comment must be first non-whitespace token
+			if (!allow_trailing && cidx != std::string::npos) {
+				size_t start = 0;
+				while (start < cidx && std::isspace(static_cast<unsigned char>(line[start]))) start++;
+				if (start != cidx) cidx = std::string::npos;
+			}
+
+			// case 1: token is in the middle, strip until cidx
+			// case 2: token not present, cidx == npos, aka max size value, so a noop
+			// (faster than adding an IF branch)
+			const std::string_view substring = std::string_view(line).substr(0, cidx);
+
+			// strip whitespace around line
+			size_t start = 0;
+			size_t end = substring.size();
+
+			// skip actually empty lines
+			if (skip_empty && end == 0) {
+				continue;
+			}
+
+			if (strip_whitespace) {
+				// find leading
+				while (start < end && std::isspace(static_cast<unsigned char>(substring[start]))) start++;
+				// trim trailing
+				while (end > start && std::isspace(static_cast<unsigned char>(substring[end - 1]))) end--;
+			}
+
+			const std::string_view trimmed = substring.substr(start, end - start);
+
+			// skip functionally empty lines
+			if (skip_empty && trimmed.size() == 0) {
+				continue;
+			}
+
+			// spit good value
+			outstream << trimmed << ' ';
+		}
+	}
+
+	return outstream.str();
+}
+
 void M_FindResponseFile (void)
 {
 	const int limit = 100;	// avoid infinite recursion
@@ -94,6 +169,7 @@ void M_FindResponseFile (void)
 		{
 			char	**argv;
 			FileSys::FileData file;
+			std::string uncommented;
 			int		argc = 0;
 			size_t	argsize = 0;
 			int 	index;
@@ -112,7 +188,8 @@ void M_FindResponseFile (void)
 				{
 					Printf ("Found response file %s!\n", Args->GetArg(i) + 1);
 					file = fr.ReadPadded(1);
-					argsize = ParseCommandLine (file.string(), &argc, nullptr);
+					uncommented = Uncomment(file.string(), UF_SKIP_EMPTY | UF_STRIP_WHITESPACE);
+					argsize = ParseCommandLine (uncommented.c_str(), &argc, nullptr);
 				}
 			}
 			else
@@ -124,7 +201,7 @@ void M_FindResponseFile (void)
 			{
 				argv = (char **)M_Malloc (argc*sizeof(char *) + argsize);
 				argv[0] = (char *)argv + argc*sizeof(char *);
-				ParseCommandLine (file.string(), nullptr, argv);
+				ParseCommandLine (uncommented.c_str(), nullptr, argv);
 
 				// Create a new argument vector
 				FArgs *newargs = new FArgs;
@@ -345,17 +422,17 @@ struct pcx_t
 	uint16_t			ymin;
 	uint16_t			xmax;
 	uint16_t			ymax;
-	
+
 	uint16_t			hdpi;
 	uint16_t			vdpi;
 
 	uint8_t				palette[48];
-	
+
 	int8_t				reserved;
 	int8_t				color_planes;
 	uint16_t			bytes_per_line;
 	uint16_t			palette_type;
-	
+
 	int8_t				filler[58];
 };
 


### PR DESCRIPTION
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms. 

---

Closes #488.

Interprets `// comments` from response files (`-file @my-response-file.txt`), ignoring their contents, allowing for non-value literate text inside response files.

This fixes the behavior seen in #488.

Example of a response file that should work properly now:

```
mod/yummy/yummy_base.pk3

// Loads my favorite mods :D
mod/yummy/condiment_base.pk3
  mod/yummy/ketchup.pk3
  mod/yummy/mustard.pk3
//--

// Extra ingredients
mod/yummy/extra_base.pk3
  mod/yummy/pickles.pk3
  // - NOTE: My sister is allergic to onions, so comment the following out
  // - only when she's at home ... yes, AT home - I'm evil >:)
  //mod/yummy/onions.pk3
//--
```