### PR TITLE
5.0: Increment LASTRUNVERSION to 229

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -701,7 +701,8 @@ void FGameConfigFile::DoGlobalSetup ()
 					var->SetGenericRep(v, CVAR_Int);
 				}
 			}
-			if (last < 226)
+			if (last < 226 // GZDoom 4.14.2
+				|| last == 228) // UZDoom 4.14.3 (227 was used in a bunch of 5.0 dev builds)
 			{
 				// We can't handle key config yet, because
 				// the files aren't fully loaded. Just queue

--- a/src/version.h
+++ b/src/version.h
@@ -60,7 +60,7 @@ const char *GetVersionString();
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "227"
+#define LASTRUNVERSION "229"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.


### PR DESCRIPTION
I messed up, so 4.14.3 needed to be increased to 228, thus 5.0 needs to be on 229. (See: #499)