### PR TITLE
Added support for client-side pointer handling in ACS functions

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -2550,14 +2550,14 @@ void FLevelLocals::ApplyCompatibility2()
 	i_compatflags2 = GetCompatibility2(ELevelCompatFlags2::FromInt(compatflags2)) | ii_compatflags2;
 }
 
-AActor* FLevelLocals::SelectActorFromTID(int tid, size_t index, AActor* defactor)
+AActor* FLevelLocals::SelectActorFromTID(int tid, size_t index, bool clientSide, AActor* defactor)
 {
 	if (tid == 0)
 		return defactor;
 
 	AActor* actor = nullptr;
 	size_t cur = 0u;
-	auto it = GetActorIterator(tid);
+	auto it = clientSide ? GetClientSideActorIterator(tid) : GetActorIterator(tid);
 	while ((actor = it.Next()) != nullptr)
 	{
 		if (cur == index)

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -158,7 +158,7 @@ struct FLevelLocals
 	ELevelCompatFlags2 GetCompatibility2(ELevelCompatFlags2 mask);
 	void ApplyCompatibility();
 	void ApplyCompatibility2();
-	AActor* SelectActorFromTID(int tid, size_t index, AActor* defactor);
+	AActor* SelectActorFromTID(int tid, size_t index, bool clientSide, AActor* defactor);
 
 	void Init();
 
@@ -348,9 +348,9 @@ public:
 	{
 		return NActorIterator(ClientSideTIDHash, type, tid);
 	}
-	AActor *SingleActorFromTID(int tid, AActor *defactor)
+	AActor *SingleActorFromTID(int tid, bool clientSide, AActor *defactor)
 	{
-		return tid == 0 ? defactor : GetActorIterator(tid).Next();
+		return tid == 0 ? defactor : (clientSide ? GetClientSideActorIterator(tid).Next() : GetActorIterator(tid).Next());
 	}
 
 	bool SectorHasTags(sector_t *sector)

--- a/src/playsim/actorptrselect.h
+++ b/src/playsim/actorptrselect.h
@@ -51,6 +51,13 @@ enum AAPTR
 
 };
 
+enum EPTRClientSideState
+{
+	CSPTR_IGNORE = -1,
+	CSPTR_SERVER,
+	CSPTR_CLIENTSIDE,
+};
+
 /*
 	COPY_AAPTR
 
@@ -66,7 +73,7 @@ enum AAPTR
 
 struct FLevelLocals;
 AActor *COPY_AAPTR(AActor *origin, int selector);
-AActor *COPY_AAPTREX(FLevelLocals *Level, AActor *origin, int selector);
+AActor *COPY_AAPTREX(FLevelLocals *Level, AActor *origin, int selector, EPTRClientSideState clientSide);
 enum PTROP
 {
 	PTROP_UNSAFETARGET = 1,

--- a/src/playsim/p_actionfunctions.cpp
+++ b/src/playsim/p_actionfunctions.cpp
@@ -3607,7 +3607,7 @@ DEFINE_ACTION_FUNCTION(AActor, A_Warp)
 
 	if ((flags & WARPF_USETID))
 	{
-		reference = self->Level->SingleActorFromTID(destination_selector, self);
+		reference = self->Level->SingleActorFromTID(destination_selector, self->IsClientSide(), self);
 	}
 	else
 	{

--- a/src/playsim/p_local.h
+++ b/src/playsim/p_local.h
@@ -35,6 +35,7 @@
 #include "doomtype.h"
 #include "vectors.h"
 #include "dobject.h"
+#include "actorptrselect.h"
 
 const double NO_VALUE = FLT_MAX;
 
@@ -147,7 +148,7 @@ void InitSpawnablesFromMapinfo();
 int P_Thing_CheckInputNum(player_t *p, int inputnum);
 int P_Thing_Warp(AActor *caller, AActor *reference, double xofs, double yofs, double zofs, DAngle angle, int flags, double heightoffset, double radiusoffset, DAngle pitch);
 struct FLevelLocals;
-int P_Thing_CheckProximity(FLevelLocals *Level, AActor *self, PClass *classname, double distance, int count, int flags, int ptr, bool counting = false);
+int P_Thing_CheckProximity(FLevelLocals *Level, AActor *self, PClass *classname, double distance, int count, int flags, int ptr, bool counting = false, EPTRClientSideState clientSide = CSPTR_IGNORE);
 
 enum
 {

--- a/src/playsim/p_things.cpp
+++ b/src/playsim/p_things.cpp
@@ -574,9 +574,9 @@ int P_Thing_CheckInputNum(player_t *p, int inputnum)
 	}
 	return renum;
 }
-int P_Thing_CheckProximity(FLevelLocals *Level, AActor *self, PClass *classname, double distance, int count, int flags, int ptr, bool counting)
+int P_Thing_CheckProximity(FLevelLocals *Level, AActor *self, PClass *classname, double distance, int count, int flags, int ptr, bool counting, EPTRClientSideState clientSide)
 {
-	AActor *ref = COPY_AAPTREX(Level, self, ptr);
+	AActor *ref = COPY_AAPTREX(Level, self, ptr, clientSide);
 
 	// We need these to check out.
 	if (!ref || !classname || distance <= 0)


### PR DESCRIPTION
Things like which TID iterator to use and which activators should be allowed need to be more managed on the backend to make it possible for true client-side scripting in ACS. Some things were left server-side as these functions I felt are commonly used with things like map spots rather than standard Actors. Going forward, only Actors owned by the client (or no activator) will be able to run client-side scripts, otherwise ignoring them.

I haven't really tested this outside of making sure it boots because frankly, there's just too much stuff here and there's not a ton of mods/maps that use client-side ACS scripts that aren't also locked to Zandronum, and even if there was, this is an official split from how Zandro handles them. I think this is one of those things that'll just have to be patched up over time since there's no possible way to know all use cases, but it's better to start more restricted and loosen it later.