### PR TITLE
Fix string OOB in C_ParseCmdLineParams

### DIFF
--- a/src/common/console/c_dispatch.cpp
+++ b/src/common/console/c_dispatch.cpp
@@ -894,7 +894,7 @@ FExecList *C_ParseCmdLineParams(FExecList *exec)
 			}
 
 			cmdString = BuildString (cmdlen, Args->GetArgList (argstart));
-			if (!cmdString.IsEmpty())
+			if (cmdString.Len() > 1)
 			{
 				if (exec == NULL)
 				{


### PR DESCRIPTION
This can happen if you have an errant `+` with no command after it.