### PR TITLE
Decoupled fullbright mode from powerups

### DIFF
--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -393,6 +393,7 @@ public:
 	short		fixedcolormap = 0;			// can be set to REDCOLORMAP, etc.
 	short		fixedlightlevel = 0;
 	EFullbrightMode FullbrightMode = FBMODE_NONE;	// Allow manually specifying the fullbright mode.
+	bool		bForceFullbright = false;
 	int			morphTics = 0;				// player is a chicken/pig if > 0
 	PClassActor *MorphedPlayerClass = nullptr;		// [MH] (for SBARINFO) class # for this player instance when morphed
 	int			MorphStyle = 0;				// which effects to apply for this player instance when morphed
@@ -477,9 +478,10 @@ public:
 		return mode;
 	}
 
-	void SetFullbrightMode(EFullbrightMode mode)
+	void SetFullbrightMode(EFullbrightMode mode, bool force)
 	{
 		FullbrightMode = mode;
+		bForceFullbright = force;
 	}
 	
 	int GetSpawnClass();

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -73,6 +73,8 @@ typedef TArray<std::tuple<PClass*, int, FPlayerColorSet>> ColorSetList;
 extern PainFlashList PainFlashes;
 extern ColorSetList ColorSets;
 
+EXTERN_CVAR(Bool, gl_enhanced_nightvision)
+
 FString GetPrintableDisplayName(PClassActor *cls);
 
 void PlayIdle(AActor *player);
@@ -143,6 +145,15 @@ enum
 	WF_USER2OK			= 1 << 9,
 	WF_USER3OK			= 1 << 10,
 	WF_USER4OK			= 1 << 11,
+};
+
+enum EFullbrightMode
+{
+	FBMODE_NONE,
+	FBMODE_DEFAULT,		// Use player preference for fullbright vs night vision.
+	FBMODE_FULLBRIGHT,
+	FBMODE_NIGHTVISION,
+	FBMODE_TORCH,
 };
 
 // The VM cannot deal with this as an invalid pointer because it performs a read barrier on every object pointer read.
@@ -381,6 +392,7 @@ public:
 	int			extralight = 0;				// so gun flashes light up areas
 	short		fixedcolormap = 0;			// can be set to REDCOLORMAP, etc.
 	short		fixedlightlevel = 0;
+	EFullbrightMode FullbrightMode = FBMODE_NONE;	// Allow manually specifying the fullbright mode.
 	int			morphTics = 0;				// player is a chicken/pig if > 0
 	PClassActor *MorphedPlayerClass = nullptr;		// [MH] (for SBARINFO) class # for this player instance when morphed
 	int			MorphStyle = 0;				// which effects to apply for this player instance when morphed
@@ -455,6 +467,19 @@ public:
 			crouchviewdelta = 0;
 			viewheight = mo ? mo->FloatVar(NAME_ViewHeight) : 0;
 		}
+	}
+
+	EFullbrightMode GetFullbrightMode() const
+	{
+		EFullbrightMode mode = FullbrightMode;
+		if (mode == FBMODE_DEFAULT)
+			mode = gl_enhanced_nightvision ? FBMODE_NIGHTVISION : FBMODE_FULLBRIGHT;
+		return mode;
+	}
+
+	void SetFullbrightMode(EFullbrightMode mode)
+	{
+		FullbrightMode = mode;
 	}
 	
 	int GetSpawnClass();

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -290,6 +290,7 @@ void player_t::CopyFrom(player_t &p, bool copyPSP)
 	fixedcolormap = p.fixedcolormap;
 	fixedlightlevel = p.fixedlightlevel;
 	FullbrightMode = p.FullbrightMode;
+	bForceFullbright = p.bForceFullbright;
 	morphTics = p.morphTics;
 	MorphedPlayerClass = p.MorphedPlayerClass;
 	MorphStyle = p.MorphStyle;
@@ -755,16 +756,17 @@ DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, GetFullbrightMode, GetFullbrightMode)
 	ACTION_RETURN_INT(self->GetFullbrightMode());
 }
 
-static void SetFullbrightMode(player_t* self, int mode)
+static void SetFullbrightMode(player_t* self, int mode, bool force)
 {
-	self->SetFullbrightMode(static_cast<EFullbrightMode>(mode));
+	self->SetFullbrightMode(static_cast<EFullbrightMode>(mode), force);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, SetFullbrightMode, SetFullbrightMode)
 {
 	PARAM_SELF_STRUCT_PROLOGUE(player_t);
 	PARAM_INT(mode);
-	self->SetFullbrightMode(static_cast<EFullbrightMode>(mode));
+	PARAM_BOOL(force);
+	self->SetFullbrightMode(static_cast<EFullbrightMode>(mode), force);
 	return 0;
 }
 
@@ -1644,6 +1646,7 @@ void P_UnPredictPlayer ()
 		int inventorytics = player->inventorytics;
 		const bool settings_controller = player->settings_controller;
 		EFullbrightMode fbmode = player->FullbrightMode;
+		bool forcefb = player->bForceFullbright;
 		FArray attached = *(FArray*)&act->AttachedLights;
 		FArray userLights = *(FArray*)&act->UserLights;
 
@@ -1654,6 +1657,7 @@ void P_UnPredictPlayer ()
 		// could cause it to change during prediction.
 		player->camera = savedcamera;
 		player->FullbrightMode = fbmode;
+		player->bForceFullbright = forcefb;
 
 		// Unlink from all lists
 		act->UnlinkFromWorld(nullptr);
@@ -1783,6 +1787,7 @@ void player_t::Serialize(FSerializer &arc)
 		("fixedcolormap", fixedcolormap)
 		("fixedlightlevel", fixedlightlevel)
 		("fullbrightmode", fbmode)
+		("bforcefullbright", bForceFullbright)
 		("morphTics", morphTics)
 		("morphedplayerclass", MorphedPlayerClass)
 		("morphstyle", MorphStyle)

--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -303,28 +303,26 @@ FVector4 V_CalcBlend(sector_t* viewsector, PalEntry* modulateColor)
 	else if (player && player->fixedlightlevel != -1 && player->fixedcolormap == NOFIXEDCOLORMAP)
 	{
 		// Draw fixedlightlevel effects as a 2D overlay. The hardware renderer just processes such a scene fullbright without any lighting.
-		auto torchtype = PClass::FindActor(NAME_PowerTorch);
-		auto litetype = PClass::FindActor(NAME_PowerLightAmp);
 		PalEntry color = 0xffffffff;
-		for (AActor* in = player->mo->Inventory; in; in = in->Inventory)
+		EFullbrightMode fbmode = player->GetFullbrightMode();
+		if (fbmode != FBMODE_NONE)
 		{
-			// Need special handling for light amplifiers 
-			if (in->IsKindOf(torchtype))
+			if (fbmode == FBMODE_TORCH)
 			{
-				// The software renderer already bakes the torch flickering into its output, so this must be omitted here.
+				// The software renderer already bakes the torch flickering into its output, so this must be omitted
+				// here.
 				float r = vid_rendermode < 4 ? 1.f : (0.8f + (7 - player->fixedlightlevel) / 70.0f);
-				if (r > 1.0f) r = 1.0f;
+				if (r > 1.0f)
+					r = 1.0f;
 				int rr = (int)(r * 255);
-				int b = rr;
-				if (gl_enhanced_nightvision) b = b * 3 / 4;
+				int b  = rr;
+				if (gl_enhanced_nightvision)
+					b = b * 3 / 4;
 				color = PalEntry(255, rr, rr, b);
 			}
-			else if (in->IsKindOf(litetype))
+			else if (fbmode == FBMODE_NIGHTVISION)
 			{
-				if (gl_enhanced_nightvision)
-				{
-					color = PalEntry(255, 104, 255, 104);
-				}
+				color = PalEntry(255, 104, 255, 104);
 			}
 		}
 		if (modulateColor)

--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -228,7 +228,7 @@ FVector4 V_CalcBlend(sector_t* viewsector, PalEntry* modulateColor)
 	{
 		player = players[consoleplayer].camera->player;
 		if (player)
-			fullbright = (player->fixedcolormap != NOFIXEDCOLORMAP || player->extralight == INT_MIN || player->fixedlightlevel != -1);
+			fullbright = (player->fixedcolormap != NOFIXEDCOLORMAP || player->extralight == INT_MIN || player->fixedlightlevel != -1 || player->bForceFullbright);
 	}
 
 	// don't draw sector based blends when any fullbright screen effect is active.
@@ -300,7 +300,7 @@ FVector4 V_CalcBlend(sector_t* viewsector, PalEntry* modulateColor)
 			V_AddBlend(blendv.r / 255.f, blendv.g / 255.f, blendv.b / 255.f, cnt / 255.0f, blend);
 		}
 	}
-	else if (player && player->fixedlightlevel != -1 && player->fixedcolormap == NOFIXEDCOLORMAP)
+	else if (player && (player->fixedlightlevel != -1 || player->bForceFullbright) && player->fixedcolormap == NOFIXEDCOLORMAP)
 	{
 		// Draw fixedlightlevel effects as a 2D overlay. The hardware renderer just processes such a scene fullbright without any lighting.
 		PalEntry color = 0xffffffff;

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -321,7 +321,7 @@ int HWDrawInfo::SetFullbrightFlags(player_t *player)
 			FullbrightFlags = Fullbright;
 			if (gl_enhanced_nv_stealth > 2) FullbrightFlags |= StealthVision;
 		}
-		else if (cplayer->fixedlightlevel != -1)
+		else if (cplayer->fixedlightlevel != -1 || cplayer->bForceFullbright)
 		{
 			EFullbrightMode fbmode = cplayer->GetFullbrightMode();
 			if (fbmode != FBMODE_NONE)

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -323,21 +323,18 @@ int HWDrawInfo::SetFullbrightFlags(player_t *player)
 		}
 		else if (cplayer->fixedlightlevel != -1)
 		{
-			auto torchtype = PClass::FindActor(NAME_PowerTorch);
-			auto litetype = PClass::FindActor(NAME_PowerLightAmp);
-			for (AActor *in = cplayer->mo->Inventory; in; in = in->Inventory)
+			EFullbrightMode fbmode = cplayer->GetFullbrightMode();
+			if (fbmode != FBMODE_NONE)
 			{
-				// Need special handling for light amplifiers 
-				if (in->IsKindOf(torchtype))
+				FullbrightFlags = Fullbright;
+				if (fbmode == FBMODE_TORCH)
 				{
-					FullbrightFlags = Fullbright;
-					if (gl_enhanced_nv_stealth > 1) FullbrightFlags |= StealthVision;
+					FullbrightFlags |= StealthVision * (gl_enhanced_nv_stealth > 1);
 				}
-				else if (in->IsKindOf(litetype))
+				else
 				{
-					FullbrightFlags = Fullbright;
-					if (gl_enhanced_nightvision) FullbrightFlags |= Nightvision;
-					if (gl_enhanced_nv_stealth > 0) FullbrightFlags |= StealthVision;
+					FullbrightFlags |= Nightvision * (fbmode == FBMODE_NIGHTVISION);
+					FullbrightFlags |= StealthVision * (gl_enhanced_nv_stealth > 0);
 				}
 			}
 		}

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -851,6 +851,13 @@ class PowerLightAmp : Powerup
 	{
 		Powerup.Duration -120;
 	}
+
+	override void InitEffect()
+	{
+		Super.InitEffect();
+		if (Owner && Owner.player)
+			Owner.player.SetFullbrightMode(FBMODE_DEFAULT);
+	}
 	
 	//===========================================================================
 	//
@@ -885,9 +892,11 @@ class PowerLightAmp : Powerup
 	override void EndEffect ()
 	{
 		Super.EndEffect();
-		if (Owner != NULL && Owner.player != NULL && Owner.player.fixedcolormap < PlayerInfo.NUMCOLORMAPS)
+		if (Owner != NULL && Owner.player != NULL)
 		{
-			Owner.player.fixedlightlevel = -1;
+			Owner.player.SetFullbrightMode(FBMODE_NONE);
+			if (Owner.player.fixedcolormap < PlayerInfo.NUMCOLORMAPS)
+				Owner.player.fixedlightlevel = -1;
 		}
 	}
 	
@@ -902,6 +911,13 @@ class PowerLightAmp : Powerup
 class PowerTorch : PowerLightAmp
 {
 	int NewTorch, NewTorchDelta;
+
+	override void InitEffect()
+	{
+		Super.InitEffect();
+		if (Owner && Owner.player)
+			Owner.player.SetFullbrightMode(FBMODE_TORCH);
+	}
 	
 	override void DoEffect ()
 	{
@@ -942,6 +958,13 @@ class PowerTorch : PowerLightAmp
 				}
 			}
 		}
+	}
+
+	override void EndEffect()
+	{
+		Super.EndEffect();
+		if (Owner && Owner.player)
+			Owner.player.SetFullbrightMode(FBMODE_NONE);
 	}
 	
 }

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2999,7 +2999,7 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	native void SendPitchLimits();
 	native clearscope bool HasWeaponsInSlot(int slot) const;
 
-	native clearscope void SetFullbrightMode(EFullbrightMode mode);
+	native clearscope void SetFullbrightMode(EFullbrightMode mode, bool force = false);
 	native ui EFullbrightMode GetFullbrightMode() const;
 
 	native clearscope int GetAverageLatency() const;

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -2863,6 +2863,15 @@ enum EPlayerGender
 	GENDER_OTHER
 }
 
+enum EFullbrightMode
+{
+	FBMODE_NONE,
+	FBMODE_DEFAULT,		// Use player preference for fullbright vs night vision.
+	FBMODE_FULLBRIGHT,
+	FBMODE_NIGHTVISION,
+	FBMODE_TORCH,
+}
+
 struct PlayerInfo native play	// self is what internally is known as player_t
 {
 	// technically engine constants but the only part of the playsim using them is the player.
@@ -2989,6 +2998,9 @@ struct PlayerInfo native play	// self is what internally is known as player_t
 	native clearscope bool GetClassicFlight() const;
 	native void SendPitchLimits();
 	native clearscope bool HasWeaponsInSlot(int slot) const;
+
+	native clearscope void SetFullbrightMode(EFullbrightMode mode);
+	native ui EFullbrightMode GetFullbrightMode() const;
 
 	native clearscope int GetAverageLatency() const;
 


### PR DESCRIPTION
This allows for setting the fullbright mode manually, such as specifically using nightvision. This is intentionally not backed up over the network and should only be accessible from the ui.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.