### PR TITLE
Reworked the scoreboard

### DIFF
--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -248,15 +248,16 @@ void CT_Drawer (void)
 
 	if (players[consoleplayer].camera != NULL &&
 		(buttonMap.ButtonDown(Button_ShowScores) ||
-		 players[consoleplayer].camera->health <= 0 ||
-		 SB_ForceActive))
+		 players[consoleplayer].playerstate == PST_DEAD ||
+		 bScoreboardToggled))
 	{
 		bool skipit = false;
-		if (gamestate == GS_CUTSCENE)
+		if (gamestate != GS_LEVEL)
 		{
-			// todo: check for summary screen
+			bScoreboardToggled = false;
+			skipit = true;
 		}
-		if (!skipit) HU_DrawScores (consoleplayer, vp.TicFrac);
+		if (!skipit) HU_DrawScores (vp.TicFrac);
 	}
 	if (chatmodeon)
 	{

--- a/src/hu_scores.cpp
+++ b/src/hu_scores.cpp
@@ -132,7 +132,7 @@ void HU_SortPlayers
 }
 */
 
-bool SB_ForceActive = false;
+bool bScoreboardToggled = false;
 
 
 // PRIVATE DATA DEFINITIONS ------------------------------------------------
@@ -145,16 +145,13 @@ bool SB_ForceActive = false;
 //
 //==========================================================================
 
-void HU_DrawScores(int player, double ticFrac)
+void HU_DrawScores(double ticFrac)
 {
-	IFVIRTUALPTR(StatusBar, DBaseStatusBar, Scoreboard_DrawScores)
-	{
-		VMValue params[] = { (DObject*)StatusBar, player, ticFrac };
-		VMCall(func, params, countof(params), nullptr, 0);
-	}
+	IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawScoreboard)
+		CallVM<void>(func, StatusBar, ticFrac);
 }
 
-CCMD (togglescoreboard)
+CCMD(togglescoreboard)
 {
-	SB_ForceActive = !SB_ForceActive;
+	bScoreboardToggled = !bScoreboardToggled;
 }

--- a/src/hu_stuff.h
+++ b/src/hu_stuff.h
@@ -42,8 +42,8 @@ void CT_Drawer (void);
 
 // [RH] Draw deathmatch scores
 
-void HU_DrawScores(int me, double ticFrac);
+void HU_DrawScores(double ticFrac);
 
-extern bool SB_ForceActive;
+extern bool bScoreboardToggled;
 
 #endif

--- a/wadsrc/static/zscript/ui/statscreen/statscreen.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen.zs
@@ -1005,40 +1005,49 @@ class StatusScreen : ScreenJob abstract version("2.5")
 	protected virtual void updateStats() {}
 	protected virtual void drawStats() {}
 
+	// TODO: Eventually this should only be here for backwards compatibility as the scoreboard
+	// has now been entirely rewritten and no longer uses this function.
 	static int, int, int GetPlayerWidths()
 	{
-		int maxNameWidth;
+		if (!StatusBar.ScoreboardFont)
+			return 0, 0, 0;
+
+		int maxNameWidth = StatusBar.ScoreboardFont.StringWidth("Name");
 		int maxScoreWidth;
 		int maxIconHeight;
 
-		StatusBar.Scoreboard_GetPlayerWidths(maxNameWidth, maxScoreWidth, maxIconHeight);
+		for (int i = 0; i < MAXPLAYERS; ++i)
+		{
+			if (!playeringame[i])
+				continue;
+
+			int width = StatusBar.ScoreboardFont.StringWidth(players[i].GetUserName(16u));
+			if (width > maxNameWidth)
+				maxNameWidth = width;
+
+			TextureID icon = players[i].mo.ScoreIcon;
+			if (icon.isValid())
+			{
+				width = int(screen.GetTextureWidth(icon) - screen.GetTextureLeftOffset(icon) + 2.5);
+				if (width > maxScoreWidth)
+					maxScoreWidth = width;
+
+				int height = int(screen.GetTextureHeight(icon) - screen.GetTextureTopOffset(icon) + 0.5);
+				if (height > maxIconHeight)
+					maxIconHeight = height;
+			}
+		}
 
 		return maxNameWidth, maxScoreWidth, maxIconHeight;
 	}
 
-	static Color GetRowColor(PlayerInfo player, bool highlight)
+	static int GetRowColor(PlayerInfo player, bool highlight)
 	{
-		return StatusBar.Scoreboard_GetRowColor(player, highlight);
+		return StatusBar.GetScoreboardTextColor(player);
 	}
 
 	static void GetSortedPlayers(in out Array<int> sorted, bool teamplay)
 	{
-		sorted.clear();
-		for(int i = 0; i < MAXPLAYERS; i++)
-		{
-			if(playeringame[i])
-			{
-				sorted.Push(i);
-			}
-		}
-
-		if(teamplay)
-		{
-			StatusBar.Scoreboard_SortPlayers(sorted, BaseStatusBar.Scoreboard_CompareByTeams);
-		}
-		else
-		{
-			StatusBar.Scoreboard_SortPlayers(sorted, BaseStatusBar.Scoreboard_CompareByPoints);
-		}
+		StatusBar.SortScoreboardPlayers(sorted, BaseStatusBar.ComparePlayerPoints);
 	}
 }

--- a/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
+++ b/wadsrc/static/zscript/ui/statscreen/statscreen_coop.zs
@@ -301,7 +301,7 @@ class CoopStatusScreen : StatusScreen
 			if (ScreenJobRunner.IsPlayerReady(i)) // Bots are automatically assumed ready, to prevent confusion
 				screen.DrawTexture(readyico, true, x - (readysize.Y * CleanXfac), y, DTA_CleanNoMove, true);
 
-			Color thiscolor = GetRowColor(player, i == consoleplayer);
+			int thiscolor = GetRowColor(player, i == consoleplayer);
 			if (player.mo.ScoreIcon.isValid())
 			{
 				screen.DrawTexture(player.mo.ScoreIcon, true, icon_x, y, DTA_CleanNoMove, true);


### PR DESCRIPTION
Rewrote the API to be much cleaner and changed the general design. There are now four main virtual functions: InitScoreboard, DrawScoreboard, DrawRemainingTime, and DrawPlayerScores. I feel this is robust enough to modify each major part of the board without having to rewrite lots of things, but more can be added later as needed and I'd rather start cut back and add on than the other way around. Features:
* New layout that's more intuitive and significantly easier to read.
* Cleaner scaling.
* Proper character limit on names (up to 32 characters) and visible player id for better moderation handling.
* Up to 10 players and 12 team scores visible at once.
* Better handling of player amounts > 8 (the player and their team score if applicable are now always rendered even if out of room).
* New API that has reduced indirection and more generalized functionality.
* Minor bug fixes.

Team logos are now drawn behind the team score to avoid clutter and player classes are drawn to the left of the player name column next to each player.

In the future I'll be adding a full scoreboard mode that supports UI input for things like scrolling to see all players, but the main purpose of this PR is to get the scoreboard API rewritten before 5.0 release as it was too messy and difficult to maintain. The intermission scoreboard has not been updated as that itself will also require a rewrite to better use the existing scoreboard infrastructure.

Previous:
<img width="1920" height="1080" alt="Screenshot_Doom_20251204_101227" src="https://github.com/user-attachments/assets/e43db900-b7be-4511-9fac-f36d17f9549d" />
New:
<img width="1920" height="1080" alt="Screenshot_Doom_20251204_101129" src="https://github.com/user-attachments/assets/63e53374-6138-4c7f-9bca-6ca094d232d6" />