### PR TITLE
Added owner sanity check to Weapon::CheckAmmo

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -959,6 +959,10 @@ class Weapon : StateProvider
 		int lAmmoUse1;
         int lAmmoUse2 = AmmoUse2;
 
+		if (Owner == null)
+		{
+			return false;
+		}
 		if (sv_infiniteammo || (Owner.FindInventory ('PowerInfiniteAmmo', true) != null))
 		{
 			return true;


### PR DESCRIPTION
This specifically fixes a scenario where if a player class has any `StartItem` that's a weapon forbidden to them, the game throws an error and aborts. Although the player doesn't receive the item as intended, `Player::GiveDefaultInventory` then calls `Weapon::CheckAmmo` on the item, which erroneously assumes that `Owner` is a valid pointer. Adding a sanity check fixes this.

This was first reported by a couple of people in Zandronum, where it crashes the game instead. This is the example `DECORATE` code that they sent me:
```
Actor DoomPlayer2 : DoomPlayer
{
Player.StartItem "Pistol1"
Player.DisplayName "DebugTest"
} 

Actor Pistol1 : Pistol{Inventory.ForbiddenTo "DoomPlayer2"}
```

- [ ] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.