### PR TITLE
Fix r_extralight double-applying to walls in HW

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -2233,7 +2233,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 	lightlist = NULL;
 
 	int rel = 0;
-	int orglightlevel = hw_ClampLight(frontsector->lightlevel);
+	int orglightlevel = hw_ClampLight(frontsector->lightlevel, false);
 	bool foggy = (!Colormap.FadeColor.isBlack() || di->Level->flags&LEVEL_HASFADETABLE);	// fog disables fake contrast
 
 	alpha = 1.0f;


### PR DESCRIPTION
I was testing making the limits higher on `r_extralight`, and noticed that the walls were being lit differently, even when I turned off fake contrast. This issue is not present in Software.

# Before n after

These screenshots were taken by modifying the `r_extralight`'s limits to allow for higher values. This simply makes the discrepancy more noticeable, but the issue is present at any non-0 value. (I did not actually increase the limits in this branch, however.)

`r_extralight 64` + `r_fakecontrast 0`, on `trunk`:
<img width="1920" height="1200" alt="Screenshot_Doom_20251127_205510" src="https://github.com/user-attachments/assets/03caaa9f-1cf1-4b04-9b62-6293adb43c09" />

`r_extralight 64` + `r_fakecontrast 0`, on this branch:
<img width="1920" height="1200" alt="Screenshot_Doom_20251127_205703" src="https://github.com/user-attachments/assets/84b62725-d5b3-47ce-9060-816fe7cefa34" />

# Testing

I made this test map to show every light level from spawn location:
[lighting-test.zip](https://github.com/user-attachments/files/23812669/lighting-test.zip)

Designed for Doom II, replaces MAP01.
