### PR TITLE
Prevent Inventory items from being marked as client-side

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -338,7 +338,7 @@ bool bPredictionGuard = false;
 
 static void NativeDestroy(DObject* self)
 {
-	if (bPredictionGuard && !(self->ObjectFlags & OF_ClientSide) && ((self->ObjectFlags & OF_Networked) || self->IsKindOf(NAME_Thinker)))
+	if (bPredictionGuard && !self->IsClientSide() && ((self->ObjectFlags & OF_Networked) || self->IsKindOf(NAME_Thinker)))
 		DPrintf(DMSG_WARNING, TEXTCOLOR_RED "Destroyed non-client-side Object %s while predicting\n", self->GetClass()->TypeName.GetChars());
 	if (!(self->ObjectFlags & OF_EuthanizeMe))
 		self->Destroy();

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -5600,7 +5600,7 @@ AActor *AActor::StaticSpawn(FLevelLocals *Level, PClassActor *type, const DVecto
 
 	AActor *actor;
 
-	if (GetDefaultByType(type)->ObjectFlags & OF_ClientSide)
+	if (GetDefaultByType(type)->IsClientSide())
 	{
 		actor = static_cast<AActor*>(Level->CreateClientSideThinker(type));
 	}
@@ -5627,7 +5627,7 @@ DEFINE_ACTION_FUNCTION(AActor, Spawn)
 
 static AActor* SpawnClientSide(PClassActor* type, double x, double y, double z, int flags)
 {
-	if (!(GetDefaultByType(type)->ObjectFlags & OF_ClientSide))
+	if (!GetDefaultByType(type)->IsClientSide())
 	{
 		ThrowAbortException(X_OTHER, "Tried to spawn a non-clientside Actor from a clientside spawn function.");
 		return nullptr;

--- a/src/scripting/zscript/zcc_compile_doom.cpp
+++ b/src/scripting/zscript/zcc_compile_doom.cpp
@@ -925,6 +925,11 @@ void ZCCDoomCompiler::InitDefaults()
 				{
 					bag.Info->SetDropItems(bag.DropItemList);
 				}
+
+				if (GetDefaultByType(ti)->IsClientSide() && ti->IsDescendantOf(NAME_Inventory))
+				{
+					Error(c->cls, "Inventory item %s cannot be client-sided", ti->TypeName.GetChars());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Due to the nature of client-sided things not being in the blockmap, this is functionally useless. With no special list handling for direct attaching, it's much better to bar this, at least until proper infrastructure can be added.

Also fixes a few missing cases of `IsClientSide()`.