### PR TITLE
Added auto compatibility option

### DIFF
--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -48,6 +48,8 @@
 #include "p_visualthinker.h"
 #include <memory>
 
+EXTERN_CVAR(Bool, sv_autocompat)
+
 struct FGlobalDLightLists
 {
 	//TODO add TSet and switch from TMap to TSet
@@ -865,6 +867,12 @@ public:
 		if (dmflags & DF_YES_FREELOOK)
 			return true;
 		return !(flags & LEVEL_FREELOOK_NO);
+	}
+
+	bool MissileShouldClip() const
+	{
+		return (i_compatflags & COMPATF_MISSILECLIP) ||
+			(sv_autocompat && (gameinfo.gametype & GAME_DoomChex) && maptype == MAPTYPE_DOOM);
 	}
 
 	node_t		*HeadNode() const

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -65,6 +65,7 @@
 CVAR(Bool, cl_bloodsplats, true, CVAR_ARCHIVE)
 CVAR(Int, sv_smartaim, 0, CVAR_ARCHIVE | CVAR_SERVERINFO)
 CVAR(Bool, cl_doautoaim, false, CVAR_ARCHIVE)
+CVAR(Bool, sv_autocompat, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_SERVERINFO)
 
 static void CheckForPushSpecial(line_t *line, int side, AActor *mobj, DVector2 * posforwindowcheck = NULL);
 static void SpawnShootDecal(AActor *t1, AActor *defaults, const FTraceResults &trace);
@@ -1583,7 +1584,7 @@ bool PIT_CheckThing(FMultiBlockThingsIterator &it, FMultiBlockThingsIterator::Ch
 		{
 			clipheight = thing->projectilepassheight;
 		}
-		else if (thing->projectilepassheight < 0 && (thing->Level->i_compatflags & COMPATF_MISSILECLIP))
+		else if (thing->projectilepassheight < 0 && thing->Level->MissileShouldClip())
 		{
 			clipheight = -thing->projectilepassheight;
 		}
@@ -2170,7 +2171,7 @@ int P_TestMobjZ(AActor *actor, bool quick, AActor **pOnmobj)
 			{
 				clipheight = thing->projectilepassheight;
 			}
-			else if (thing->projectilepassheight < 0 && (thing->Level->i_compatflags & COMPATF_MISSILECLIP))
+			else if (thing->projectilepassheight < 0 && thing->Level->MissileShouldClip())
 			{
 				clipheight = -thing->projectilepassheight;
 			}

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1869,6 +1869,7 @@ OptionMenu "CompatibilityOptions" protected
 {
 	Position -35
 	Title "$CMPTMNU_TITLE"
+	Option "$CMPTMNU_AUTO",							"sv_autocompat", "OnOff"
 	Option "$CMPTMNU_MODE",							"compatmode", "CompatModes", "", 1
 	StaticText " "
 	Submenu "$CMPTMNU_ACTORBEHAVIOR",				"CompatActorMenu"


### PR DESCRIPTION
This attempts to fix more map-breaking compatibility options by enabling certain behaviors in intelligent ways based on both game and map type. To start, auto missile clipping has been added, making it so in vanilla Doom maps specifically missiles will pass through things like torches, matching the original game.

I'm aware that the UDMF handling on the map type is technically wrong as it doesn't account for namespaces, but this can be fixed at a later time as I imagine even with DSDA UDMF few maps have it at the moment, relatively speaking. The only real upgrade needed here would be to check against the ZDoom namespace since other namespaces are probably for ports that use vanilla behaviors by default. Hexen is also not included in the test since it had Actor over Actor and thus needed correct Actor heights by default (this should help catch any pre-UDMF maps made for ZDoom).

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.