### PR TITLE
PP Expansion - Temporal

### DIFF
--- a/src/common/rendering/gl/gl_renderbuffers.cpp
+++ b/src/common/rendering/gl/gl_renderbuffers.cpp
@@ -969,6 +969,21 @@ void GLPPRenderState::Draw()
 	glViewport(screen->mScreenViewport.left, screen->mScreenViewport.top, screen->mScreenViewport.width, screen->mScreenViewport.height);
 }
 
+void GLPPRenderState::CopyToTexture(PPTexture* dst)
+{
+	PPGLTextureBackend* backend = GetGLTexture(dst);
+	GLuint dstTexture = backend->Tex.handle;
+
+	GLuint srcFB = buffers->mPipelineFB[buffers->mCurrentPipelineTexture].handle;
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, srcFB);
+
+	glBindTexture(GL_TEXTURE_2D, dstTexture);
+
+	glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, dst->Width, dst->Height);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+}
+
 void GLPPRenderState::PushGroup(const FString &name)
 {
 	FGLDebug::PushGroup(name.GetChars());

--- a/src/common/rendering/gl/gl_renderbuffers.h
+++ b/src/common/rendering/gl/gl_renderbuffers.h
@@ -31,6 +31,7 @@ private:
 
 	friend class FGLRenderBuffers;
 	friend class PPGLTextureBackend;
+	friend class GLPPRenderState;
 };
 
 class PPGLFrameBuffer
@@ -48,6 +49,7 @@ private:
 
 	friend class FGLRenderBuffers;
 	friend class PPGLTextureBackend;
+	friend class GLPPRenderState;
 };
 
 class PPGLRenderBuffer
@@ -91,6 +93,7 @@ public:
 	void PushGroup(const FString &name) override;
 	void PopGroup() override;
 	void Draw() override;
+	void CopyToTexture(PPTexture* dst) override;
 
 private:
 	PPGLTextureBackend *GetGLTexture(PPTexture *texture);

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocessshader.h
@@ -3,6 +3,15 @@
 #include "zstring.h"
 #include "tarray.h"
 
+enum class PixelFormat
+{
+	Rgba8,
+	Rgba16f,
+	R32f,
+	Rg16f,
+	Rgba16_snorm
+};
+
 enum class PostProcessUniformType
 {
 	Undefined,

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.h
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.h
@@ -36,6 +36,7 @@ public:
 
 	void BlitSceneToPostprocess();
 	void BlitCurrentToImage(VkTextureImage *image, VkImageLayout finallayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+	void CopyCurrentToImage(VkTextureImage *image, VkImageLayout finallayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	void DrawPresentTexture(const IntRect &box, bool applyGamma, bool screenshot);
 
 	int GetCurrentPipelineImage() const { return mCurrentPipelineImage; }

--- a/src/common/rendering/vulkan/renderer/vk_pprenderstate.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_pprenderstate.cpp
@@ -97,6 +97,16 @@ void VkPPRenderState::Draw()
 	}
 }
 
+void VkPPRenderState::CopyToTexture(PPTexture* dst)
+{
+	if (!dst->Backend)
+		dst->Backend = std::make_unique<VkPPTexture>(fb, dst);
+
+	auto backend = static_cast<VkPPTexture*>(dst->Backend.get());
+
+	fb->GetPostprocess()->CopyCurrentToImage(&backend->TexImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+}
+
 void VkPPRenderState::RenderScreenQuad(VkPPRenderPassSetup *passSetup, VulkanDescriptorSet *descriptorSet, VulkanFramebuffer *framebuffer, int framebufferWidth, int framebufferHeight, int x, int y, int width, int height, const void *pushConstants, uint32_t pushConstantsSize, bool stencilTest)
 {
 	auto cmdbuffer = fb->GetCommands()->GetDrawCommands();

--- a/src/common/rendering/vulkan/renderer/vk_pprenderstate.h
+++ b/src/common/rendering/vulkan/renderer/vk_pprenderstate.h
@@ -19,6 +19,7 @@ public:
 	void PopGroup() override;
 
 	void Draw() override;
+	void CopyToTexture(PPTexture* dst) override;
 
 private:
 	void RenderScreenQuad(VkPPRenderPassSetup *passSetup, VulkanDescriptorSet *descriptorSet, VulkanFramebuffer *framebuffer, int framebufferWidth, int framebufferHeight, int x, int y, int width, int height, const void *pushConstants, uint32_t pushConstantsSize, bool stencilTest);

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1535,7 +1535,7 @@ class GLDefsParser
 			bool validTarget = false;
 			if (sc.Compare("beforebloom")) validTarget = true;
 			if (sc.Compare("scene")) validTarget = true;
-			if (sc.Compare("screen")) validTarget = true;		
+			if (sc.Compare("screen")) validTarget = true;
 			if (!validTarget)
 				sc.ScriptError("Invalid target '%s' for postprocess shader",sc.String);
 


### PR DESCRIPTION
This patch implements a temporal postprocessing system for UZDoom that evolved through several iterations, ultimately settling on a simplified LastInputTexture approach. 

The final version removes the complex per-shader persistent texture system in favor of a single shared LastInputTexture buffer.

This provides all postprocess shaders access to the previous frame's "scene" output (before UI rendering), enabling temporal effects like auto-exposure, motion blur, and temporal anti-aliasing.

This does mean "screen" target shaders (which run after UI rendering) don't receive temporally coherent data for UI-based effects.

The simplified approach introduces UpdateLastInputTexture in PPCustomShaders that copies the scene output after all "scene" shaders run, making previous frame data automatically available to subsequent passes. This reduces complexity while covering most temporal effect use cases. A basic copy.fp shader handles the texture capture. The PPPersistentBuffer class remains but is now used centrally rather than per-shader-instance as in my first proof-of-concept commit.

-------------------------------------------

In a future PR, I'd like to look into expanding the PP pipeline further. I would like to be able to inject shaders on just the first-person weapon, and just the HUD. I would also like to get the "timer" uniform to work with postprocessing shaders.