### PR TITLE
Fixed StaticEventHandlers double destroying

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -345,7 +345,7 @@ bool EventManager::RegisterHandler(DStaticEventHandler* handler)
 	return true;
 }
 
-bool EventManager::UnregisterHandler(DStaticEventHandler* handler)
+bool EventManager::UnregisterHandler(DStaticEventHandler *handler, bool destroying)
 {
 	if (handler == nullptr || handler->ObjectFlags & OF_EuthanizeMe)
 		return false;
@@ -378,7 +378,8 @@ bool EventManager::UnregisterHandler(DStaticEventHandler* handler)
 	if (handler->IsStatic())
 	{
 		handler->ObjectFlags &= ~OF_Transient;
-		handler->Destroy();
+		if (!destroying)
+			handler->Destroy();
 	}
 	return true;
 }
@@ -2397,7 +2398,7 @@ void DStaticEventHandler::NewGame()
 void DStaticEventHandler::OnDestroy()
 {
 	if (owner)
-		owner->UnregisterHandler(this);
+		owner->UnregisterHandler(this, true);
 	Super::OnDestroy();
 }
 

--- a/src/events.h
+++ b/src/events.h
@@ -463,7 +463,7 @@ struct EventManager
 	// register
 	bool RegisterHandler(DStaticEventHandler* handler);
 	// unregister
-	bool UnregisterHandler(DStaticEventHandler* handler);
+	bool UnregisterHandler(DStaticEventHandler* handler, bool destroying);
 	// find
 	bool CheckHandler(DStaticEventHandler* handler);
 	// check type


### PR DESCRIPTION
This area will probably need to be cleaned up in general, but for now this fixes this oversight.