### PR TITLE
Added optional gameplay mod submenu to options

### DIFF
--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -362,6 +362,7 @@ OptionMenu "OptionsMenu" protected
 	StaticText " "
 	Submenu "$OPTMNU_PLAYER",			"NewPlayerMenu"
 	Submenu "$OPTMNU_GAMEPLAY",			"GameplayOptions"
+	OptionalSubmenu "$OPTMNU_ADDONS",	"AddOnOptions"
 	Submenu "$OPTMNU_COMPATIBILITY",	"CompatibilityOptions"
 	Submenu "$OPTMNU_AUTOMAP",			"AutomapOptions"
 	Submenu "$OPTMNU_HUD",				"HUDOptions"
@@ -1774,6 +1775,14 @@ OptionMenu GameplayOptions protected
 	Option "$GMPLYMNU_NOCOUNTENDMONSTER",		"sv_nocountendmonst", "NoYes"
 	Option "$GMPLYMNU_ALWAYSSPAWNMULTI",		"sv_alwaysspawnmulti", "YesNo"
 	Class "GameplayMenu"
+}
+
+// This is solely meant to be added to by mods. Ideally they should use their own
+// submenus within this.
+OptionMenu AddOnOptions protected
+{
+	Position -35
+	Title 	"$ADDONMNU_TITLE"
 }
 
 OptionMenu DeathmatchOptions protected

--- a/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenuitems.zs
@@ -181,6 +181,15 @@ class OptionMenuItemSubmenu : OptionMenuItem
 	}
 }
 
+class OptionMenuItemOptionalSubmenu : OptionMenuItemSubmenu
+{
+	override bool Visible()
+	{
+		let desc = OptionMenuDescriptor(MenuDescriptor.GetDescriptor(mAction));
+		return desc && desc.mItems.Size() > 0 && Super.Visible();
+	}
+}
+
 //=============================================================================
 //
 // opens a submenu, command is a submenu name


### PR DESCRIPTION
Allows modders to add their mod settings into this menu rather than appending it to the very bottom by adding to GameplayModOptions. Also adds OptionalSubmenu to MENUDEF, a  submenu label type that only displays if its menu has any content to do so.

Implements #498 in a way that I consider unobtrusive to how MENUDEF works. I don't think adding backwords compat for this is possible without potentially messing up a bunch of other menus and how they work.