### PR TITLE
Don't predict if the player's pawn hasn't called PostBeginPlay yet

### DIFF
--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1480,6 +1480,7 @@ void P_PredictPlayer (player_t *player)
 	if (demoplayback || gamestate != GS_LEVEL ||
 		player->mo == NULL ||
 		player != player->mo->Level->GetConsolePlayer() ||
+		(player->mo->ObjectFlags & OF_JustSpawned) ||
 		(player->cheats & CF_PREDICTING))
 	{
 		return;


### PR DESCRIPTION
This does some important networking and therefore should not be predicted at all. Instead, simply don't predict until this is handled properly.

Fixes #748 