### PR TITLE
Fixes #778 setting nointerscrollabort now correctly prevents skipping…

### DIFF
--- a/src/intermission/intermission.cpp
+++ b/src/intermission/intermission.cpp
@@ -803,11 +803,18 @@ void DIntermissionScreenScroller::Init(FIntermissionAction *desc, bool first)
 int DIntermissionScreenScroller::Responder (FInputEvent *ev)
 {
 	int res = Super::Responder(ev);
-	if (res == -1 && !nointerscrollabort)
+
+	if (res == -1)
 	{
+		if (nointerscrollabort) {
+			// Consume the key press to prevent advancing the scroller
+			return 0;
+		}
+
 		mBackground = mSecondPic;
 		mTicker = mScrollDelay + mScrollTime;
 	}
+	
 	return res;
 }
 


### PR DESCRIPTION
This fix allows `nointerscrollabort` to actually prevent a keypress event from advancing a scrolling intermission screen (e.g. the E3M8 bunny cutscene). If this was the intended behavior of that setting, it hasn't worked correctly in a long time.

~~This fix removes a bit of behavior that I do not believe had any effect. If `nointerscrollabort` was false and a keypress event was sent, the intermission controller advanced the screen anyway, so setting the background and adjusting the ticker wouldn't do much. I may be misunderstanding. I am open to suggestions.~~