### PR TITLE
Added interpolated movement for dynamic lights

### DIFF
--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -376,58 +376,99 @@ void FDynamicLight::Tick()
 //==========================================================================
 void FDynamicLight::UpdateLocation()
 {
-	double oldx= X();
-	double oldy= Y();
+	if (!IsActive())
+		return;
+
+	const DVector3 oldpos = Pos;
 	float oldradius = radius;
 
-	if (IsActive())
+	AActor *target = this->target;	// perform the read barrier only once.
+
+	// Offset is calculated in relation to the owning actor.
+	DAngle angle = target->Angles.Yaw;
+	double s = angle.Sin();
+	double c = angle.Cos();
+	if (IsSpot())
 	{
-		AActor *target = this->target;	// perform the read barrier only once.
+		Yaw = angle;
+		if (!explicitpitch)
+			Pitch = target->Angles.Pitch;
+	}
 
-		// Offset is calculated in relation to the owning actor.
-		DAngle angle = target->Angles.Yaw;
-		double s = angle.Sin();
-		double c = angle.Cos();
-		if (IsSpot())
+	Vel.Z  = 0.0;
+	Pos = target->Vec3Offset(m_off.X * c + m_off.Y * s, m_off.X * s - m_off.Y * c, m_off.Z + target->GetBobOffset());
+	Sector = target->subsector->sector;	// Get the render sector. target->Sector is the sector according to play logic.
+
+	if (!(target->flags5 & MF5_NOINTERACTION))
+	{
+		// Some z-coordinate fudging to prevent the light from getting too close to the floor or ceiling planes. With proper attenuation this would render them invisible.
+		// A distance of 5 is needed so that the light's effect doesn't become too small.
+		// [SP] don't do this if +NOINTERACTION is set, since the object can fly right through floors and ceilings with that flag
+		if (Z() < target->floorz + 5.) Pos.Z = target->floorz + 5.;
+		else if (Z() > target->ceilingz - 5.) Pos.Z = target->ceilingz - 5.;
+	}
+
+	// The radius being used here is always the maximum possible with the
+	// current settings. This avoids constant relinking of flickering lights
+
+	float intensity;
+
+	if (lighttype == FlickerLight || lighttype == RandomFlickerLight || lighttype == PulseLight)
+	{
+		intensity = float(max(GetIntensity(), GetSecondaryIntensity()));
+	}
+	else
+	{
+		intensity = m_currentRadius;
+	}
+	radius = intensity * 2.0f;
+	if (radius < m_currentRadius * 2) radius = m_currentRadius * 2;
+
+	const bool interpolated = IsInterpolated();
+	// This requires no relinking so is free, it just needs to be gated to ensure it doesn't look
+	// wonky next to the x and y not interpolating.
+	if (interpolated)
+		Vel.Z = oldpos.Z - Z();
+
+	if (X() != oldpos.X || Y() != oldpos.Y || radius != oldradius)
+	{
+		// If we're interpolating light movement, do a singular large relink that covers the span of all
+		// desired sectors along the path. This makes movements more expensive but is needed to ensure all
+		// sectors in the interpolated movement are captured at once. Dynamically relinking every single
+		// frame would be too expensive.
+		if (interpolated)
 		{
-			Yaw = angle;
-			if (!explicitpitch)
-				Pitch = target->Angles.Pitch;
-		}
-
-		Pos = target->Vec3Offset(m_off.X * c + m_off.Y * s, m_off.X * s - m_off.Y * c, m_off.Z + target->GetBobOffset());
-		Sector = target->subsector->sector;	// Get the render sector. target->Sector is the sector according to play logic.
-
-		if (!(target->flags5 & MF5_NOINTERACTION))
-		{
-			// Some z-coordinate fudging to prevent the light from getting too close to the floor or ceiling planes. With proper attenuation this would render them invisible.
-			// A distance of 5 is needed so that the light's effect doesn't become too small.
-			// [SP] don't do this if +NOINTERACTION is set, since the object can fly right through floors and ceilings with that flag
-			if (Z() < target->floorz + 5.) Pos.Z = target->floorz + 5.;
-			else if (Z() > target->ceilingz - 5.) Pos.Z = target->ceilingz - 5.;
-		}
-
-		// The radius being used here is always the maximum possible with the
-		// current settings. This avoids constant relinking of flickering lights
-
-		float intensity;
-
-		if (lighttype == FlickerLight || lighttype == RandomFlickerLight || lighttype == PulseLight)
-		{
-			intensity = float(max(GetIntensity(), GetSecondaryIntensity()));
+			Vel.X = oldpos.X - X();
+			Vel.Y = oldpos.Y - Y();
+			if (!Vel.XY().isZero())
+			{
+				double         curRad = radius;
+				const DVector3 curPos = Pos;
+				radius += Vel.XY().Length() * 0.5;
+				Pos.X -= Vel.X * 0.5;
+				Pos.Y -= Vel.Y * 0.5;
+				LinkLight();
+				radius = curRad;
+				Pos    = curPos;
+			}
+			else
+			{
+				// Only a radius change, don't bother with interpolating.
+				LinkLight();
+			}
 		}
 		else
 		{
-			intensity = m_currentRadius;
-		}
-		radius = intensity * 2.0f;
-		if (radius < m_currentRadius * 2) radius = m_currentRadius * 2;
-
-		if (X() != oldx || Y() != oldy || radius != oldradius)
-		{
-			//Update the light lists
+			// Update the light lists
+			Vel.XY().Zero();
 			LinkLight();
 		}
+	}
+	else if (!Vel.XY().isZero())
+	{
+		// If we interpolated a movement last tick, make sure to link back to our real position.
+		Vel.XY().Zero();
+		LinkLight();
 	}
 }
 

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -42,7 +42,8 @@ enum LightFlag
 	LF_DONTLIGHTACTORS = 32,
 	LF_SPOT = 64,
 	LF_DONTLIGHTOTHERS = 128,
-	LF_DONTLIGHTMAP = 256
+	LF_DONTLIGHTMAP = 256,
+	LF_INTERPOLATED = 512,
 };
 
 typedef TFlags<LightFlag> LightFlags;
@@ -202,6 +203,11 @@ struct FDynamicLight
 		return Pos + Level->Displacements.getOffset(Sector->PortalGroup, portalgroup);
 	}
 
+	inline DVector3 GetPos(int portalgroup, double ticFrac) const
+	{
+		return PosRelative(portalgroup) + Vel * (1.0 - ticFrac);
+	}
+
 	bool ShouldLightActor(AActor *check)
 	{
 		return visibletoplayer && IsActive() && 
@@ -226,6 +232,7 @@ struct FDynamicLight
 	double GetLightDefIntensity() const { return lightDefIntensity; }
 	int GetTimer() const { return target->IsClientSide() ? Level->LocalTimer : Level->LocalWorldTimer; }
 
+	bool IsInterpolated() const { return ((*pLightFlags) & LF_INTERPOLATED); }
 	bool IsSubtractive() const { return !!((*pLightFlags) & LF_SUBTRACTIVE); }
 	bool IsAdditive() const { return !!((*pLightFlags) & LF_ADDITIVE); }
 	bool IsSpot() const { return !!((*pLightFlags) & LF_SPOT); }
@@ -256,7 +263,7 @@ private:
 
 public:
 	FCycler m_cycler;
-	DVector3 Pos;
+	DVector3 Pos, Vel;
 	DVector3 m_off;
 
 	// This date can either come from the owning actor or from a light definition

--- a/src/rendering/hwrenderer/hw_dynlightdata.cpp
+++ b/src/rendering/hwrenderer/hw_dynlightdata.cpp
@@ -31,6 +31,7 @@
 #include"hw_cvars.h"
 #include "v_video.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
+#include "r_utility.h"
 
 // If we want to share the array to avoid constant allocations it needs to be thread local unless it'd be littered with expensive synchronization.
 thread_local FDynLightData lightdata;
@@ -53,7 +54,7 @@ CVAR (Bool, gl_light_particles, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 //==========================================================================
 bool GetLight(FDynLightData& dld, int group, Plane & p, FDynamicLight * light, bool checkside)
 {
-	DVector3 pos = light->PosRelative(group);
+	DVector3 pos = light->GetPos(group, r_viewpoint.TicFrac);
 	float radius = (light->GetRadius());
 
 	auto dist = fabs(p.DistToPoint((float)pos.X, (float)pos.Z, (float)pos.Y));
@@ -78,7 +79,7 @@ void AddLightToList(FDynLightData &dld, int group, FDynamicLight * light, bool f
 {
 	int i = 0;
 
-	DVector3 pos = light->PosRelative(group);
+	DVector3 pos = light->GetPos(group, r_viewpoint.TicFrac);
 	float radius = light->GetRadius();
 
 	float cs;

--- a/src/rendering/hwrenderer/scene/hw_spritelight.cpp
+++ b/src/rendering/hwrenderer/scene/hw_spritelight.cpp
@@ -266,7 +266,7 @@ void hw_GetDynModelLight(AActor *self, FDynLightData &modellightdata)
 					if (light->ShouldLightActor(self))
 					{
 						int group = subsector->sector->PortalGroup;
-						DVector3 pos = light->PosRelative(group);
+						DVector3 pos = light->GetPos(group, r_viewpoint.TicFrac);
 						float radius = (float)(light->GetRadius() + actorradius);
 						double dx = pos.X - x;
 						double dy = pos.Y - y;

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -440,7 +440,7 @@ void HWWall::SetupLights(HWDrawInfo*di, FDynLightData &lightdata)
 				{
 					iter_dlight++;
 
-					DVector3 posrel = node->lightsource->PosRelative(seg->frontsector->PortalGroup);
+					DVector3 posrel = node->lightsource->GetPos(seg->frontsector->PortalGroup, r_viewpoint.TicFrac);
 					float x = posrel.X;
 					float y = posrel.Y;
 					float z = posrel.Z;
@@ -503,7 +503,7 @@ void HWWall::SetupLights(HWDrawInfo*di, FDynLightData &lightdata)
 				{
 					iter_dlight++;
 
-					DVector3 posrel = node->lightsource->PosRelative(seg->frontsector->PortalGroup);
+					DVector3 posrel = node->lightsource->GetPos(seg->frontsector->PortalGroup, r_viewpoint.TicFrac);
 					float x = posrel.X;
 					float y = posrel.Y;
 					float z = posrel.Z;

--- a/wadsrc/static/zscript/actors/shared/dynlights.zs
+++ b/wadsrc/static/zscript/actors/shared/dynlights.zs
@@ -17,6 +17,7 @@ class DynamicLight : Actor
 	flagdef spot: lightflags, 6;
 	flagdef dontlightothers: lightflags, 7;
 	flagdef dontlightmap: lightflags, 8;
+	flagdef interpolated: lightflags, 9;
 
 	enum EArgs
 	{
@@ -40,6 +41,7 @@ class DynamicLight : Actor
 		LF_SPOT = 64,
 		LF_DONTLIGHTOTHERS = 128,
 		LF_DONTLIGHTMAP = 256,
+		LF_INTERPOLATED = 512,
 	};
 
 	enum ELightType


### PR DESCRIPTION
Interpolation for light movement along the xy axes in particularly is tricky because of the linking cost. While there have been significant improvements to this in 5.0, doing it every single frame is still expensive. As such, updating light xy position in real time has never been easy.

This new strategy makes interpolation opt-in and tries to instead strategically link to all possible lit sectors across the area of the light's movement. When an xy movement is done, it gets the center point of the movement and increases the light's radius to cover the full span. This avoids most sectors potentially being missed from the average point during traversal while still only needing to link once per tick, and only if an xy movement was detected. The interpolation data is stored in the light's velocity to avoid branching during render calculations. To avoid keeping the radius larger than expected, after an interpolated movement the light is relinked to its real position and size. This is only done if another xy movement isn't queued up, ensuring only one link is ever done at most per step.

TODO:
-Add proper support for static portals
-Better optimize performance during rendering (can something other than the Vel strat be used here?)
-Remove branches in ticking? Will need verifying with lots of lights at once to ensure this isn't a waste of time
-Checking if the increased linking size has a major impact with lots of moving lights
-Make sure sector-heavy maps aren't seeing significant decreases in performance
-Don't use r_viewpoint.TicFrac? Not sure how bad this is for cache performance

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.