### PR TITLE
Add 'NoGiveAll' inventory flag

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -71,6 +71,7 @@ class Inventory : Actor
 	flagdef Unclearable: ItemFlags, 24;
 	flagdef NeverLocal: ItemFlags, 25;
 	flagdef IsKeyItem: ItemFlags, 26;
+	flagdef NoCheat: ItemFlags, 27;
 
 	flagdef ForceRespawnInSurvival: none, 0;
 	flagdef PickupFlash: none, 6;

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -71,7 +71,7 @@ class Inventory : Actor
 	flagdef Unclearable: ItemFlags, 24;
 	flagdef NeverLocal: ItemFlags, 25;
 	flagdef IsKeyItem: ItemFlags, 26;
-	flagdef NoCheat: ItemFlags, 27;
+	flagdef NoGiveAll: ItemFlags, 27;
 
 	flagdef ForceRespawnInSurvival: none, 0;
 	flagdef PickupFlash: none, 6;

--- a/wadsrc/static/zscript/actors/player/player_cheat.zs
+++ b/wadsrc/static/zscript/actors/player/player_cheat.zs
@@ -90,7 +90,7 @@ extend class PlayerPawn
 			if (type != NULL)
 			{
 				let def = getDefaultByType(type);
-				if (giveall == ALL_YES && def.bNoCheat) {}
+				if (giveall == ALL_YES && def.bNoGiveAll) {}
 				else GiveInventory(type, 1, true);
 			}
 
@@ -109,7 +109,7 @@ extend class PlayerPawn
 				if (ammotype && getDefaultByType(ammotype).GetParentAmmo() == ammotype)
 				{
 					let def = getDefaultByType(ammotype);
-					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					let ammoitem = FindInventory(ammotype);
 					if (ammoitem == NULL)
@@ -171,7 +171,7 @@ extend class PlayerPawn
 					{
 						let def = getDefaultByType(keytype);
 						
-						if (def.bNoCheat && giveall != ALL_YESYES) continue;
+						if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 						if (def.special1 != 0)
 						{
@@ -197,7 +197,7 @@ extend class PlayerPawn
 				if (type != null && type != "Weapon" && !type.isAbstract())
 				{
 					readonly<Weapon> def = getDefaultByType(type);
-					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					// Don't give replaced weapons unless the replacement was done by Dehacked.
 					let rep = GetReplacement(type);
@@ -228,7 +228,7 @@ extend class PlayerPawn
 				if (type!= null)
 				{
 					let def = getDefaultByType(type);
-					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					if (def.Icon.isValid() && (def.MaxAmount > 1 || def.bAutoActivate == false) && CheckArtifact(type))
 					{
@@ -252,7 +252,7 @@ extend class PlayerPawn
 				if (type != null)
 				{
 					let def = GetDefaultByType (type);
-					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					if (def.Icon.isValid())
 					{

--- a/wadsrc/static/zscript/actors/player/player_cheat.zs
+++ b/wadsrc/static/zscript/actors/player/player_cheat.zs
@@ -108,7 +108,7 @@ extend class PlayerPawn
 
 				if (ammotype && GetDefaultByType(ammotype).GetParentAmmo() == ammotype)
 				{
-					let def = getDefaultByType(ammotype);
+					let def = GetDefaultByType(ammotype);
 					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					let ammoitem = FindInventory(ammotype);
@@ -169,8 +169,8 @@ extend class PlayerPawn
 
 					if (keytype)
 					{
-						let def = getDefaultByType(keytype);
 						
+						let def = GetDefaultByType(keytype);
 						if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 						if (def.special1 != 0)
@@ -196,7 +196,7 @@ extend class PlayerPawn
 				let type = (class<Weapon>)(AllActorClasses[i]);
 				if (type != null && type != "Weapon" && !type.isAbstract())
 				{
-					readonly<Weapon> def = getDefaultByType(type);
+					readonly<Weapon> def = GetDefaultByType(type);
 					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					// Don't give replaced weapons unless the replacement was done by Dehacked.
@@ -227,7 +227,7 @@ extend class PlayerPawn
 				type = (class<Inventory>)(AllActorClasses[i]);
 				if (type!= null)
 				{
-					let def = getDefaultByType(type);
+					let def = GetDefaultByType(type);
 					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;
 
 					if (def.Icon.isValid() && (def.MaxAmount > 1 || def.bAutoActivate == false) && CheckArtifact(type))

--- a/wadsrc/static/zscript/actors/player/player_cheat.zs
+++ b/wadsrc/static/zscript/actors/player/player_cheat.zs
@@ -89,7 +89,7 @@ extend class PlayerPawn
 			
 			if (type != NULL)
 			{
-				let def = getDefaultByType(type);
+				let def = GetDefaultByType(type);
 				if (giveall == ALL_YES && def.bNoGiveAll) {}
 				else GiveInventory(type, 1, true);
 			}
@@ -106,7 +106,7 @@ extend class PlayerPawn
 			{
 				let ammotype = (class<Ammo>)(AllActorClasses[i]);
 
-				if (ammotype && getDefaultByType(ammotype).GetParentAmmo() == ammotype)
+				if (ammotype && GetDefaultByType(ammotype).GetParentAmmo() == ammotype)
 				{
 					let def = getDefaultByType(ammotype);
 					if (def.bNoGiveAll && giveall != ALL_YESYES) continue;

--- a/wadsrc/static/zscript/actors/player/player_cheat.zs
+++ b/wadsrc/static/zscript/actors/player/player_cheat.zs
@@ -86,9 +86,12 @@ extend class PlayerPawn
 		{
 			// Select the correct type of backpack based on the game
 			type = (class<Inventory>)(gameinfo.backpacktype);
+			
 			if (type != NULL)
 			{
-				GiveInventory(type, 1, true);
+				let def = getDefaultByType(type);
+				if (giveall == ALL_YES && def.bNoCheat) {}
+				else GiveInventory(type, 1, true);
 			}
 
 			if (!giveall)
@@ -103,8 +106,11 @@ extend class PlayerPawn
 			{
 				let ammotype = (class<Ammo>)(AllActorClasses[i]);
 
-				if (ammotype && GetDefaultByType(ammotype).GetParentAmmo() == ammotype)
+				if (ammotype && getDefaultByType(ammotype).GetParentAmmo() == ammotype)
 				{
+					let def = getDefaultByType(ammotype);
+					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+
 					let ammoitem = FindInventory(ammotype);
 					if (ammoitem == NULL)
 					{
@@ -159,13 +165,21 @@ extend class PlayerPawn
 			{
 				if (AllActorClasses[i] is "Key")
 				{
-					let keyitem = GetDefaultByType (AllActorClasses[i]);
-					if (keyitem.special1 != 0)
+					let keytype = (class<Ammo>)(AllActorClasses[i]);
+
+					if (keytype)
 					{
-						let item = Inventory(Spawn(AllActorClasses[i]));
-						if (!item.CallTryPickup (self))
+						let def = getDefaultByType(keytype);
+						
+						if (def.bNoCheat && giveall != ALL_YESYES) continue;
+
+						if (def.special1 != 0)
 						{
-							item.Destroy ();
+							let item = Inventory(Spawn(AllActorClasses[i]));
+							if (!item.CallTryPickup (self))
+							{
+								item.Destroy ();
+							}
 						}
 					}
 				}
@@ -182,6 +196,9 @@ extend class PlayerPawn
 				let type = (class<Weapon>)(AllActorClasses[i]);
 				if (type != null && type != "Weapon" && !type.isAbstract())
 				{
+					readonly<Weapon> def = getDefaultByType(type);
+					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+
 					// Don't give replaced weapons unless the replacement was done by Dehacked.
 					let rep = GetReplacement(type);
 					if (rep == type || rep is "DehackedPickup")
@@ -189,7 +206,6 @@ extend class PlayerPawn
 						// Give the weapon only if it is set in a weapon slot.
 						if (player.weapons.LocateWeapon(type))
 						{
-							readonly<Weapon> def = GetDefaultByType (type);
 							if (giveall == ALL_YESYES || !def.bCheatNotWeapon)
 							{
 								GiveInventory(type, 1, true);
@@ -211,7 +227,9 @@ extend class PlayerPawn
 				type = (class<Inventory>)(AllActorClasses[i]);
 				if (type!= null)
 				{
-					let def = GetDefaultByType (type);
+					let def = getDefaultByType(type);
+					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+
 					if (def.Icon.isValid() && (def.MaxAmount > 1 || def.bAutoActivate == false) && CheckArtifact(type))
 					{
 						// Do not give replaced items unless using "give everything"
@@ -234,6 +252,8 @@ extend class PlayerPawn
 				if (type != null)
 				{
 					let def = GetDefaultByType (type);
+					if (def.bNoCheat && giveall != ALL_YESYES) continue;
+
 					if (def.Icon.isValid())
 					{
 						// Do not give replaced items unless using "give everything"


### PR DESCRIPTION
Prevents the 'Give All' command from giving inventory items with this flag enabled, but will not prevent 'give everything' or 'give [item name]' from working

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.