### PR TITLE
Added client-side events to handlers

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -550,6 +550,18 @@ bool EventManager::SendNetworkBuffer(const FName& cmd, const DNetworkBuffer* buf
 	return true;
 }
 
+bool EventManager::SendClientSideEvent(FString name, int arg1, int arg2, int arg3, bool manual)
+{
+	if (ShouldCallStatic(false) && !staticEventManager.SendClientSideEvent(name, arg1, arg2, arg3, manual))
+		return false;
+
+	if (gamestate != GS_LEVEL && gamestate != GS_TITLELEVEL)
+		return false;
+
+	QueuedEvents.Push({ consoleplayer, name, { arg1, arg2, arg3 }, manual });
+	return true;
+}
+
 bool EventManager::CheckHandler(DStaticEventHandler* handler)
 {
 	for (DStaticEventHandler* lhandler = FirstEventHandler; lhandler; lhandler = lhandler->next)
@@ -645,6 +657,7 @@ void EventManager::Shutdown()
 		handler->Destroy();
 	}
 	FirstEventHandler = LastEventHandler = nullptr;
+	QueuedEvents.Reset();
 }
 
 #define DEFINE_EVENT_LOOPER(name, play) void EventManager::name() \
@@ -995,6 +1008,20 @@ void EventManager::Console(int player, FString name, int arg1, int arg2, int arg
 		handler->ConsoleProcess(player, name, arg1, arg2, arg3, manual, ui);
 }
 
+void EventManager::ProcessClientSideEvents()
+{
+	if (ShouldCallStatic(false))
+		staticEventManager.ProcessClientSideEvents();
+
+	for (auto& ev : QueuedEvents)
+	{
+		for (DStaticEventHandler *handler = FirstEventHandler; handler; handler = handler->next)
+			handler->ClientSideProcess(ev);
+	}
+
+	QueuedEvents.Clear();
+}
+
 void EventManager::RenderOverlay(EHudState state)
 {
 	if (ShouldCallStatic(false)) staticEventManager.RenderOverlay(state);
@@ -1074,6 +1101,7 @@ void EventManager::NewGame()
 DEFINE_EVENT_LOOPER(RenderFrame, false)
 DEFINE_EVENT_LOOPER(WorldLightning, true)
 DEFINE_EVENT_LOOPER(WorldTick, true)
+DEFINE_EVENT_LOOPER(ClientSideTick, true)
 DEFINE_EVENT_LOOPER(UiTick, false)
 DEFINE_EVENT_LOOPER(PostUiTick, false)
 
@@ -1681,6 +1709,18 @@ DEFINE_ACTION_FUNCTION(DEventHandler, SendNetworkEvent)
 	ACTION_RETURN_BOOL(currentVMLevel->localEventManager->SendNetworkEvent(name, arg1, arg2, arg3, false));
 }
 
+DEFINE_ACTION_FUNCTION(DEventHandler, SendClientSideEvent)
+{
+	PARAM_PROLOGUE;
+	PARAM_STRING(name);
+	PARAM_INT(arg1);
+	PARAM_INT(arg2);
+	PARAM_INT(arg3);
+	//
+
+	ACTION_RETURN_BOOL(currentVMLevel->localEventManager->SendClientSideEvent(name, arg1, arg2, arg3, false));
+}
+
 DEFINE_ACTION_FUNCTION(DEventHandler, SendInterfaceEvent)
 {
 	PARAM_PROLOGUE;
@@ -2084,6 +2124,18 @@ void DStaticEventHandler::WorldTick()
 	}
 }
 
+void DStaticEventHandler::ClientSideTick()
+{
+	IFVIRTUAL(DStaticEventHandler, ClientSideTick)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func))
+			return;
+		VMValue params[1] = {(DStaticEventHandler *)this};
+		VMCall(func, params, 1, nullptr, 0);
+	}
+}
+
 FRenderEvent EventManager::SetupRenderEvent()
 {
 	FRenderEvent e;
@@ -2353,6 +2405,19 @@ void DStaticEventHandler::ConsoleProcess(int player, FString name, int arg1, int
 	}
 }
 
+void DStaticEventHandler::ClientSideProcess(FConsoleEvent& ev)
+{
+	IFVIRTUAL(DStaticEventHandler, ClientSideProcess)
+	{
+		// don't create excessive DObjects if not going to be processed anyway
+		if (isEmpty(func))
+			return;
+
+		VMValue params[2] = {(DStaticEventHandler *)this, &ev};
+		VMCall(func, params, 2, nullptr, 0);
+	}
+}
+
 void DStaticEventHandler::CheckReplacement(PClassActor *replacee, PClassActor **replacement, bool *final )
 {
 	IFVIRTUAL(DStaticEventHandler, CheckReplacement)
@@ -2439,6 +2504,32 @@ CCMD(event)
 			arg[i] = atoi(argv[2 + i]);
 		// call locally
 		primaryLevel->localEventManager->Console(-1, argv[1], arg[0], arg[1], arg[2], true, false);
+	}
+}
+
+CCMD(clientsideevent)
+{
+	if (gamestate != GS_LEVEL /* && gamestate != GS_TITLELEVEL*/) // not sure if this should work in title level, but
+	                                                              // probably not, because this is for actual playing
+	{
+		DPrintf(DMSG_SPAMMY, "clientsideevent cannot be used outside of a map.\n");
+		return;
+	}
+
+	int argc = argv.argc();
+
+	if (argc < 2 || argc > 5)
+	{
+		Printf("Usage: clientsideevent <name> [arg1] [arg2] [arg3]\n");
+	}
+	else
+	{
+		int arg[3] = {0, 0, 0};
+		int argn   = min<int>(argc - 2, countof(arg));
+		for (int i = 0; i < argn; i++)
+			arg[i] = atoi(argv[2 + i]);
+		// queue up the events
+		primaryLevel->localEventManager->SendClientSideEvent(argv[1], arg[0], arg[1], arg[2], true);
 	}
 }
 

--- a/src/events.h
+++ b/src/events.h
@@ -250,6 +250,18 @@ public:
 //
 // ==============================================
 
+struct FConsoleEvent
+{
+	// player that activated this event. note that it's always -1 for non-playsim events (i.e. these not called with
+	// netevent)
+	int Player;
+	//
+	FString Name;
+	int     Args[3];
+	//
+	bool IsManual;
+};
+
 class DStaticEventHandler : public DObject // make it a part of normal GC process
 {
 	DECLARE_CLASS(DStaticEventHandler, DObject);
@@ -322,6 +334,7 @@ public:
 	int WorldLineDamaged(line_t* line, AActor* source, int damage, FName damagetype, int side, DVector3 position, bool isradius);
 	void WorldLightning();
 	void WorldTick();
+	void ClientSideTick();
 
 	//
 	void RenderFrame();
@@ -345,6 +358,7 @@ public:
 	// 
 	void ConsoleProcess(int player, FString name, int arg1, int arg2, int arg3, bool manual, bool ui);
 	void NetCommandProcess(FNetworkCommand& cmd);
+	void ClientSideProcess(FConsoleEvent& cmd);
 
 	//
 	void CheckReplacement(PClassActor* replacee, PClassActor** replacement, bool* final);
@@ -422,17 +436,6 @@ struct FPlayerEvent
 	bool IsReturn;
 };
 
-struct FConsoleEvent 
-{
-	// player that activated this event. note that it's always -1 for non-playsim events (i.e. these not called with netevent)
-	int Player;
-	//
-	FString Name;
-	int Args[3];
-	//
-	bool IsManual;
-};
-
 struct FReplaceEvent
 {
 	PClassActor* Replacee;
@@ -452,6 +455,7 @@ struct EventManager
 	FLevelLocals *Level = nullptr;
 	DStaticEventHandler* FirstEventHandler = nullptr;
 	DStaticEventHandler* LastEventHandler = nullptr;
+	TArray<FConsoleEvent> QueuedEvents = {};
 
 	EventManager() = default;
 	EventManager(FLevelLocals *l) { Level = l; }
@@ -511,6 +515,8 @@ struct EventManager
 	void WorldLightning();
 	// this executes on every tick, before everything, only when in valid level and not paused
 	void WorldTick();
+	// This executes every local tick after the server is ran but before the UI.
+	void ClientSideTick();
 	// this executes on every tick on UI side, always
 	void UiTick();
 	// this executes on every tick on UI side, always AND immediately after everything else
@@ -554,6 +560,10 @@ struct EventManager
 	bool SendNetworkCommand(const FName& cmd, VMVa_List& args);
 	// Send a pre-built command buffer over.
 	bool SendNetworkBuffer(const FName& cmd, const DNetworkBuffer* buffer);
+	// Send a client-side event to be processed next local world tick.
+	bool SendClientSideEvent(FString name, int arg1, int arg2, int arg3, bool manual);
+	// Loop through the events and send off a signal.
+	void ProcessClientSideEvents();
 
 	// check if there is anything that should receive GUI events
 	bool CheckUiProcessors();

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -63,6 +63,12 @@ void P_RunClientSideLogic()
 	C_Ticker();
 	M_Ticker();
 
+	// These are like net events but are designed to run instantly on the next tick rather
+	// than waiting for the server to verify the action. Useful for managing client-sided
+	// logic.
+	primaryLevel->localEventManager->ProcessClientSideEvents();
+	primaryLevel->localEventManager->ClientSideTick();
+
 	// [ZZ] also tick the UI part of the events
 	primaryLevel->localEventManager->UiTick();
 

--- a/wadsrc/static/zscript/events.zs
+++ b/wadsrc/static/zscript/events.zs
@@ -175,6 +175,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual void WorldLineDamaged(WorldEvent e) {}
     virtual void WorldLightning(WorldEvent e) {} // for the sake of completeness.
     virtual void WorldTick() {}
+    version("4.15.1") virtual void ClientSideTick() {}
 
     //
     //virtual ui void RenderFrame(RenderEvent e) {}
@@ -200,6 +201,7 @@ class StaticEventHandler : Object native play version("2.4")
     virtual ui void InterfaceProcess(ConsoleEvent e) {}
     virtual void NetworkProcess(ConsoleEvent e) {}
     version("4.12") virtual void NetworkCommandProcess(NetworkCommand cmd) {}
+    version("4.15.1") virtual void ClientSideProcess(ConsoleEvent e) {}
     
     //
     virtual void CheckReplacement(ReplaceEvent e) {}
@@ -225,5 +227,6 @@ class EventHandler : StaticEventHandler native version("2.4")
     clearscope static native void SendNetworkEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
     version("4.12") clearscope static native vararg bool SendNetworkCommand(Name cmd, ...);
     version("4.12") clearscope static native bool SendNetworkBuffer(Name cmd, NetworkBuffer buffer);
+    version("4.15.1") clearscope static native bool SendClientSideEvent(String name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
     clearscope static native void SendInterfaceEvent(int playerNum, string name, int arg1 = 0, int arg2 = 0, int arg3 = 0);
 }


### PR DESCRIPTION
These will run in the play scope but locally, similar to other client-side logic. Useful for doing managing of things like lights.

Currently drafted while I ponder if this is a good idea or not. Normally I'd reserve this for console/interface events, but the nature of the UI makes play-scoped client-side things too tricky to work with.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.