### PR TITLE
Update a_scroll.cpp

### DIFF
--- a/src/playsim/mapthinkers/a_scroll.cpp
+++ b/src/playsim/mapthinkers/a_scroll.cpp
@@ -129,7 +129,7 @@ static void RotationComp(const sector_t *sec, int which, double dx, double dy, d
 	}
 	else
 	{
-		double ca = -an.Cos();
+		double ca = an.Cos();
 		double sa = -an.Sin();
 		tdx = dx*ca - dy*sa;
 		tdy = dy*ca + dx*sa;


### PR DESCRIPTION
Remove the sign(-) on -an.Cos(), fixing the intended counter rotation.[Fixes #631]

I did *not* make a compat flag(I don't know how), but maybe there should be one just in case there are maps that intentionally use the old behaviour?

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.