### PR TITLE
Fixes #706 and other OOB exceptions thrown when Argv FString is empty…

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -252,3 +252,4 @@ Heath
 Carlos "Cardboard Marty" Sanchez
 JeremWatts
 Faizan "IndieSunPraiser" Mughal
+William "TorrentialFire" Merzon-Wilson

--- a/src/common/utility/m_argv.cpp
+++ b/src/common/utility/m_argv.cpp
@@ -419,7 +419,7 @@ const char * FArgs::CheckValue(const FArg check) const
 	if (i > 0 && i < (int)Argv.Size() - 1)
 	{
 		i++;
-		return Argv[i][0] != '+' && Argv[i][0] != '-' ? Argv[i].GetChars() : nullptr;
+		return Argv[i].IsNotEmpty() && Argv[i][0] != '+' && Argv[i][0] != '-' ? Argv[i].GetChars() : nullptr;
 	}
 	else
 	{


### PR DESCRIPTION
When an empty string is passed as an argument value to the engine, `m_argv.cpp` attempts to index into the string without checking its length, and an exception is thrown.

Assuming this is desired behavior for sniffing out other places in the engine where FStrings are indexed OOB, I have added the appropriate check to FArgs::CheckValue, which short-circuits the check if the corresponding FString in Argv is empty.

EDIT: Dang, my commit message is wrong. This was introduced earlier than the commit I mentioned. Looking in a bit more detail...