### PR TITLE
Fix building on VS2026

### DIFF
--- a/src/common/thirdparty/rapidxml/rapidxml.hpp
+++ b/src/common/thirdparty/rapidxml/rapidxml.hpp
@@ -382,8 +382,8 @@ namespace rapidxml
     public:
 
         //! \cond internal
-        typedef void *((alloc_func)(std::size_t));       // Type of user-defined function used to allocate memory
-        typedef void (free_func)(void *);              // Type of user-defined function used to free memory
+        typedef void *alloc_func(std::size_t);       // Type of user-defined function used to allocate memory
+        typedef void free_func(void *);              // Type of user-defined function used to free memory
         //! \endcond
         
         //! Constructs empty pool with default allocator functions.


### PR DESCRIPTION
Fix a compiling error on Visual Studio 2026:
```
rapidxml.hpp(385,24): error C2059: syntax error: '<parameter-list>'
```
Maybe it's a VS bug, but we can avoid it easily.