### PR TITLE
Allow loading LZDoom 4 saves

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2070,7 +2070,7 @@ void G_DoLoadGame ()
 	#if LOAD_GZDOOM_4142_SAVES
 	FString software = arc.GetString("Software");
 	bool gzdoom_compat_ok = false;
-	if(engine.Compare("GZDOOM") == 0)
+	if(engine.Compare("GZDOOM") == 0 || engine.Compare("LZDOOM") == 0)
 	{
 		gzdoom_compat_ok = CheckGZDoomSaveCompat(engine, software);
 	}

--- a/src/menu/loadsavemenu.cpp
+++ b/src/menu/loadsavemenu.cpp
@@ -62,7 +62,7 @@ EXTERN_CVAR(Int, save_sort_order)
 
 bool CheckGZDoomSaveCompat(FString &engine, FString &software)
 {
-	if(software.IndexOf("GZDoom g") == 0)
+	if(software.IndexOf("GZDoom g") == 0 || software.IndexOf("LZDoom l") == 0)
 	{
 		if(software.Len() < 11) return false; // GZDoom g????????
 
@@ -101,7 +101,7 @@ bool CheckGZDoomSaveCompat(FString &engine, FString &software)
 					//GZDoom g4.14.##, don't allow
 					return false;
 				}
-				else if(v2 > 2)
+				else if(v2 > 2 && software.IndexOf("GZDoom g") == 0)
 				{
 					//GZDoom g4.14.3+, don't allow
 					return false;
@@ -109,7 +109,7 @@ bool CheckGZDoomSaveCompat(FString &engine, FString &software)
 				/*
 				else
 				{
-					//GZDoom g4.14.0 / GZDoom g4.14.1 / GZDoom g4.14.2, allow
+					//GZDoom g4.14.0 / GZDoom g4.14.1 / GZDoom g4.14.2, LZDoom l4.14.#, allow
 				}
 				*/
 			}
@@ -123,7 +123,7 @@ bool CheckGZDoomSaveCompat(FString &engine, FString &software)
 		/*
 		else
 		{
-		//GZDoom g4.0.0 - GZDoom g4.13.2, allow
+		//GZDoom g4.0.0 - GZDoom g4.13.2, LZDoom l4.#, allow
 		}
 		*/
 	}
@@ -182,7 +182,7 @@ void FSavegameManager::ReadSaveStrings()
 						#if LOAD_GZDOOM_4142_SAVES
 						FString software = arc.GetString("Software");
 
-						if(engine.Compare("GZDOOM") == 0)
+						if(engine.Compare("GZDOOM") == 0 || engine.Compare("LZDOOM") == 0)
 						{
 							if(!CheckGZDoomSaveCompat(engine, software))
 							{


### PR DESCRIPTION
I don't know if it is a smart idea and whether this is the best way to do it, but this allows LZDoom 4 saves to be loaded in UZDoom, currently tested with a Heretic save from LZDoom's 4.11.4 release where everything worked fine.

Should also work with saves from current LZDoom trunk (edit: I mean `l4.14dev`, at version 4.14.3), I tested this by editing `info.json`. 4.15 and above don't show up and that's currently intended by looking at the rest of the code.

GZDoom saves loading shouldn't be affected.