### PR TITLE
Allow removing status screen by setting to "None"

### DIFF
--- a/src/wi_stuff.cpp
+++ b/src/wi_stuff.cpp
@@ -1168,6 +1168,12 @@ IMPLEMENT_CLASS(DInterBackground, true, false)
 DObject* WI_Start(wbstartstruct_t *wbstartstruct)
 {
 	FName screenclass = deathmatch ? gameinfo.statusscreen_dm : multiplayer ? gameinfo.statusscreen_coop : gameinfo.statusscreen_single;
+	if (screenclass == NAME_None)
+	{
+		// Keyword to explicitly disable the intermission
+		return nullptr;
+	}
+
 	auto cls = PClass::FindClass(screenclass);
 
 	if (cls == nullptr || !cls->IsDescendantOf("StatusScreen"))


### PR DESCRIPTION
Adds the ability to remove intermission screens, by setting them to "None" in MAPINFO's GameInfo block.

# Reasoning

I have a mod which doesn't have an intermission screen, it handles everything in-level. This is a problem because while there's plenty of places where it is forced on you (like the `changemap` command).

My previous solution to this was to add a dummy intermission which simply drew a black screen and then called `End()` immediately. This stopped working as intended when the multiplayer ready system was added.

My use case for wanting to opt-out of the ready system is a gross hack, so I've just made it so I don't need the gross hack anymore. Plus, this was really easy to add; the game already passes a `nullptr` status screen when it otherwise skips intermission.

# Testing

I've made a mod which disables all intermission screens. Should be compatible with any IWAD, just add it and finish a level: [disable-intermissions.zip](https://github.com/user-attachments/files/23941251/disable-intermissions.zip)
