### PR TITLE
Fix some minor cases of uninitialized variables

### DIFF
--- a/src/common/filesystem/source/file_directory.cpp
+++ b/src/common/filesystem/source/file_directory.cpp
@@ -149,6 +149,7 @@ int FDirectory::AddDirectory(const char *dirpath, LumpFilterInfo* filter, FileSy
 bool FDirectory::Open(LumpFilterInfo* filter, FileSystemMessageFunc Printf)
 {
 	NumLumps = AddDirectory(FileName, filter, Printf);
+	GenerateHash(true);
 	PostProcessArchive(filter);
 	return true;
 }

--- a/src/common/filesystem/source/resourcefile.cpp
+++ b/src/common/filesystem/source/resourcefile.cpp
@@ -303,12 +303,15 @@ int entrycmp(const void* a, const void* b)
 //
 //==========================================================================
 
-void FResourceFile::GenerateHash()
+void FResourceFile::GenerateHash(bool no_reader)
 {
 	// hash the directory after sorting
 	using namespace FileSys::md5;
 
-	auto n = snprintf(Hash, 48, "%08X-%04X-", (unsigned)Reader.GetLength(), NumLumps);
+	// FIXME: Directories do not have a file reader from which they
+	// can generate a full hash. However, we need to generate
+	// *something* to avoid reading uninitialized memory later.
+	auto n = snprintf(Hash, 48, "%08X-%04X-", no_reader ? 0 : (unsigned)Reader.GetLength(), NumLumps);
 
 	md5_state_t state;
 	md5_init(&state);
@@ -328,6 +331,8 @@ void FResourceFile::GenerateHash()
 	{
 		n += snprintf(Hash + n, 3, "%02X", c);
 	}
+
+	HashGenerated = true;
 }
 
 //==========================================================================

--- a/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointbuffer.cpp
@@ -36,7 +36,9 @@ HWViewpointBuffer::HWViewpointBuffer(int pipelineNbr):
 		mBufferPipeline[n]->SetData(mByteSize, nullptr, BufferUsageType::Persistent);
 	}
 
+	mUploadIndex = 0;
 	Clear();
+
 	mLastMappedIndex = UINT_MAX;
 }
 

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -157,11 +157,11 @@ static void CollectDefaultSearchPaths()
 
 FGameConfigFile::FGameConfigFile ()
 {
-
 	FString pathname;
 
 	OkayToWrite = false;	// Do not allow saving of the config before DoKeySetup()
 	bModSetup = false;
+	b226ResetGamepad = false;
 	pathname = GetConfigPath (true);
 	ChangePathName (pathname.GetChars());
 	LoadConfigFile ();

--- a/src/playsim/p_maputl.cpp
+++ b/src/playsim/p_maputl.cpp
@@ -169,7 +169,7 @@ void P_LineOpening (FLineOpening &open, AActor *actor, const line_t *linedef, co
 				usefront = !P_PointOnLineSide (*ref, linedef);
 		}
 
-		open.lowfloorthroughportal = false;
+		open.lowfloorthroughportal = 0;
 		if (usefront)
 		{
 			open.bottom = ff;
@@ -213,6 +213,7 @@ void P_LineOpening (FLineOpening &open, AActor *actor, const line_t *linedef, co
 		open.lowfloor = LINEOPEN_MAX;
 		open.frontfloorplane.SetAtHeight(LINEOPEN_MIN, sector_t::floor);
 		open.backfloorplane.SetAtHeight(LINEOPEN_MIN, sector_t::floor);
+		open.lowfloorthroughportal = 0;
 	}
 
 	open.topffloor = open.bottomffloor = nullptr;


### PR DESCRIPTION
Just some very small cases of uninitialized variables I found trying to use Valgrind. (There's more I haven't gotten to, but they seem like large enough projects that I'll do them in separate branches.)

# Uninitialized hash when loading directory as file

GetHash is used unconditionally during FileSystem::InitMultipleFiles. Directories were originally skipping making a hash, because they don't have a file reader.

Since hashing directories aren't super important (they'd be useless for multiplayer, etc), I just omitted the parts that the hash generation needed from FileReader. I figured it's more important that it just has anything defined in that space.

Additionally, I left in the "HashGenerated" safety assert. (I can remove it if it's considered bloat, but I did find it helped me track this bug down.)

# Uninitialized mUploadIndex on HWViewpointBuffer creation

Clear() determines if it needs a new pipeline based on mUploadIndex. mUploadIndex is not initialized to any particular value, and Clear is called in the constructor.

I picked 0, but I'm not sure this is correct. Seemed to work fine when playing casually, though.

# Uninitialized b226ResetGamepad

(Oops, this one's my fault.) b226ResetGamepad was not initialized to anything in FGameConfigFile's constructor.

# Uninitialized lowfloorthroughportal in LineOpening

open.lowfloorthroughportal was not set to any particular value when using the FFCF_ONLY3DFLOORS flag. This uninitialized value may have been read later in P_LineOpening_XFloors.

(Also it was getting set to false in the block that it does get set even though it's an integer. That's not part of the uninitialized fixes, it just bothered me.)

# Checklist

- [x] I have reviewed [CONTRIBUTING.md](https://github.com/UZDoom/UZDoom/blob/trunk/CONTRIBUTING.md) and agree to its terms.
