### PR TITLE
Make menu dimming more tolerable

### DIFF
--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -330,7 +330,7 @@ void OnMenuOpen(bool makeSound)
 //
 //==========================================================================
 
-CUSTOM_CVAR(Float, dimamount, -1.f, CVAR_ARCHIVE)
+CUSTOM_CVAR(Float, dimamount, 0.8f, CVAR_ARCHIVE)
 {
 	if (self < 0.f && self != -1.f)
 	{
@@ -341,7 +341,7 @@ CUSTOM_CVAR(Float, dimamount, -1.f, CVAR_ARCHIVE)
 		self = 1.f;
 	}
 }
-CVAR(Color, dimcolor, 0xffd700, CVAR_ARCHIVE)
+CVAR(Color, dimcolor, 0x000000, CVAR_ARCHIVE)
 
 void System_M_Dim()
 {


### PR DESCRIPTION
As suggested numerous times by several different people. Improves readability of menus

Before / After

<img width="1349" height="1098" alt="image" src="https://github.com/user-attachments/assets/398f4634-fab1-4269-84ab-3b384140a74e" />