### PR TITLE
Reset animated textures and sky on level change

### DIFF
--- a/src/common/textures/firetexture.cpp
+++ b/src/common/textures/firetexture.cpp
@@ -44,6 +44,14 @@
 static constexpr int32_t FIRESKY_W = 64;
 static constexpr int32_t FIRESKY_H = 128;
 
+void FireTexture::Reset()
+{
+	Image.Clear();
+	Image.AppendFill(0, Width * Height);
+	for (size_t i = 0u; i < Width; ++i)
+		Image[(Height - 1) * Width + i] = (uint8_t)(Palette.Size() - 1);
+}
+
 FireTexture::FireTexture()
 {
 	SetSize(FIRESKY_W, FIRESKY_H);

--- a/src/common/textures/firetexture.h
+++ b/src/common/textures/firetexture.h
@@ -10,6 +10,7 @@ class FireTexture : public FTexture
 
 public:
 	FireTexture();
+	void Reset();
 	void SetPalette(TArray<PalEntry>& colors);
 	void Update();
 	virtual FBitmap GetBgraBitmap(const PalEntry* remap, int* trans) override;

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -1199,6 +1199,35 @@ void FTextureAnimator::UpdateAnimations (uint64_t mstime)
 	}
 }
 
+void FTextureAnimator::ResetTimers()
+{
+	for (auto& fire : mFireTextures)
+	{
+		fire.SwitchTime = 0u;
+		static_cast<FireTexture *>(fire.texture->GetTexture())->Reset();
+		fire.texture->CleanHardwareData();
+		if (fire.texture->GetSoftwareTexture())
+			delete fire.texture->GetSoftwareTexture();
+		fire.texture->SetSoftwareTexture(nullptr);
+	}
+	for (auto& anim : mAnimations)
+	{
+		anim.SwitchTime = 0u;
+		anim.CurFrame   = 0u;
+		if (anim.AnimType == FAnimDef::ANIM_OscillateDown)
+			anim.AnimType = FAnimDef::ANIM_OscillateUp;
+		if (anim.bDiscrete)
+		{
+			TexMan.SetTranslation(anim.BasePic, anim.Frames[anim.CurFrame].FramePic);
+		}
+		else
+		{
+			for (size_t i = 0u; i < anim.NumFrames; ++i)
+				TexMan.SetTranslation(anim.BasePic + i, anim.BasePic + (i + anim.CurFrame) % anim.NumFrames);
+		}
+	}
+}
+
 //==========================================================================
 //
 // operator<<

--- a/src/gamedata/textures/animations.h
+++ b/src/gamedata/textures/animations.h
@@ -137,6 +137,7 @@ public:
 
 	bool InitStandaloneAnimation(FStandaloneAnimation &animInfo, FTextureID tex, uint32_t curTic);
 	FTextureID UpdateStandaloneAnimation(FStandaloneAnimation &animInfo, double curTic);
+	void ResetTimers();
 };
 
 extern FTextureAnimator TexAnim;

--- a/src/p_setup.cpp
+++ b/src/p_setup.cpp
@@ -306,6 +306,9 @@ void FLevelLocals::ClearLevelData(bool fullgc)
 	total_monsters = total_items = total_secrets =
 	killed_monsters = found_items = found_secrets = 0;
 	LocalTimer = LocalWorldTimer = 0;
+	sky1pos = sky2pos = 0.0;
+	hw_sky1pos = hw_sky2pos = hw_skymistpos = 0.0;
+	TexAnim.ResetTimers();
 
 	ClearVelocities();
 


### PR DESCRIPTION
These were designed to use the total engine time but must now be reset with the level.