### PR TITLE
Translation scripts: fix f-string for compat with older Python versions

### DIFF
--- a/libraries/Translation/scripts/compile.py
+++ b/libraries/Translation/scripts/compile.py
@@ -54,7 +54,7 @@ def get_po_files(po_paths):
 					languages[po_id] = _po_files[po_id]["meta"]["id"]
 				if languages[po_id] != _po_files[po_id]["meta"]["id"]:
 					failed = True
-					print(f"inconsistent language mapping {languages[po_id]} / {_po_files[po_id]["meta"]["id"]}")
+					print(f"inconsistent language mapping {languages[po_id]} / {_po_files[po_id]['meta']['id']}")
 					break
 		if failed:
 			continue


### PR DESCRIPTION
Fixes #653.

As described in that issue, up until Python 3.12, it wasn't possible to use the starting quote of an f-string anywhere inside of its brace expressions. This changes to single quotes in the one instance where it was broken and makes the issue go away.