### PR TITLE
Improved auto transparency handling

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1124,6 +1124,7 @@ void D_Display ()
 	cycles.Reset();
 	cycles.Clock();
 
+	r_UseVanillaTransparency = UseVanillaTransparency(); // [SP] Cache UseVanillaTransparency() call
 	r_renderercaps = GetCaps(); // [SP] Get the current capabilities of the renderer
 
 	if (players[consoleplayer].camera == NULL)

--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -52,9 +52,9 @@
 #include "thingdef.h"
 #include "types.h"
 #include "vmbuilder.h"
+#include "r_vanillatrans.h"
 
 extern TArray<PalEntry> TranslationColors;
-extern TMap<FName, bool> AutoTrans;
 
 void JitDumpLog(FILE *file, VMScriptFunction *func);
 
@@ -129,7 +129,6 @@ static PClassActor* FindInfoName(int index, bool mustexist = false)
 			cls = static_cast<PClassActor*>(RUNTIME_CLASS(AActor)->CreateDerivedClass(name.GetChars(), (unsigned)sizeof(AActor)));
 			NewClassType(cls, -1);	// This needs a VM type to work as intended.
 			cls->InitializeDefaults();
-			AutoTrans[cls->TypeName] = true;
 			PClassActor::AllActorClasses.Push(cls);
 		}
 		if (cls)
@@ -1804,6 +1803,8 @@ static int PatchThing (int thingy, int flags)
 
 	if (info != (AActor *)&dummy)
 	{
+		if (hadTranslucency)
+			AutoTrans.Remove(type->TypeName);
 		// Reset heights for things hanging from the ceiling that
 		// don't specify a new height.
 		if (info->flags & MF_SPAWNCEILING &&
@@ -1829,6 +1830,10 @@ static int PatchThing (int thingy, int flags)
 					info->RenderStyle = STYLE_Normal;
 			}
 		}
+		// If the thing being replaced had ZDoom's transparency, let the auto handling know
+		// it should disable it if desired.
+		if ((info->renderflags & RF_ZDOOMTRANS) && type->ActorInfo()->Replacement == nullptr)
+			bDehackedTransPresent = true;
 		// Speed could be either an int of fixed value, depending on its use
 		// If this value is very large it needs to be rescaled.
 		if (fabs(info->Speed) >= 256)
@@ -3795,7 +3800,6 @@ void FinishDehPatch ()
 			if (newlycreated)
 			{
 				subclass->InitializeDefaults();
-				AutoTrans[subclass->TypeName] = true;
 				PClassActor::AllActorClasses.Push(subclass);
 			}
 		}

--- a/src/r_data/r_vanillatrans.cpp
+++ b/src/r_data/r_vanillatrans.cpp
@@ -24,68 +24,22 @@
 #include "c_cvars.h"
 #include "filesystem.h"
 #include "doomtype.h"
-#ifdef _DEBUG
-#include "c_dispatch.h"
-#endif
 
-bool r_UseVanillaTransparency;
+int r_UseVanillaTransparency = 0;
 CVAR(Int, r_vanillatrans, 0, CVAR_ARCHIVE)
 TMap<FName, bool> AutoTrans = {};
+bool bDehackedTransPresent = false;
+bool bModdedTransPresent = false;
 
-namespace
+int UseVanillaTransparency()
 {
-	bool firstTime = true;
-	bool foundDehacked = false;
-	bool foundDecorate = false;
-	bool foundZScript = false;
-}
-#ifdef _DEBUG
-CCMD (debug_checklumps)
-{
-	Printf("firstTime: %d\n", firstTime);
-	Printf("foundDehacked: %d\n", foundDehacked);
-	Printf("foundDecorate: %d\n", foundDecorate);
-	Printf("foundZScript: %d\n", foundZScript);
-}
-#endif
-
-void UpdateVanillaTransparency()
-{
-	firstTime = true;
-}
-
-bool UseVanillaTransparency()
-{
-	if (firstTime)
-	{
-		int lastlump = 0;
-		fileSystem.FindLump("ZSCRIPT", &lastlump); // ignore first ZScript
-		if (fileSystem.FindLump("ZSCRIPT", &lastlump) == -1) // no loaded ZScript
-		{
-			lastlump = 0;
-			foundDehacked = fileSystem.FindLump("DEHACKED", &lastlump) != -1;
-			lastlump = 0;
-			foundDecorate = fileSystem.FindLump("DECORATE", &lastlump) != -1;
-			foundZScript = false;
-		}
-		else
-		{
-			foundZScript = true;
-			foundDehacked = false;
-			foundDecorate = false;
-		}
-		firstTime = false;
-	}
-
 	switch (r_vanillatrans)
 	{
-		case 0: return false;
-		case 1: return true;
+		case 2:
+			return bDehackedTransPresent;
+		case 3:
+			return !bModdedTransPresent;
 		default:
-		if (foundDehacked)
-			return true;
-		if (foundDecorate)
-			return false;
-		return r_vanillatrans == 3;
+			return clamp<int>(r_vanillatrans, -1, 1);
 	}
 }

--- a/src/r_data/r_vanillatrans.h
+++ b/src/r_data/r_vanillatrans.h
@@ -23,8 +23,9 @@
 
 #pragma once
 
-void UpdateVanillaTransparency();
-bool UseVanillaTransparency();
-extern bool r_UseVanillaTransparency;
+int UseVanillaTransparency();
+extern int r_UseVanillaTransparency;
 extern TMap<FName, bool> AutoTrans;
+extern bool bDehackedTransPresent;
+extern bool bModdedTransPresent;
 EXTERN_CVAR(Int, r_vanillatrans)

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1328,11 +1328,11 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 	{
 		trans = 1.f;
 	}
-	if (r_vanillatrans && (thing->renderflags & RF_ZDOOMTRANS))
+	if (r_UseVanillaTransparency && (thing->renderflags & RF_ZDOOMTRANS))
 	{
 		// [SP] "canonical transparency" - with the flip of a CVar, disable transparency for Doom objects,
 		//   and disable 'additive' translucency for certain objects from other games.
-		if (r_vanillatrans == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
+		if (r_UseVanillaTransparency == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
 		{
 			trans = 1.f;
 			RenderStyle.BlendOp = STYLEOP_Add;

--- a/src/rendering/swrenderer/things/r_sprite.cpp
+++ b/src/rendering/swrenderer/things/r_sprite.cpp
@@ -165,9 +165,9 @@ namespace swrenderer
 		if (thing->flags5 & MF5_BRIGHT)
 			vis->renderflags |= RF_FULLBRIGHT;
 		vis->RenderStyle = thing->RenderStyle;
-		if (r_vanillatrans && (thing->renderflags & RF_ZDOOMTRANS))
+		if (r_UseVanillaTransparency && (thing->renderflags & RF_ZDOOMTRANS))
 		{
-			if (r_vanillatrans == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
+			if (r_UseVanillaTransparency == 1 || AutoTrans.CheckKey(thing->GetClass()->TypeName) != nullptr)
 				vis->RenderStyle = LegacyRenderStyles[STYLE_Normal];
 		}
 		vis->FillColor = thing->fillcolor;

--- a/src/scripting/thingdef.cpp
+++ b/src/scripting/thingdef.cpp
@@ -39,6 +39,7 @@
 #include "thingdef.h"
 #include "zcc_parser.h"
 #include "zcc_compile_doom.h"
+#include "r_vanillatrans.h"
 
 // EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 void InitThingdef();
@@ -401,8 +402,6 @@ void ParseAllDecorate();
 void SynthesizeFlagFields();
 void SetDoomCompileEnvironment();
 
-extern TMap<FName, bool> AutoTrans;
-
 void ParseScripts()
 {
 	int lump, lastlump = 0;
@@ -458,6 +457,18 @@ void LoadActors()
 
 	FScriptPosition::StrictErrors = strictdecorate;
 	ParseAllDecorate();
+
+	// If preferring vanilla, check if any Actors from DECORATE/ZScript were relying on transparency.
+	for (auto cls : PClass::AllClasses)
+	{
+		if (cls->IsDescendantOf(NAME_Actor) && (GetDefaultByType(cls)->renderflags & RF_ZDOOMTRANS) &&
+		    !AutoTrans.CheckKey(cls->TypeName) && static_cast<PClassActor*>(cls)->ActorInfo()->Replacement == nullptr)
+		{
+			bModdedTransPresent = true;
+			break;
+		}
+	}
+
 	SynthesizeFlagFields();
 
 	FunctionBuildList.Build();

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -934,9 +934,11 @@ OptionValue Fuzziness
 
 OptionValue VanillaTrans
 {
-	0.0, "$OPTVAL_VTFZDOOM"
-	1.0, "$OPTVAL_VTFVANILLA"
-	2.0, "$OPTVAL_AUTO"
+	-1, "$OPTVAL_AUTO"
+	0, "$OPTVAL_VTFZDOOM"
+	1, "$OPTVAL_VTFVANILLA"
+	2, "$OPTVAL_VTAZDOOM"
+	3, "$OPTVAL_VTAVANILLA"
 }
 
 OptionMenu "VideoOptions" protected


### PR DESCRIPTION
* If ZDoom preferred, use translucency unless a dehacked Actor is present that relied on being opaque, force setting everything to opaque.
* If Vanilla preferred, stay opaque unless a DECORATE/ZScript Actor is present that relied on transparency, forcing everything to transparent.

This adds back in the previous auto translucency modes for the selector. This time around rather than checking raw lumps it attempts to check the Actors themselves to make this determination. This should make it less error prone should e.g. a map include dehacked just to change the map names. The new auto mode has been moved to -1.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.