### PR TITLE
Temporarily disable ANIMDEF textures updating while paused

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1205,7 +1205,7 @@ void D_Display ()
 	}
 
 	screen->FrameTime = I_msTimeFS();
-	TexAnim.UpdateAnimations(static_cast<uint64_t>(((primaryLevel->LocalWorldTimer + I_GetTimeFrac()) * 1000.0) / TICRATE));
+	TexAnim.UpdateAnimations(static_cast<uint64_t>(((primaryLevel->LocalTimer + I_GetTimeFrac()) * 1000.0) / TICRATE));
 	R_UpdateSky(I_GetTimeFrac());
 	screen->BeginFrame();
 	twod->ClearClipRect();


### PR DESCRIPTION
The menu UI also relies on this. Will need a fuller solution in the future.