### PR TITLE
Mirrors in portals fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -78,7 +78,7 @@ public:
 	virtual void * GetSource() const = 0;	// GetSource MUST be implemented!
 	virtual const char *GetName() = 0;
 	virtual bool AllowSSAO() { return true; }
-	virtual bool IsSky() { return false; }
+	virtual bool IsSky(HWDrawInfo *di) { return false; }
 	virtual bool NeedCap() { return true; }
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state) = 0;
@@ -251,7 +251,7 @@ protected:
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return portal; }
-	virtual bool IsSky() { return true; }
+	virtual bool IsSky(HWDrawInfo *di) { return true; }
 	virtual const char *GetName();
 	virtual bool AllowSSAO() override;
 
@@ -274,7 +274,7 @@ protected:
 	void DrawPortalStencil(FRenderState &state, int pass) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return origin; }
-	virtual bool IsSky() { return true; }	// although this isn't a real sky it can be handled as one.
+	bool IsSky(HWDrawInfo *di) override;
 	virtual const char *GetName();
 	FSectorPortalGroup *origin;
 
@@ -311,6 +311,7 @@ public:
 	{
 		origin = pt;
 	}
+	void SetupCoverage(HWDrawInfo *di);
 
 };
 
@@ -363,7 +364,7 @@ struct HWSkyPortal : public HWPortal
 protected:
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state);
 	virtual void * GetSource() const { return origin; }
-	virtual bool IsSky() { return true; }
+	virtual bool IsSky(HWDrawInfo *di) { return true; }
 	virtual bool NeedDepthBuffer() { return false; }
 	virtual const char *GetName();
 


### PR DESCRIPTION
Fixed rendering line mirrors through line portals (setup mapsections correctly), and plane mirrors in line mirrors (borrowed setcoverage code from Stacked Sector portals). Also added a little thickfog in skybox check.

Test map (just walk around and look at reflections through portals, and reflections in reflections): 
[mirrors_in_portals.wad.zip](https://github.com/user-attachments/files/23832080/mirrors_in_portals.wad.zip)

Images of problems that were fixed (taken from test map):
![mir1](https://github.com/user-attachments/assets/cb741ee0-1c66-49b9-9465-ee63148b7828)
![mir2](https://github.com/user-attachments/assets/b3a1d0d2-cd0a-4616-81f3-41cab169d80f)
![mir3](https://github.com/user-attachments/assets/641c2fa8-488c-46f2-b55a-8da432bde550)
![mir4](https://github.com/user-attachments/assets/b05317ca-7313-4e66-973f-8c6d097da503)
