### PR TITLE
Damage-modifying Function Expansion

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -856,7 +856,7 @@ public:
 	// Adjusts the angle for deflection/reflection of incoming missiles
 	// Returns true if the missile should be allowed to explode anyway
 	bool AdjustReflectionAngle (AActor *thing, DAngle &angle);
-	int AbsorbDamage(int damage, FName dmgtype, AActor *inflictor, AActor *source, int flags);
+	int AbsorbDamage(int damage, FName dmgtype, AActor *inflictor, AActor *source, int flags, DAngle angle);
 	void AlterWeaponSprite(visstyle_t *vis);
 
 	bool CheckNoDelay();
@@ -883,11 +883,11 @@ public:
 	// Perform some special damage action. Returns the amount of damage to do.
 	// Returning -1 signals the damage routine to exit immediately
 	int DoSpecialDamage (AActor *target, int damage, FName damagetype);
-	int CallDoSpecialDamage(AActor *target, int damage, FName damagetype);
+	int CallDoSpecialDamage(AActor *target, int damage, FName damagetype, int flags, DAngle angle);
 
 	// Like DoSpecialDamage, but called on the actor receiving the damage.
 	int TakeSpecialDamage (AActor *inflictor, AActor *source, int damage, FName damagetype);
-	int CallTakeSpecialDamage(AActor *inflictor, AActor *source, int damage, FName damagetype);
+	int CallTakeSpecialDamage(AActor *inflictor, AActor *source, int damage, FName damagetype, int flags, DAngle angle);
 
 	// Actor had MF_SKULLFLY set and rammed into something
 	// Returns false to stop moving and true to keep moving
@@ -1712,7 +1712,7 @@ public:
 
 	int GetLightLevel(sector_t* rendersector);
 	int ApplyDamageFactor(FName damagetype, int damage) const;
-	int GetModifiedDamage(FName damagetype, int damage, bool passive, AActor *inflictor, AActor *source, int flags = 0);
+	int GetModifiedDamage(FName damagetype, int damage, bool passive, AActor *inflictor, AActor *source, int flags, DAngle angle);
 	void DeleteAttachedLights();
 	bool isFrozen() const;
 

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1215,7 +1215,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 					}
 				}
 
-				damage = inflictor->CallDoSpecialDamage(target, damage, mod);
+				damage = inflictor->CallDoSpecialDamage(target, damage, mod, flags, angle);
 				if (damage < 0)
 				{
 					return -1;
@@ -1231,13 +1231,13 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				// Handle active damage modifiers (e.g. PowerDamage)
 				if (damage > 0 && !(flags & DMG_NO_ENHANCE))
 				{
-					damage = source->GetModifiedDamage(mod, damage, false, inflictor, target, flags);
+					damage = source->GetModifiedDamage(mod, damage, false, inflictor, target, flags, angle);
 				}
 			}
 			// Handle passive damage modifiers (e.g. PowerProtection), provided they are not afflicted with protection penetrating powers.
 			if (damage > 0 && !(flags & DMG_NO_PROTECT))
 			{
-				damage = target->GetModifiedDamage(mod, damage, true, inflictor, source, flags);
+				damage = target->GetModifiedDamage(mod, damage, true, inflictor, source, flags, angle);
 			}
 			if (damage > 0 && !(flags & DMG_NO_FACTOR))
 			{
@@ -1246,7 +1246,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 
 			if (damage >= 0)
 			{
-				damage = target->CallTakeSpecialDamage(inflictor, source, damage, mod);
+				damage = target->CallTakeSpecialDamage(inflictor, source, damage, mod, flags, angle);
 			}
 
 			// '<0' is handled below. This only handles the case where damage gets reduced to 0.
@@ -1374,7 +1374,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 				int newdam = damage;
 				if (damage > 0)
 				{
-					newdam = player->mo->AbsorbDamage(damage, mod, inflictor, source, flags);
+					newdam = player->mo->AbsorbDamage(damage, mod, inflictor, source, flags, angle);
 				}
 				if (!telefragDamage || (player->mo->flags7 & MF7_LAXTELEFRAGDMG)) //rawdamage is never modified.
 				{
@@ -1455,7 +1455,7 @@ static int DamageMobj (AActor *target, AActor *inflictor, AActor *source, int da
 		if (!(flags & (DMG_NO_ARMOR|DMG_FORCED)) && target->Inventory != NULL && damage > 0)
 		{
 			int newdam = damage;
-			newdam = target->AbsorbDamage(damage, mod, inflictor, source, flags);
+			newdam = target->AbsorbDamage(damage, mod, inflictor, source, flags, angle);
 			damage = newdam;
 			if (damage <= 0)
 			{
@@ -1848,7 +1848,7 @@ void P_PoisonDamage (player_t *player, AActor *source, int damage, bool playPain
 	// Take half damage in trainer mode
 	damage = int(damage * G_SkillProperty(SKILLP_DamageFactor) * sv_damagefactorplayer);
 	// Handle passive damage modifiers (e.g. PowerProtection)
-	damage = target->GetModifiedDamage(player->poisontype, damage, true, nullptr, source);
+	damage = target->GetModifiedDamage(player->poisontype, damage, true, nullptr, source, 0, DAngle::fromDeg(0));
 	// Modify with damage factors
 	damage = target->ApplyDamageFactor(player->poisontype, damage);
 

--- a/src/playsim/p_interaction.cpp
+++ b/src/playsim/p_interaction.cpp
@@ -1848,7 +1848,7 @@ void P_PoisonDamage (player_t *player, AActor *source, int damage, bool playPain
 	// Take half damage in trainer mode
 	damage = int(damage * G_SkillProperty(SKILLP_DamageFactor) * sv_damagefactorplayer);
 	// Handle passive damage modifiers (e.g. PowerProtection)
-	damage = target->GetModifiedDamage(player->poisontype, damage, true, nullptr, source, 0, DAngle::fromDeg(0));
+	damage = target->GetModifiedDamage(player->poisontype, damage, true, nullptr, source, 0, nullAngle);
 	// Modify with damage factors
 	damage = target->ApplyDamageFactor(player->poisontype, damage);
 

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -902,9 +902,9 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, ClearCounters, ClearCounters)
 	return 0;
 }
 
-static int GetModifiedDamage(AActor *self, int type, int damage, bool passive, AActor *inflictor, AActor *source, int flags)
+static int GetModifiedDamage(AActor *self, int type, int damage, bool passive, AActor *inflictor, AActor *source, int flags, double ang)
 {
-	return self->GetModifiedDamage(ENamedName(type), damage, passive, inflictor, source, flags);
+	return self->GetModifiedDamage(ENamedName(type), damage, passive, inflictor, source, flags, DAngle::fromDeg(ang));
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetModifiedDamage, GetModifiedDamage)
@@ -916,7 +916,8 @@ DEFINE_ACTION_FUNCTION_NATIVE(AActor, GetModifiedDamage, GetModifiedDamage)
 	PARAM_OBJECT(inflictor, AActor);
 	PARAM_OBJECT(source, AActor);
 	PARAM_INT(flags);
-	ACTION_RETURN_INT(self->GetModifiedDamage(type, damage, passive, inflictor, source, flags));
+	PARAM_ANGLE(ang);
+	ACTION_RETURN_INT(self->GetModifiedDamage(type, damage, passive, inflictor, source, flags, ang));
 }
 
 static int ApplyDamageFactor(AActor *self, int type, int damage)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -620,8 +620,8 @@ class Actor : Thinker native
 	virtual native void BeginPlay();
 	virtual native void Activate(Actor activator);
 	virtual native void Deactivate(Actor activator);
-	virtual native int DoSpecialDamage (Actor target, int damage, Name damagetype);
-	virtual native int TakeSpecialDamage (Actor inflictor, Actor source, int damage, Name damagetype);
+	virtual native int DoSpecialDamage (Actor target, int damage, Name damagetype, int flags = 0, double angle = 0);
+	virtual native int TakeSpecialDamage (Actor inflictor, Actor source, int damage, Name damagetype, int flags = 0, double angle = 0);
 	virtual native void Die(Actor source, Actor inflictor, int dmgflags = 0, Name MeansOfDeath = 'none');
 	virtual native bool Slam(Actor victim);
 	virtual void Touch(Actor toucher) {}
@@ -888,7 +888,7 @@ class Actor : Thinker native
 	native void SpawnTeleportFog(Vector3 pos, bool beforeTele, bool setTarget);
 	native Actor RoughMonsterSearch(int distance, bool onlyseekable = false, bool frontonly = false, double fov = 0);
 	native clearscope int ApplyDamageFactor(Name damagetype, int damage);
-	native int GetModifiedDamage(Name damagetype, int damage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0);
+	native int GetModifiedDamage(Name damagetype, int damage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0, double angle = 0.);
 	native bool CheckBossDeath();
 	native bool CheckFov(Actor target, double fov);
 

--- a/wadsrc/static/zscript/actors/inventory/armor.zs
+++ b/wadsrc/static/zscript/actors/inventory/armor.zs
@@ -147,7 +147,7 @@ class BasicArmor : Armor
 	//
 	//===========================================================================
 
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags, double angle)
 	{
 		int saved;
 
@@ -577,7 +577,7 @@ class HexenArmor : Armor
 	//
 	//===========================================================================
 
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags, double angle)
 	{
 		if (!DamageTypeDefinition.IgnoreArmor(damageType))
 		{

--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -1168,7 +1168,7 @@ class Inventory : Actor
 	//
 	//===========================================================================
 
-	virtual void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0) {}
+	virtual void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor = null, Actor source = null, int flags = 0, double angle = 0.0) {}
 
 	virtual Vector2 ModifyBob(Vector2 Bob, double ticfrac) {return Bob;}
 
@@ -1266,7 +1266,7 @@ class Inventory : Actor
 	//
 	//===========================================================================
 
-	virtual void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor = null, Actor source = null, int flags = 0) {}
+	virtual void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor = null, Actor source = null, int flags = 0, double angle = 0.0) {}
 	
 	//===========================================================================
 	//

--- a/wadsrc/static/zscript/actors/inventory/powerups.zs
+++ b/wadsrc/static/zscript/actors/inventory/powerups.zs
@@ -767,7 +767,7 @@ class PowerIronFeet : Powerup
 		Powerup.Mode "Normal";
 	}
 	
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags, double angle)
 	{
 		if (damageType == 'Drowning')
 		{
@@ -801,7 +801,7 @@ class PowerMask : PowerIronFeet
 		Inventory.Icon "I_MASK";
 	}
 	
-	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags)
+	override void AbsorbDamage (int damage, Name damageType, out int newdamage, Actor inflictor, Actor source, int flags, double angle)
 	{
 		if (damageType == 'Fire' || damageType == 'Drowning')
 		{
@@ -1662,7 +1662,7 @@ class PowerDamage : Powerup
 	//
 	//===========================================================================
 
-	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
+	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags, double angle)
 	{
 		if (!passive && damage > 0)
 		{
@@ -1756,7 +1756,7 @@ class PowerProtection : Powerup
 	//
 	//===========================================================================
 
-	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags)
+	override void ModifyDamage(int damage, Name damageType, out int newdamage, bool passive, Actor inflictor, Actor source, int flags, double angle)
 	{
 		if (passive && damage > 0)
 		{

--- a/wadsrc/static/zscript/actors/shared/hatetarget.zs
+++ b/wadsrc/static/zscript/actors/shared/hatetarget.zs
@@ -34,7 +34,7 @@ class HateTarget : Actor
 		}
 	}
 
-	override int TakeSpecialDamage(Actor inflictor, Actor source, int damage, Name damagetype)
+	override int TakeSpecialDamage(Actor inflictor, Actor source, int damage, Name damagetype, int flags, double angle)
 	{
 		if (special2 != 0)
 		{

--- a/wadsrc/static/zscript/actors/strife/strifestuff.zs
+++ b/wadsrc/static/zscript/actors/strife/strifestuff.zs
@@ -1759,7 +1759,7 @@ class ForceFieldGuard : Actor
 		Stop;
 	}
 	
-	override int TakeSpecialDamage (Actor inflictor, Actor source, int damage, Name damagetype)
+	override int TakeSpecialDamage (Actor inflictor, Actor source, int damage, Name damagetype, int flags, double angle)
 	{
 		if (inflictor == NULL || !(inflictor is "DegninOre"))
 		{


### PR DESCRIPTION
Expanded `<Modify/Absorb>Damage` and `<Do/Take>SpecialDamage` to include flags/angle from DamageMobj where absent.

For the unfamiliar, this does not introduce incompatibilities. `GetModifiedDamage` was expanded once before with no negative effect on mods that don't utilize optional parameters in virtual overrides.