### PR TITLE
Add musinfo music changer 14100

### DIFF
--- a/wadsrc/static/mapinfo/common.txt
+++ b/wadsrc/static/mapinfo/common.txt
@@ -222,6 +222,7 @@ DoomEdNums
  14065 = AmbientSound
  14066 = SoundSequence
  14067 = AmbientSoundNoGravity
+ 14100 = MusicChanger, 0
  14101 = MusicChanger, 1
  14102 = MusicChanger, 2
  14103 = MusicChanger, 3


### PR DESCRIPTION
Most other ports supporting musinfo support thing type 14100, a musinfo music changer thing that resets to a map's default music, matching the behavior of the UDMF/Hexen format thing 14165 with an arg0 of 0.

https://github.com/doom-cross-port-collab/issue-tracker/issues/19