### PR TITLE
Fully client-sided sound updating

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -706,28 +706,25 @@ CUSTOM_CVAR (Int, dmflags2, 0, CVAR_SERVERINFO | CVAR_NOINITCALL)
 	if ((self & DF2_NO_AUTOMAP) && automapactive)
 		AM_Stop ();
 
+	// Revert our view to our own eyes if spying someone else.
+	if ((self & DF2_DISALLOW_SPYING) && players[consoleplayer].camera != players[consoleplayer].mo)
+	{
+		// The player isn't looking through its own eyes, so make it.
+		players[consoleplayer].camera = players[consoleplayer].mo;
+
+		S_UpdateSounds(players[consoleplayer].camera, 0);
+		StatusBar->AttachToPlayer(&players[consoleplayer]);
+
+		if (demoplayback || multiplayer)
+			StatusBar->ShowPlayerName();
+	}
+
 	for (unsigned int i = 0; i < MAXPLAYERS; i++)
 	{
 		player_t *p = &players[i];
 
 		if (!playeringame[i])
 			continue;
-
-		// Revert our view to our own eyes if spying someone else.
-		if (self & DF2_DISALLOW_SPYING)
-		{
-			// The player isn't looking through its own eyes, so make it.
-			if (p->camera != p->mo)
-			{
-				p->camera = p->mo;
-
-				S_UpdateSounds (p->camera);
-				StatusBar->AttachToPlayer (p);
-
-				if (demoplayback || multiplayer)
-					StatusBar->ShowPlayerName ();
-			}
-		}
 
 		// Come out of chasecam mode if we're not allowed to use chasecam.
 		if (!(dmflags2 & DF2_CHASECAM) && CheckCheatmode(false))

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1005,7 +1005,7 @@ static void ChangeSpy (int changespy)
 	}
 
 	players[consoleplayer].camera = players[pnum].mo;
-	S_UpdateSounds(players[consoleplayer].camera);
+	S_UpdateSounds(players[consoleplayer].camera, 0);
 	StatusBar->AttachToPlayer (&players[pnum]);
 	if (demoplayback || multiplayer)
 	{

--- a/src/sound/s_doomsound.cpp
+++ b/src/sound/s_doomsound.cpp
@@ -832,17 +832,19 @@ static void S_SetListener(AActor *listenactor)
 // Updates music & sounds
 //==========================================================================
 
-void S_UpdateSounds (AActor *listenactor)
+void S_UpdateSounds (AActor *listenactor, int tics)
 {
-	// should never happen
 	S_SetListener(listenactor);
-	
-	for (auto Level : AllLevels())
+
+	for (int i = 0; i < tics; ++i)
 	{
-		SN_UpdateActiveSequences(Level);
+		for (auto Level : AllLevels())
+		{
+			SN_UpdateActiveSequences(Level);
+		}
 	}
 
-	soundEngine->UpdateSounds(primaryLevel->time);
+	soundEngine->UpdateSounds(primaryLevel->LocalWorldTimer);
 }
 
 //==========================================================================
@@ -944,7 +946,7 @@ void S_SerializeSounds(FSerializer &arc)
 		// playing before the wipe, and depending on the synchronization
 		// between the main thread and the mixer thread at the time, the
 		// sounds might be heard briefly before pausing for the wipe.
-		soundEngine->SetRestartTime(primaryLevel->time + 2);
+		soundEngine->SetRestartTime(primaryLevel->LocalWorldTimer + 2);
 	}
 	GSnd->Sync(false);
 	GSnd->UpdateSounds();

--- a/src/sound/s_doomsound.h
+++ b/src/sound/s_doomsound.h
@@ -10,7 +10,7 @@ void S_InitData();
 void S_Start();
 void S_Shutdown();
 
-void S_UpdateSounds(AActor* listenactor);
+void S_UpdateSounds(AActor* listenactor, int tics);
 
 void S_PrecacheLevel(FLevelLocals* l);
 


### PR DESCRIPTION
Also fixes the spycam breaking the listener and sound sequencing logic. Previously sound sequences were only updated once per engine tick ran always, but now use the number of local unpaused ticks that have occurred to know how much to advance. This should hopefully do a better job keeping pace when the engine falls behind, ensuring sounds are still played back correctly (audio is rendered separately from the game loop so they will continue to play back even while the game is lagging out).