### PR TITLE
Added network owner system for Objects

### DIFF
--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -28,7 +28,6 @@
 
 #include <stdint.h>
 #include "m_argv.h"
-#include "tarray.h"
 
 inline constexpr size_t MAXPLAYERS = 64u;
 

--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -635,13 +635,22 @@ void DObject::Serialize(FSerializer &arc)
 	SerializeFlag("travelling", OF_Travelling);
 	SerializeFlag("transient", OF_Transient);	// This is needed for rollbacks.
 	SerializeFlag("norollback", OF_NoRollback);
+	if (!arc.IsRollback())
+		arc("networkowner", _networkOwner);
 		
 	ObjectFlags |= OF_SerialSuccess;
 
-	if (arc.isReading() && (ObjectFlags & OF_Networked) && !arc.IsRollback())
+	if (arc.isReading() && !arc.IsRollback())
 	{
-		ClearNetworkID();
-		EnableNetworking(true);
+		if (ObjectFlags & OF_Networked)
+		{
+			ClearNetworkID();
+			EnableNetworking(true);
+		}
+		// This will get fixed during level load since it's not guaranteed clients will actually occupy
+		// the same slot number. Once clients get their real slot, they'll transfer all their owned
+		// Objects.
+		NetworkEntityManager::SetTempOwner(_networkOwner, this);
 	}
 }
 
@@ -696,16 +705,26 @@ void *DObject::ScriptVar(FName field, PType *type)
 void NetworkEntityManager::InitializeNetworkEntities()
 {
 	if (!s_netEntities.Size())
-		s_netEntities.AppendFill(nullptr, NetIDStart); // Allocate the first 0-8 slots for the world and clients.
+		s_netEntities.AppendFill(nullptr, NetIDStart); // Allocate the first 0-MAXPLAYERS slots for the world and clients.
+}
+
+uint32_t NetworkEntityManager::GetClientID(unsigned playNum)
+{
+	return ClientNetIDStart + playNum;
+}
+
+unsigned NetworkEntityManager::GetPlayerNum(uint32_t id)
+{
+	return id - ClientNetIDStart;
 }
 
 // Clients need special handling since they always go in slots 1 - MAXPLAYERS.
-void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const unsigned int playNum)
+void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, unsigned playNum)
 {
 	// If resurrecting, we need to swap the corpse's position with the new pawn's
 	// position so it's no longer considered the client's body.
-	const uint32_t id = ClientNetIDStart + playNum;
-	DObject* const oldBody = s_netEntities[id];
+	const uint32_t id = GetClientID(playNum);
+	DObject* oldBody = s_netEntities[id];
 	if (oldBody != nullptr)
 	{
 		if (oldBody == mo)
@@ -716,6 +735,7 @@ void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const unsigned in
 		s_netEntities[curID] = oldBody;
 		oldBody->ClearNetworkID();
 		oldBody->SetNetworkID(curID);
+		RemoveNetworkOwner(oldBody);
 
 		mo->ClearNetworkID();
 	}
@@ -726,9 +746,10 @@ void NetworkEntityManager::SetClientNetworkEntity(DObject* mo, const unsigned in
 
 	s_netEntities[id] = mo;
 	mo->SetNetworkID(id);
+	SetNetworkOwner(playNum, mo);
 }
 
-void NetworkEntityManager::AddNetworkEntity(DObject* const ent)
+void NetworkEntityManager::AddNetworkEntity(DObject* ent)
 {
 	if (IsPredicting() || ent->IsNetworked() || ent->IsClientSide() || ent->IsPredicted())
 		return;
@@ -750,7 +771,7 @@ void NetworkEntityManager::AddNetworkEntity(DObject* const ent)
 	ent->SetNetworkID(id);
 }
 
-void NetworkEntityManager::RemoveNetworkEntity(DObject* const ent)
+void NetworkEntityManager::RemoveNetworkEntity(DObject* ent)
 {
 	if (IsPredicting() || !ent->IsNetworked())
 		return;
@@ -760,13 +781,14 @@ void NetworkEntityManager::RemoveNetworkEntity(DObject* const ent)
 		return;
 
 	assert(s_netEntities[id] == ent);
+	RemoveNetworkOwner(ent);
 	if (id >= NetIDStart)
 		s_openNetIDs.Push(id);
 	s_netEntities[id] = nullptr;
 	ent->ClearNetworkID();
 }
 
-DObject* NetworkEntityManager::GetNetworkEntity(const uint32_t id)
+DObject* NetworkEntityManager::GetNetworkEntity(uint32_t id)
 {
 	if (id == WorldNetID || id >= s_netEntities.Size())
 		return nullptr;
@@ -838,6 +860,108 @@ void NetworkEntityManager::DisablePrediction()
 bool NetworkEntityManager::IsPredicting()
 {
 	return s_bClientPredicting;
+}
+
+void NetworkEntityManager::SetNetworkOwner(unsigned playNum, DObject* ent)
+{
+	// Objects can only belong to clients that are aware the object exists
+	// in the first place. Client-side objects should automatically be considered
+	// owned by their respective clients.
+	if (!ent->IsNetworked() || ent->GetNetworkID() == WorldNetID)
+		return;
+
+	const uint32_t id = GetClientID(playNum);
+	if (s_netEntities[id] == nullptr || ent->GetNetworkOwner() == id)
+		return;
+
+	RemoveNetworkOwner(ent);
+	ent->SetNetworkOwner(id);
+	s_ownedEntities[id].Push(ent);
+}
+
+void NetworkEntityManager::RemoveNetworkOwner(DObject* ent)
+{
+	const uint32_t owner = ent->GetNetworkOwner();
+	if (owner == WorldNetID)
+		return;
+
+	auto lut = s_ownedEntities.CheckKey(owner);
+	if (lut != nullptr)
+	{
+		if (ent->GetNetworkID() == owner)
+		{
+			for (auto owned : *lut)
+				owned->SetNetworkOwner(WorldNetID);
+			lut->Clear();
+		}
+		else
+		{
+			lut->Delete(lut->Find(ent));
+			ent->SetNetworkOwner(WorldNetID);
+		}
+	}
+}
+
+TArrayView<DObject*> NetworkEntityManager::GetOwnedNetworkEntities(unsigned playNum)
+{
+	auto ents = s_ownedEntities.CheckKey(GetClientID(playNum));
+	if (ents == nullptr)
+		return { nullptr, 0u };
+
+	return { ents->Data(), ents->Size() };
+}
+
+void NetworkEntityManager::SetTempOwner(uint32_t id, DObject* ent)
+{
+	if (id != WorldNetID)
+		s_tempOwnedEntities[id].Push(ent);
+}
+
+void NetworkEntityManager::SetTempTransfer(unsigned playNum, uint32_t id)
+{
+	s_toTransfer[playNum] = id;
+}
+
+void NetworkEntityManager::TransferTempOwners()
+{
+	TMap<unsigned, uint32_t>::Iterator it = { s_toTransfer };
+	TMap<unsigned, uint32_t>::Pair* pair = nullptr;
+	while (it.NextPair(pair))
+	{
+		const uint32_t id = GetClientID(it->Key);
+		auto& arr = s_ownedEntities[id];
+		arr.Append(s_tempOwnedEntities[it->Value]);
+		s_tempOwnedEntities.Remove(it->Value);
+
+		TMap<DObject*, bool> marked = {};
+		for (size_t i = 0u; i < arr.Size(); ++i)
+		{
+			auto ent = arr[i];
+			if (ent == nullptr || (ent->ObjectFlags & OF_EuthanizeMe) || marked.CheckKey(ent) != nullptr)
+			{
+				arr.Delete(i);
+			}
+			else
+			{
+				ent->SetNetworkOwner(id);
+				marked[ent] = true;
+			}
+		}
+	}
+
+	TMap<uint32_t, TArray<DObject*>>::Iterator remaining = { s_tempOwnedEntities };
+	TMap<uint32_t, TArray<DObject*>>::Pair* rPair = nullptr;
+	while (remaining.NextPair(rPair))
+	{
+		for (auto ent : rPair->Value)
+		{
+			if (ent != nullptr && !(ent->ObjectFlags & OF_EuthanizeMe))
+				ent->SetNetworkOwner(WorldNetID);
+		}
+	}
+
+	s_toTransfer.Clear();
+	s_tempOwnedEntities.Clear();
 }
 
 //==========================================================================

--- a/src/common/objects/dobject.h
+++ b/src/common/objects/dobject.h
@@ -343,6 +343,7 @@ protected:
 private:
 	// This is intentionally left unserialized.
 	uint32_t _networkID;
+	uint32_t _networkOwner;
 
 public:
 	inline bool IsNetworked() const { return (ObjectFlags & OF_Networked); }
@@ -351,6 +352,8 @@ public:
 	inline bool IsPredicted() const { return (ObjectFlags & OF_Predicted); }
 	inline void SetPredicted(bool set) { if (set) ObjectFlags |= OF_Predicted; else ObjectFlags &= ~OF_Predicted; }
 	inline bool IsPredicting() const { return (ObjectFlags & OF_Predicting); }
+	inline uint32_t GetNetworkOwner() const { return _networkOwner; }
+	inline void SetNetworkOwner(const uint32_t id) { _networkOwner = id; }
 	void SetNetworkID(const uint32_t id);
 	void ClearNetworkID();
 	void RemoveFromNetwork();
@@ -464,6 +467,7 @@ inline T *&DObject::PointerVar(FName field)
 	return *(T**)ScriptVar(field, nullptr);	// pointer check is more tricky and for the handful of uses in the DECORATE parser not worth the hassle.
 }
 
+#include "i_net.h"
 
 class NetworkEntityManager final
 {
@@ -473,25 +477,41 @@ private:
 	inline static TArray<uint32_t> s_openNetIDs = {};
 	inline static TArray<DObject*> s_problemEntities = {};
 	inline static TArray<DObject*> s_predictedEntities = {};
+	inline static TMap<uint32_t, TArray<DObject*>> s_ownedEntities = {};
+
+	// Eventually when players in-game join, store their stuff in here in case a player
+	// actually exists in their saved slot, that way when deserializing them it doesn't
+	// overwrite an actual player's owned entities.
+	inline static TMap<uint32_t, TArray<DObject*>> s_tempOwnedEntities = {};
+	inline static TMap<unsigned, uint32_t> s_toTransfer = {};
 
 public:
 	NetworkEntityManager() = delete;
 	
 	static constexpr uint32_t WorldNetID = 0u;
 	static constexpr uint32_t ClientNetIDStart = 1u;
-	inline static uint32_t NetIDStart;// = MAXPLAYERS + 1u;
+	static constexpr uint32_t NetIDStart = ClientNetIDStart + MAXPLAYERS;
 
 	static void InitializeNetworkEntities();
-	static void SetClientNetworkEntity(DObject* mo, const unsigned int playNum);
-	static void AddNetworkEntity(DObject* const ent);
-	static void RemoveNetworkEntity(DObject* const ent);
-	static DObject* GetNetworkEntity(const uint32_t id);
+	static uint32_t GetClientID(unsigned playNum);
+	static unsigned GetPlayerNum(uint32_t id);
+	static void SetClientNetworkEntity(DObject* mo, unsigned playNum);
+	static void AddNetworkEntity(DObject* ent);
+	static void RemoveNetworkEntity(DObject* ent);
+	static DObject* GetNetworkEntity(uint32_t id);
 	static void AddPredictedEntity(DObject* ent);
 	static void VerifyPredictedEntities();
 	static void RemovePredictedEntity(DObject* ent);
 	static void EnablePrediction();
 	static void DisablePrediction();
 	static bool IsPredicting();
+	static void SetNetworkOwner(unsigned playNum, DObject* ent);
+	static void RemoveNetworkOwner(DObject* ent);
+	static TArrayView<DObject*> GetOwnedNetworkEntities(unsigned playNum);
+
+	static void SetTempOwner(uint32_t id, DObject* ent);
+	static void SetTempTransfer(unsigned playNum, uint32_t id);
+	static void TransferTempOwners();
 };
 
 // This is the only method aside from calling CreateNew that should be used for creating DObjects

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -3934,7 +3934,6 @@ static int D_DoomMain_Internal (void)
 	const char *wad;
 	FIWadManager *iwad_man;
 
-	NetworkEntityManager::NetIDStart = MAXPLAYERS + 1;
 	GC::AddMarkerFunc(GC_MarkGameRoots);
 	VM_CastSpriteIDToString = Doom_CastSpriteIDToString;
 

--- a/src/p_saveg.cpp
+++ b/src/p_saveg.cpp
@@ -649,7 +649,12 @@ void FLevelLocals::SerializePlayers(FSerializer &arc, bool skipload)
 				for (unsigned int i = 0u; i < MAXPLAYERS; ++i)
 				{
 					if (PlayerInGame(i) && Players[i]->mo != nullptr)
+					{
+						// The player will store their previous slot with all their original owned
+						// Objects, so make sure they get moved to the correct one.
+						NetworkEntityManager::SetTempTransfer(i, Players[i]->mo->GetNetworkOwner());
 						NetworkEntityManager::SetClientNetworkEntity(Players[i]->mo, i);
+					}
 				}
 			}
 		}
@@ -1052,6 +1057,8 @@ void FLevelLocals::Serialize(FSerializer &arc, bool hubload)
 		while (it.Next()) ImpactDecalCount++;
 
 		automap->UpdateShowAllLines();
+
+		NetworkEntityManager::TransferTempOwners();
 
 	}
 	// clean up the static data we allocated

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -513,6 +513,8 @@ DBehavior* AActor::AddBehavior(PClass& type)
 
 		b->Owner = this;
 		b->ObjectFlags |= (ObjectFlags & OF_TransferrableFlags);
+		if (GetNetworkOwner() != NetworkEntityManager::WorldNetID)
+			NetworkEntityManager::SetNetworkOwner(NetworkEntityManager::GetPlayerNum(GetNetworkOwner()), b);
 
 		Behaviors[type.TypeName] = b;
 		Level->AddActorBehavior(*b);
@@ -6203,12 +6205,18 @@ int MorphPointerSubstitution(AActor* from, AActor* to)
 	{
 		to->flags &= ~MF_UNMORPHED;
 		to->alternative = from->alternative = nullptr;
+		if (to->player == nullptr)
+			NetworkEntityManager::RemoveNetworkOwner(from);
 	}
 	else
 	{
 		from->flags |= MF_UNMORPHED;
 		from->alternative = to;
 		to->alternative = from;
+		if (to->player != nullptr)
+			NetworkEntityManager::SetNetworkOwner(to->player - players, from);
+		else if (from->GetNetworkOwner() != NetworkEntityManager::WorldNetID)
+			NetworkEntityManager::SetNetworkOwner(NetworkEntityManager::GetPlayerNum(from->GetNetworkOwner()), to);
 	}
 
 	return true;

--- a/src/playsim/p_pspr.cpp
+++ b/src/playsim/p_pspr.cpp
@@ -215,6 +215,9 @@ DPSprite::DPSprite(player_t *owner, AActor *caller, int id)
 
 	if (Caller->IsKindOf(NAME_Weapon) || Caller->IsKindOf(NAME_PlayerPawn))
 		Flags = (PSPF_ADDWEAPON|PSPF_ADDBOB|PSPF_POWDOUBLE|PSPF_CVARFAST|PSPF_PIVOTPERCENT);
+
+	NetworkEntityManager::AddNetworkEntity(this);
+	NetworkEntityManager::SetNetworkOwner(owner - players, this);
 }
 
 //------------------------------------------------------------------------

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1772,6 +1772,19 @@ static void P_RollbackPlayers(FSerializer& arc)
 	arc.EndArray();
 }
 
+static void GetOwnedThinkerList(TMap<int, TArray<DThinker*>>& thinkers)
+{
+	thinkers.Clear();
+
+	auto view = NetworkEntityManager::GetOwnedNetworkEntities(consoleplayer);
+	for (auto obj : view)
+	{
+		auto thinker = dyn_cast<DThinker>(obj);
+		if (thinker != nullptr)
+			thinkers[thinker->GetStatNum()].Push(thinker);
+	}
+}
+
 void P_PredictClient()
 {
 	if (gamestate != GS_LEVEL)

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -2755,6 +2755,65 @@ DEFINE_ACTION_FUNCTION(DObject, S_ChangeMusic)
 	ACTION_RETURN_BOOL(S_ChangeMusic(music.GetChars(), order, looping, force));
 }
 
+static void SetNetworkOwner(DObject* self, player_t* player)
+{
+	if (self->GetNetworkID() < NetworkEntityManager::NetIDStart)
+	{
+		Printf(TEXTCOLOR_RED "Players cannot assign their network owners\n");
+		return;
+	}
+
+	const uint32_t owner = self->GetNetworkOwner();
+	if (player == nullptr)
+		NetworkEntityManager::RemoveNetworkOwner(self);
+	else
+		NetworkEntityManager::SetNetworkOwner(player - players, self);
+
+	// Make sure any of its owned objects are transfered over as well if it's an Actor.
+	const uint32_t newOwner = self->GetNetworkOwner();
+	if (owner != newOwner && self->IsKindOf(NAME_Actor))
+	{
+		TArray<DObject*> ents = {};
+
+		auto actor = dyn_cast<AActor>(self);
+		if (actor->alternative != nullptr && actor->alternative->GetNetworkOwner() == owner)
+			ents.Push(actor->alternative);
+		if (actor->ViewPos != nullptr && actor->ViewPos->GetNetworkID() == owner)
+			ents.Push(actor->ViewPos);
+		if (!actor->IsKindOf(NAME_Inventory) || actor->PointerVar<AActor>(NAME_Owner) == nullptr)
+		{
+			for (AActor* inv = actor->Inventory; inv != nullptr; inv = inv->Inventory)
+			{
+				if (inv->GetNetworkOwner() == owner)
+					ents.Push(inv);
+			}
+		}
+		TMap<FName, TObjPtr<DBehavior*>>::Iterator it = { actor->Behaviors };
+		TMap<FName, TObjPtr<DBehavior*>>::Pair* pair = nullptr;
+		while (it.NextPair(pair))
+		{
+			DBehavior* b = it->Value;
+			if (b != nullptr && b->GetNetworkOwner() == owner)
+				ents.Push(b);
+		}
+
+		for (auto ent : ents)
+		{
+			if (newOwner == NetworkEntityManager::WorldNetID)
+				NetworkEntityManager::RemoveNetworkOwner(ent);
+			else
+				NetworkEntityManager::SetNetworkOwner(player - players, ent);
+		}
+	}
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(DObject, SetNetworkOwner, SetNetworkOwner)
+{
+	PARAM_SELF_PROLOGUE(DObject);
+	PARAM_POINTER(player, player_t);
+	SetNetworkOwner(self, player);
+	return 0;
+}
 
 DEFINE_ACTION_FUNCTION(_Screen, GetViewWindow)
 {

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -1914,6 +1914,8 @@ static void SetViewPos(AActor *self, double x, double y, double z, int flags)
 	{
 		auto vp = Create<DViewPosition>();
 		vp->ObjectFlags |= (self->ObjectFlags & OF_TransferrableFlags);
+		if (self->GetNetworkOwner() != NetworkEntityManager::WorldNetID)
+			NetworkEntityManager::SetNetworkOwner(NetworkEntityManager::GetPlayerNum(self->GetNetworkOwner()), vp);
 
 		self->ViewPos = vp;
 		GC::WriteBarrier(self, vp);

--- a/wadsrc/static/zscript/actors/inventory_util.zs
+++ b/wadsrc/static/zscript/actors/inventory_util.zs
@@ -70,6 +70,7 @@ extend class Actor
 		// run sometime in the future, so by the time it runs, the inventory
 		// might not be in the same state as it was when DEM_INVUSE was sent.
 		Inv.InventoryID = InventoryID++;
+		Inv.SetNetworkOwner(player);
 	}
 
 	//============================================================================
@@ -146,6 +147,7 @@ extend class Actor
 			item.DetachFromOwner();
 			item.Owner = NULL;
 			item.Inv = NULL;
+			item.SetNetworkOwner(null);
 		}
 	}
 
@@ -785,6 +787,7 @@ extend class Actor
 		for (let item = Inv; item != null; item = item.Inv)
 		{
 			item.Owner = self;
+			item.SetNetworkOwner(player);
 		}
 	}
 

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -214,6 +214,8 @@ extend class Object
 	native static void MarkSound(Sound snd);
 	native static uint BAM(double angle);
 	native static void SetMusicVolume(float vol);
+
+	version("4.15.1") native void SetNetworkOwner(PlayerInfo player);
 }
 
 class Thinker : Object native play


### PR DESCRIPTION
Allows objects to be bound to specific clients. In the future this will allow the predictor to know what needs to be rolled back and what's safe to tick while predicting.

Implements #587 

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.