### PR TITLE
make r_extralight rescale the 0-255 range into r_extralight-255 instead of simply adding

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_decal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_decal.cpp
@@ -111,7 +111,7 @@ void HWDecal::DrawDecal(HWDrawInfo *di, FRenderState &state)
 
 			if (low1 < dv[1].z || low2 < dv[2].z)
 			{
-				int thisll = lightlist[k].caster != nullptr ? hw_ClampLight(*lightlist[k].p_lightlevel) : lightlevel;
+				int thisll = lightlist[k].caster != nullptr ? RescaleLightLevel(*lightlist[k].p_lightlevel) : lightlevel;
 				FColormap thiscm;
 				thiscm.FadeColor = Colormap.FadeColor;
 				CopyFrom3DLight(thiscm, &lightlist[k]);

--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -470,7 +470,7 @@ void HWFlat::SetFrom3DFloor(F3DFloor *rover, bool top, bool underside)
 
 	// FF_FOG requires an inverted logic where to get the light from
 	lightlist_t *light = P_GetPlaneLight(sector, plane.plane, underside);
-	lightlevel = hw_ClampLight(*light->p_lightlevel);
+	lightlevel = RescaleLightLevel(*light->p_lightlevel);
 
 	if (rover->flags & FF_FOG)
 	{
@@ -536,7 +536,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 
 		srf |= SSRF_RENDERFLOOR;
 
-		lightlevel = hw_ClampLight(frontsector->GetFloorLight());
+		lightlevel = RescaleLightLevel(frontsector->GetFloorLight());
 		Colormap = frontsector->Colormap;
 		FlatColor = frontsector->SpecialColors[sector_t::floor];
 		AddColor = frontsector->AdditiveColors[sector_t::floor];
@@ -571,7 +571,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 				if ((!(sector->GetFlags(sector_t::floor)&PLANEF_ABSLIGHTING) || light->lightsource == NULL)
 					&& (light->p_lightlevel != &frontsector->lightlevel))
 				{
-					lightlevel = hw_ClampLight(*light->p_lightlevel);
+					lightlevel = RescaleLightLevel(*light->p_lightlevel);
 				}
 
 				CopyFrom3DLight(Colormap, light);
@@ -594,7 +594,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 
 		srf |= SSRF_RENDERCEILING;
 
-		lightlevel = hw_ClampLight(frontsector->GetCeilingLight());
+		lightlevel = RescaleLightLevel(frontsector->GetCeilingLight());
 		Colormap = frontsector->Colormap;
 		FlatColor = frontsector->SpecialColors[sector_t::ceiling];
 		AddColor = frontsector->AdditiveColors[sector_t::ceiling];
@@ -628,7 +628,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 				if ((!(sector->GetFlags(sector_t::ceiling)&PLANEF_ABSLIGHTING))
 					&& (light->p_lightlevel != &frontsector->lightlevel))
 				{
-					lightlevel = hw_ClampLight(*light->p_lightlevel);
+					lightlevel = RescaleLightLevel(*light->p_lightlevel);
 				}
 				CopyFrom3DLight(Colormap, light);
 			}
@@ -720,7 +720,7 @@ void HWFlat::ProcessSector(HWDrawInfo *di, sector_t * frontsector, int which)
 
 							if (rover->flags&FF_FIX)
 							{
-								lightlevel = hw_ClampLight(rover->model->lightlevel);
+								lightlevel = RescaleLightLevel(rover->model->lightlevel);
 								Colormap = rover->GetColormap();
 							}
 

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -187,7 +187,7 @@ float GetFogDensity(FLevelLocals* Level, ELightMode lightmode, int lightlevel, P
 		// case 2: black fog
 		if ((!isDoomSoftwareLighting(lightmode) || blendfactor > 0) && !(Level->flags3 & LEVEL3_NOLIGHTFADE))
 		{
-			density = distfogtable[lightmode != ELightMode::LinearStandard][RescaleLightLevel<false>(lightlevel)];
+			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight(lightlevel)];
 		}
 		else
 		{

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -187,7 +187,7 @@ float GetFogDensity(FLevelLocals* Level, ELightMode lightmode, int lightlevel, P
 		// case 2: black fog
 		if ((!isDoomSoftwareLighting(lightmode) || blendfactor > 0) && !(Level->flags3 & LEVEL3_NOLIGHTFADE))
 		{
-			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight(lightlevel, false)];
+			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight<false>(lightlevel)];
 		}
 		else
 		{

--- a/src/rendering/hwrenderer/scene/hw_lighting.cpp
+++ b/src/rendering/hwrenderer/scene/hw_lighting.cpp
@@ -187,7 +187,7 @@ float GetFogDensity(FLevelLocals* Level, ELightMode lightmode, int lightlevel, P
 		// case 2: black fog
 		if ((!isDoomSoftwareLighting(lightmode) || blendfactor > 0) && !(Level->flags3 & LEVEL3_NOLIGHTFADE))
 		{
-			density = distfogtable[lightmode != ELightMode::LinearStandard][hw_ClampLight<false>(lightlevel)];
+			density = distfogtable[lightmode != ELightMode::LinearStandard][RescaleLightLevel<false>(lightlevel)];
 		}
 		else
 		{

--- a/src/rendering/hwrenderer/scene/hw_lighting.h
+++ b/src/rendering/hwrenderer/scene/hw_lighting.h
@@ -9,9 +9,18 @@ struct Colormap;
 
 EXTERN_CVAR(Int, r_extralight)
 
-inline int hw_ClampLight(int lightlevel, bool addExtra = true)
+template<bool addExtra = true>
+inline int hw_ClampLight(int lightlevel) // TODO/tidy: rename + move out of hwrenderer namespace
 {
-	return clamp(lightlevel + r_extralight * addExtra, 0, 255);
+	if constexpr(addExtra)
+	{
+		//max is needed for negative r_extralight values
+		return max(int((clamp(lightlevel, 0, 255) / 255.0) * (255.0 - r_extralight)) + r_extralight, 0);
+	}
+	else
+	{
+		return clamp(lightlevel, 0, 255);
+	}
 }
 
 EXTERN_CVAR(Int, gl_weaponlight);

--- a/src/rendering/hwrenderer/scene/hw_lighting.h
+++ b/src/rendering/hwrenderer/scene/hw_lighting.h
@@ -9,17 +9,23 @@ struct Colormap;
 
 EXTERN_CVAR(Int, r_extralight)
 
-template<bool addExtra = true>
-inline int hw_ClampLight(int lightlevel) // TODO/tidy: rename + move out of hwrenderer namespace
+inline int hw_ClampLight(int lightlevel)
 {
-	if constexpr(addExtra)
+	return clamp(lightlevel, 0, 255);
+}
+
+template<bool doClamp = true>
+inline int RescaleLightLevel(int lightlevel) // TODO/tidy: move out of hwrenderer namespace
+{
+	if constexpr(doClamp)
 	{
 		//max is needed for negative r_extralight values
 		return max(int((clamp(lightlevel, 0, 255) / 255.0) * (255.0 - r_extralight)) + r_extralight, 0);
 	}
 	else
 	{
-		return clamp(lightlevel, 0, 255);
+		//max is needed for negative r_extralight values
+		return max(int((max(lightlevel, 0) / 255.0) * (255.0 - r_extralight)) + r_extralight, 0);
 	}
 }
 

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -1143,7 +1143,7 @@ void HWEEHorizonPortal::DrawContents(HWDrawInfo *di, FRenderState &state)
 	{
 		HWHorizonInfo horz;
 		horz.plane.GetFromSector(sector, sector_t::ceiling);
-		horz.lightlevel = hw_ClampLight(sector->GetCeilingLight());
+		horz.lightlevel = RescaleLightLevel(sector->GetCeilingLight());
 		horz.colormap = sector->Colormap;
 		horz.specialcolor = 0xffffffff;
 		if (portal->mType == PORTS_PLANE)
@@ -1157,7 +1157,7 @@ void HWEEHorizonPortal::DrawContents(HWDrawInfo *di, FRenderState &state)
 	{
 		HWHorizonInfo horz;
 		horz.plane.GetFromSector(sector, sector_t::floor);
-		horz.lightlevel = hw_ClampLight(sector->GetFloorLight());
+		horz.lightlevel = RescaleLightLevel(sector->GetFloorLight());
 		horz.colormap = sector->Colormap;
 		horz.specialcolor = 0xffffffff;
 		if (portal->mType == PORTS_PLANE)

--- a/src/rendering/hwrenderer/scene/hw_setcolor.cpp
+++ b/src/rendering/hwrenderer/scene/hw_setcolor.cpp
@@ -51,7 +51,7 @@ void SetColor(FRenderState &state, FLevelLocals* Level, ELightMode lightmode, in
 		int hwlightlevel = CalcLightLevel(lightmode, sectorlightlevel, rellight, weapon, cm.BlendFactor);
 		PalEntry pe = CalcLightColor(lightmode, hwlightlevel, cm.LightColor, cm.BlendFactor);
 		state.SetColorAlpha(pe, alpha, cm.Desaturation);
-		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight<false>(sectorlightlevel + rellight), cm.BlendFactor);
+		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight(sectorlightlevel + rellight), cm.BlendFactor);
 		else state.SetNoSoftLightLevel();
 	}
 }

--- a/src/rendering/hwrenderer/scene/hw_setcolor.cpp
+++ b/src/rendering/hwrenderer/scene/hw_setcolor.cpp
@@ -51,7 +51,7 @@ void SetColor(FRenderState &state, FLevelLocals* Level, ELightMode lightmode, in
 		int hwlightlevel = CalcLightLevel(lightmode, sectorlightlevel, rellight, weapon, cm.BlendFactor);
 		PalEntry pe = CalcLightColor(lightmode, hwlightlevel, cm.LightColor, cm.BlendFactor);
 		state.SetColorAlpha(pe, alpha, cm.Desaturation);
-		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight(sectorlightlevel + rellight, false), cm.BlendFactor);
+		if (isSoftwareLighting(lightmode)) state.SetSoftLightLevel(hw_ClampLight<false>(sectorlightlevel + rellight), cm.BlendFactor);
 		else state.SetNoSoftLightLevel();
 	}
 }

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -257,7 +257,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			// set up the light slice
 			secplane_t *topplane = i == 0 ? &topp : &(*lightlist)[i].plane;
 			secplane_t *lowplane = i == (*lightlist).Size() - 1 ? &bottomp : &(*lightlist)[i + 1].plane;
-			int thislight = (*lightlist)[i].caster != nullptr ? hw_ClampLight(*(*lightlist)[i].p_lightlevel) : lightlevel;
+			int thislight = (*lightlist)[i].caster != nullptr ? RescaleLightLevel(*(*lightlist)[i].p_lightlevel) : lightlevel;
 			int thisll = actor == nullptr ? thislight : (uint8_t)actor->Sector->CheckSpriteGlow(thislight, actor->InterpolatedPosition(vp.TicFrac));
 
 			FColormap thiscm;
@@ -684,7 +684,7 @@ void HWSprite::SplitSprite(HWDrawInfo *di, sector_t * frontsector, bool transluc
 		if (lightbottom<z1)
 		{
 			copySprite=*this;
-			copySprite.lightlevel = hw_ClampLight(*lightlist[i].p_lightlevel);
+			copySprite.lightlevel = RescaleLightLevel(*lightlist[i].p_lightlevel);
 			copySprite.Colormap.CopyLight(lightlist[i].extra_colormap);
 
 			if (di->Level->flags3 & LEVEL3_NOCOLOREDSPRITELIGHTING)
@@ -1263,7 +1263,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		((thing->renderflags & RF_FULLBRIGHT) && (!texture || !texture->isFullbrightDisabled()));
 
 	if (fullbright)	lightlevel = 255;
-	else lightlevel = hw_ClampLight(thing->GetLightLevel(rendersector));
+	else lightlevel = RescaleLightLevel(thing->GetLightLevel(rendersector));
 
 	foglevel = (uint8_t)clamp<short>(rendersector->lightlevel, 0, 255); // this *must* use the sector's light level or the fog will just look bad.
 
@@ -1491,7 +1491,7 @@ void HWSprite::ProcessParticle(HWDrawInfo *di, particle_t *particle, sector_t *s
 	if (spr && !spr->ValidTexture())
 		return;
 
-	lightlevel = hw_ClampLight(spr ? spr->GetLightLevel(sector) : sector->GetSpriteLight());
+	lightlevel = RescaleLightLevel(spr ? spr->GetLightLevel(sector) : sector->GetSpriteLight());
 	foglevel = (uint8_t)clamp<short>(sector->lightlevel, 0, 255);
 
 	trans = particle->alpha;
@@ -1522,7 +1522,7 @@ void HWSprite::ProcessParticle(HWDrawInfo *di, particle_t *particle, sector_t *s
 
 			if (lightbottom < particle->Pos.Z)
 			{
-				lightlevel = hw_ClampLight(*lightlist[i].p_lightlevel);
+				lightlevel = RescaleLightLevel(*lightlist[i].p_lightlevel);
 				Colormap.CopyLight(lightlist[i].extra_colormap);
 				break;
 			}

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -2237,7 +2237,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 	lightlist = NULL;
 
 	int rel = 0;
-	int orglightlevel = hw_ClampLight(frontsector->lightlevel, false);
+	int orglightlevel = hw_ClampLight<false>(frontsector->lightlevel);
 	bool foggy = (!Colormap.FadeColor.isBlack() || di->Level->flags&LEVEL_HASFADETABLE);	// fog disables fake contrast
 
 	alpha = 1.0f;

--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -307,7 +307,7 @@ void HWWall::RenderTexturedWall(HWWallDispatcher*di, FRenderState &state, int rf
 
 			if (low1 < ztop[0] || low2 < ztop[1])
 			{
-				int thisll = (*lightlist)[i].caster != nullptr ? hw_ClampLight(*(*lightlist)[i].p_lightlevel) : lightlevel;
+				int thisll = (*lightlist)[i].caster != nullptr ? RescaleLightLevel(*(*lightlist)[i].p_lightlevel) : lightlevel;
 				FColormap thiscm;
 				thiscm.FadeColor = Colormap.FadeColor;
 				thiscm.FogDensity = Colormap.FogDensity;
@@ -789,7 +789,7 @@ void HWWall::Put3DWall(HWWallDispatcher *di, lightlist_t * lightlist, bool trans
 	// only modify the light di->Level-> if it doesn't originate from the seg's frontsector. This is to account for light transferring effects
 	if (lightlist->p_lightlevel != &seg->sidedef->sector->lightlevel)
 	{
-		lightlevel = hw_ClampLight(*lightlist->p_lightlevel);
+		lightlevel = RescaleLightLevel(*lightlist->p_lightlevel);
 	}
 	// relative light won't get changed here. It is constant across the entire wall.
 
@@ -1038,7 +1038,7 @@ bool HWWall::DoHorizon(HWWallDispatcher *di, seg_t * seg,sector_t * fs, vertex_t
 			else
 			{
 				hi.plane.GetFromSector(fs, sector_t::ceiling);
-				hi.lightlevel = hw_ClampLight(fs->GetCeilingLight());
+				hi.lightlevel = RescaleLightLevel(fs->GetCeilingLight());
 				hi.colormap = fs->Colormap;
 				hi.specialcolor = fs->SpecialColors[sector_t::ceiling];
 
@@ -1046,7 +1046,7 @@ bool HWWall::DoHorizon(HWWallDispatcher *di, seg_t * seg,sector_t * fs, vertex_t
 				{
 					light = P_GetPlaneLight(fs, &fs->ceilingplane, true);
 
-					if (!(fs->GetFlags(sector_t::ceiling) & PLANEF_ABSLIGHTING)) hi.lightlevel = hw_ClampLight(*light->p_lightlevel);
+					if (!(fs->GetFlags(sector_t::ceiling) & PLANEF_ABSLIGHTING)) hi.lightlevel = RescaleLightLevel(*light->p_lightlevel);
 					hi.colormap.CopyLight(light->extra_colormap);
 				}
 
@@ -1067,7 +1067,7 @@ bool HWWall::DoHorizon(HWWallDispatcher *di, seg_t * seg,sector_t * fs, vertex_t
 			else
 			{
 				hi.plane.GetFromSector(fs, sector_t::floor);
-				hi.lightlevel = hw_ClampLight(fs->GetFloorLight());
+				hi.lightlevel = RescaleLightLevel(fs->GetFloorLight());
 				hi.colormap = fs->Colormap;
 				hi.specialcolor = fs->SpecialColors[sector_t::floor];
 
@@ -1075,7 +1075,7 @@ bool HWWall::DoHorizon(HWWallDispatcher *di, seg_t * seg,sector_t * fs, vertex_t
 				{
 					light = P_GetPlaneLight(fs, &fs->floorplane, false);
 
-					if (!(fs->GetFlags(sector_t::floor) & PLANEF_ABSLIGHTING)) hi.lightlevel = hw_ClampLight(*light->p_lightlevel);
+					if (!(fs->GetFlags(sector_t::floor) & PLANEF_ABSLIGHTING)) hi.lightlevel = RescaleLightLevel(*light->p_lightlevel);
 					hi.colormap.CopyLight(light->extra_colormap);
 				}
 
@@ -1782,7 +1782,7 @@ void HWWall::BuildFFBlock(HWWallDispatcher *di, seg_t * seg, F3DFloor * rover, i
 			Colormap.Clear();
 			Colormap.LightColor = light->extra_colormap.FadeColor;
 			// the fog plane defines the light di->Level->, not the front sector
-			lightlevel = hw_ClampLight(*light->p_lightlevel);
+			lightlevel = RescaleLightLevel(*light->p_lightlevel);
 			texture = NULL;
 			type = RENDERWALL_FFBLOCK;
 		}
@@ -2237,7 +2237,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 	lightlist = NULL;
 
 	int rel = 0;
-	int orglightlevel = hw_ClampLight<false>(frontsector->lightlevel);
+	int orglightlevel = hw_ClampLight(frontsector->lightlevel);
 	bool foggy = (!Colormap.FadeColor.isBlack() || di->Level->flags&LEVEL_HASFADETABLE);	// fog disables fake contrast
 
 	alpha = 1.0f;
@@ -2284,7 +2284,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 		else
 		{
 			// normal texture
-			lightlevel = hw_ClampLight(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::mid, false, &rel));
+			lightlevel = RescaleLightLevel(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::mid, false, &rel));
 			rellight = CalcRelLight(lightlevel, orglightlevel, rel);
 			texture = TexMan.GetGameTexture(seg->sidedef->GetTexture(side_t::mid), true);
 			if (texture && texture->isValid())
@@ -2359,7 +2359,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 
 			if (bch1a < fch1 || bch2a < fch2)
 			{
-				lightlevel = hw_ClampLight(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::top, false, &rel));
+				lightlevel = RescaleLightLevel(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::top, false, &rel));
 				rellight = CalcRelLight(lightlevel, orglightlevel, rel);
 				texture = TexMan.GetGameTexture(seg->sidedef->GetTexture(side_t::top), true);
 				if (texture && texture->isValid())
@@ -2433,7 +2433,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 			texture = tex;
 		}
 		else texture = nullptr;
-		lightlevel = hw_ClampLight(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::mid, false, &rel));
+		lightlevel = RescaleLightLevel(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::mid, false, &rel));
 		rellight = CalcRelLight(lightlevel, orglightlevel, rel);
 
 		float skew;
@@ -2484,7 +2484,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 
 			if (backsector->e->XFloor.ffloors.Size() || frontsector->e->XFloor.ffloors.Size())
 			{
-				lightlevel = hw_ClampLight(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::top, false, &rel));
+				lightlevel = RescaleLightLevel(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::top, false, &rel));
 				rellight = CalcRelLight(lightlevel, orglightlevel, rel);
 				DoFFloorBlocks(di, seg, frontsector, backsector, fch1, fch2, ffh1, ffh2, bch1, bch2, bfh1, bfh2);
 			}
@@ -2501,7 +2501,7 @@ void HWWall::Process(HWWallDispatcher *di, seg_t *seg, sector_t * frontsector, s
 
 		if (bfh1 > ffh1 || bfh2 > ffh2)
 		{
-			lightlevel = hw_ClampLight(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::bottom, false, &rel));
+			lightlevel = RescaleLightLevel(seg->sidedef->GetLightLevel(foggy, orglightlevel, side_t::bottom, false, &rel));
 			rellight = CalcRelLight(lightlevel, orglightlevel, rel);
 			texture = TexMan.GetGameTexture(seg->sidedef->GetTexture(side_t::bottom), true);
 			if (texture && texture->isValid())
@@ -2603,7 +2603,7 @@ void HWWall::ProcessLowerMiniseg(HWWallDispatcher *di, seg_t *seg, sector_t * fr
 		flags = 0;
 
 		// can't do fake contrast without a sidedef
-		lightlevel = hw_ClampLight(frontsector->lightlevel);
+		lightlevel = RescaleLightLevel(frontsector->lightlevel);
 		rellight = 0;
 
 		alpha = 1.0f;

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -329,7 +329,7 @@ WeaponLighting HWDrawInfo::GetWeaponLighting(sector_t *viewsector, const DVector
 		auto fakesec = hw_FakeFlat(viewsector, in_area, false);
 
 		// calculate light level for weapon sprites
-		l.lightlevel = hw_ClampLight(fakesec->lightlevel);
+		l.lightlevel = RescaleLightLevel(fakesec->lightlevel);
 
 		// calculate colormap for weapon sprites
 		if (viewsector->e->XFloor.ffloors.Size() && !(Level->flags3 & LEVEL3_NOCOLOREDSPRITELIGHTING))
@@ -351,7 +351,7 @@ WeaponLighting HWDrawInfo::GetWeaponLighting(sector_t *viewsector, const DVector
 				if (lightbottom < pos.Z)
 				{
 					l.cm = lightlist[i].extra_colormap;
-					l.lightlevel = hw_ClampLight(*lightlist[i].p_lightlevel);
+					l.lightlevel = RescaleLightLevel(*lightlist[i].p_lightlevel);
 					break;
 				}
 			}

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -348,10 +348,10 @@ CUSTOM_CVAR(Float, r_visibility, 8.0f, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 CUSTOM_CVAR(Int, r_extralight, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
-	if (self < -8)
-		self = -8;
-	else if (self > 8)
-		self = 8;
+	if (self < -64)
+		self = -64;
+	else if (self > 128)
+		self = 128;
 }
 
 //==========================================================================

--- a/src/rendering/swrenderer/scene/r_light.cpp
+++ b/src/rendering/swrenderer/scene/r_light.cpp
@@ -148,7 +148,7 @@ namespace swrenderer
 
 	fixed_t LightVisibility::LightLevelToShadeImpl(RenderViewport *viewport, int lightlevel, bool foggy)
 	{
-		lightlevel = hw_ClampLight(lightlevel);
+		lightlevel = RescaleLightLevel<false>(lightlevel);
 		bool nolightfade = !foggy && ((viewport->Level()->flags3 & LEVEL3_NOLIGHTFADE));
 		if (nolightfade)
 		{

--- a/src/rendering/swrenderer/scene/r_light.cpp
+++ b/src/rendering/swrenderer/scene/r_light.cpp
@@ -43,6 +43,7 @@
 #include "g_levellocals.h"
 #include "swrenderer/scene/r_light.h"
 #include "swrenderer/viewport/r_viewport.h"
+#include "hwrenderer/scene/hw_lighting.h"
 
 EXTERN_CVAR(Bool, r_fullbrightignoresectorcolor)
 EXTERN_CVAR(Int, r_extralight)
@@ -147,7 +148,7 @@ namespace swrenderer
 
 	fixed_t LightVisibility::LightLevelToShadeImpl(RenderViewport *viewport, int lightlevel, bool foggy)
 	{
-		lightlevel += r_extralight;
+		lightlevel = hw_ClampLight(lightlevel);
 		bool nolightfade = !foggy && ((viewport->Level()->flags3 & LEVEL3_NOLIGHTFADE));
 		if (nolightfade)
 		{

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2412,7 +2412,7 @@ OptionMenu ModReplayerOptions protected
 	
 	StaticText ""
 	StaticText "$ACCMNU_LIGHT"
-	Slider "$ACCMNU_LIGHT_EXTRA", "r_extralight", -8, 8, 1, 0
+	Slider "$ACCMNU_LIGHT_EXTRA", "r_extralight", -64, 128, 1, 0
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_EXTRA"
 	Slider "$ACCMNU_LIGHT_RADIUS", "r_visibility", 0.0, 16.0, 1.0, 1
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"


### PR DESCRIPTION
this lets the range of values it can work with be greatly extended without harming lighting effects on maps