### PR TITLE
Update Linux/Haiku screenshot path

### DIFF
--- a/src/common/platform/posix/unix/i_specialpaths.cpp
+++ b/src/common/platform/posix/unix/i_specialpaths.cpp
@@ -75,6 +75,7 @@ DEFGETPATH(Data, "XDG_DATA_HOME", "$HOME/config/non-packaged/data");
 DEFGETPATH(Config, "XDG_CONFIG_HOME", "$HOME/.config");
 DEFGETPATH(Cache, "XDG_CACHE_HOME", "$HOME/.cache");
 DEFGETPATH(Data, "XDG_DATA_HOME", "$HOME/.local/share");
+DEFGETPATH(Pictures, "XDG_PICTURES_DIR", "$HOME/Pictures");
 #endif
 #undef DEFGETPATH
 
@@ -197,7 +198,11 @@ FString M_GetConfigPath(bool for_reading)
 
 FString M_GetDocumentsPath()
 {
+#ifdef __HAIKU__
+	return FStringf("%s/" GAMENAMELOWERCASE "/", GetConfigPath());
+#else
 	return M_GetAppDataPath(false) + "/";
+#endif
 }
 
 
@@ -211,7 +216,13 @@ FString M_GetDocumentsPath()
 
 FString M_GetScreenshotsPath()
 {
-	return M_GetDocumentsPath() + "screenshots/";
+#ifdef __HAIKU__
+	static FString path = M_GetDocumentsPath() + "screenshots";
+#else
+	static FString path = FStringf("%s/Screenshots/" GAMENAME, GetPicturesPath());
+#endif
+	path = NicePath(path.GetChars());
+	return path;
 }
 
 //===========================================================================


### PR DESCRIPTION
Previously all gzdoom files lived in `~/.config/gzdoom`, so screenshots lives in `~/.config/gzdoom/screenshots`

ecf42b81699571ee4bca52c66f1b5441e5346e19 updated paths to follow the XDG spec.

This moved all non-config data to `$XDG_DATA_HOME/games/uzdoom`, which is `~/.local/share/games/uzdoom` on most distros. As a side effect of this change, screenshots became even more burried than before.

This was noticed in #517, and it was suggested to use `~/Pictures` (much like window's use of `My Pictures`)

This moves screenshots to `$XDG_PICTURES_DIR/Screenshots/UZDoom` (`~/Pictures/Screenshots/UZDoom` on most distros). This is the same location both Gnome and KDE place screenshots, too.