### PR TITLE
Louden UI sounds to match the overall game volume.

### DIFF
--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -63,7 +63,7 @@ static ScaleOverrider *CurrentScaleOverrider;
 CVAR (Int, m_showinputgrid, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, m_blockcontrollers, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
-CVAR (Float, snd_menuvolume, 0.6f, CVAR_ARCHIVE)
+CVAR (Float, snd_menuvolume, 1.0f, CVAR_ARCHIVE)
 CVAR(Int, m_use_mouse, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Int, m_show_backbutton, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR(Bool, m_cleanscale, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)


### PR DESCRIPTION


https://github.com/user-attachments/assets/3be54a2a-1029-4835-916b-9c7622244699




Due to the fixed audio volume issues in UZDoom (a welcome change), unfortunately now the menu sounds are too quiet.

Listen to the volume differences when the menu sounds are played between the old and new values. The latter has more consistent volume between gameplay and menu, and was in fact how it originally was in GZDoom