### PR TITLE
Fix LookForEnemiesEx().

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1445,7 +1445,7 @@ DEFINE_ACTION_FUNCTION(AActor, LookForEnemiesEx)
 
 	while (it.Next(&cres))
 	{
-		if ((cres.thing->player == nullptr && ValidEnemyInBlock(cres.thing, self, params)) ||
+		if ((cres.thing->player == nullptr && ValidEnemyInBlock(self, cres.thing, params)) ||
 			(!noPlayers && cres.thing->player && isTargetablePlayer(self, cres.thing->player, allaround, params)))
 			targets->Push(cres.thing);
 	}


### PR DESCRIPTION
ValidEnemyInBlock() was doing sight checks with the iterated thing as the onlooker instead of the self pointer. Which causes issues like return dead enemies as valid.