### PR TITLE
Fix sound sequence thing (arg) sound sequence index range

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -96,13 +96,13 @@
 #include "p_terrain.h"
 #include "r_sky.h"
 #include "r_utility.h"
+#include "s_sndseq.h"
 #include "sbar.h"
 #include "serialize_obj.h"
 #include "serializer_doom.h"
 #include "shadowinlines.h"
 #include "teaminfo.h"
 #include "thingdef.h"
-#include "s_sndseq.h"
 
 // MACROS ------------------------------------------------------------------
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -102,6 +102,7 @@
 #include "shadowinlines.h"
 #include "teaminfo.h"
 #include "thingdef.h"
+#include "s_sndseq.h"
 
 // MACROS ------------------------------------------------------------------
 
@@ -6704,9 +6705,9 @@ AActor *FLevelLocals::SpawnMapThing (FMapThing *mthing, int position)
 	{
 		int type = mthing->args[0];
 		if (type == 255) type = -1;
-		if (type > 63)
+		if (type > (MAX_SNDSEQS - 1))
 		{
-			Printf ("Sound sequence %d out of range\n", type);
+			Printf ("Sound sequence %d out of range (0-%d)\n", type, (MAX_SNDSEQS - 1));
 		}
 		else
 		{


### PR DESCRIPTION
In 10c833f the limit of sound sequences was raised from 63 to 4095. This change was only to polyobjs, but not to the (arguably rather obscure) sound sequence thing that takes the index as arg0 ([doomednum 1411](https://zdoom.org/wiki/Sound_sequence_thing)).

This PR fixes this issue. It also improves the message shown, displaying the actual possible range.

Example map: [sndseq-thing-limit.zip](https://github.com/user-attachments/files/23696148/sndseq-thing-limit.zip)
In UZDoom 4.14.3-rc2 It will show a message, saying that sound sequence 4095 is out of range, and not play the sound sequence. With the changes in this PR it will not show the message, and the sound sequence works correctly.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.