### PR TITLE
Enable a default crosshair with a more sensible scale size for modern displays

### DIFF
--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -59,7 +59,7 @@ IMPLEMENT_CLASS(DHUDFont, false, false);
 
 CVAR(Color, crosshaircolor, 0xff0000, CVAR_ARCHIVE);
 CVAR(Int, crosshairhealth, 2, CVAR_ARCHIVE);
-CVARD(Float, crosshairscale, 0.5, CVAR_ARCHIVE, "changes the size of the crosshair");
+CVARD(Float, crosshairscale, 0.2, CVAR_ARCHIVE, "changes the size of the crosshair");
 CVAR(Bool, crosshairgrow, false, CVAR_ARCHIVE);
 
 CUSTOM_CVARD(Float, hud_scalefactor, 1.f, CVAR_ARCHIVE, "changes the hud scale")

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -123,7 +123,7 @@ EXTERN_CVAR(Float, hud_scalefactor)
 EXTERN_CVAR(Bool, hud_aspectscale)
 
 CVAR (Bool, crosshairon, true, CVAR_ARCHIVE);
-CVAR (Int, crosshair, 0, CVAR_ARCHIVE)
+CVAR (Int, crosshair, 1, CVAR_ARCHIVE)
 CVAR (Bool, crosshairforce, false, CVAR_ARCHIVE)
 CUSTOM_CVAR(Int, am_showmaplabel, 2, CVAR_ARCHIVE)
 {


### PR DESCRIPTION
My rationale is that mouselook is already enabled by default _anyway_, therefore not having a crosshair to go with it by default comes off as a missing feature to me.

Here's the tweaked settings on a 1080p display. I think the chosen `crosshairscale` size looks decent here.

<img width="1920" height="1080" alt="Screenshot_Doom_20251119_210057" src="https://github.com/user-attachments/assets/ade75f0d-bddb-400b-ad47-d471ea982441" />
