### PR TITLE
Improved LastSafePos logic

### DIFF
--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1397,7 +1397,7 @@ void FLevelLocals::PlayerReborn (int player)
 	p->cheats |= chasecam;
 	p->Bot = Bot;			//Added by MC:
 	p->settings_controller = settings_controller;
-	p->LastSafePos = p->mo->Pos();
+	p->LastSafePos.Update(*p->mo, true);
 
 	p->oldbuttons = ~0, p->attackdown = true; p->usedown = true;	// don't do anything immediately
 	p->original_oldbuttons = ~0;

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1867,7 +1867,10 @@ int FLevelLocals::FinishTravel()
 	for (size_t i = 0u; i < MAXPLAYERS; ++i)
 	{
 		if (PlayerInGame(i) && !(Players[i]->mo->ObjectFlags & OF_EuthanizeMe) && toCallBack.Find(Players[i]->mo) < toCallBack.Size())
+		{
+			Players[i]->LastSafePos.Update(*Players[i]->mo, true);
 			Players[i]->mo->SetState(Players[i]->mo->SpawnState);
+		}
 	}
 
 	for (auto th : toCallBack)

--- a/src/gamedata/r_defs.h
+++ b/src/gamedata/r_defs.h
@@ -757,6 +757,7 @@ struct sector_t
 	int prevsec;						// -1 or number of sector for previous step
 	int nextsec;						// -1 or number of next step sector
 
+	int LastDamage;						// Last time this sector had SectorDamage called on it.
 	FName damagetype;					// [RH] Means-of-death for applied damage
 	int damageamount;					// [RH] Damage to do while standing on floor
 	short damageinterval;				// Interval for damage application
@@ -796,7 +797,7 @@ public:
 	void RemoveForceField();
 	int Index() const { return sectornum; }
 
-	bool IsDangerous(const DVector3& pos, double height) const;
+	bool IsDangerous(const DVector3& pos, double height, int moTID);
 
 	void AdjustFloorClip () const;
 	void SetColor(PalEntry pe, int desat);

--- a/src/maploader/maploader.cpp
+++ b/src/maploader/maploader.cpp
@@ -1095,6 +1095,7 @@ void MapLoader::LoadSectors (MapData *map, FMissingTextureTracker &missingtex)
 		ss->SeqName = NAME_None;
 		ss->nextsec = -1;	//jff 2/26/98 add fields to support locking out
 		ss->prevsec = -1;	// stair retriggering until build completes
+		ss->LastDamage = -1;
 		memset(ss->SpecialColors, -1, sizeof(ss->SpecialColors));
 		memset(ss->AdditiveColors, 0, sizeof(ss->AdditiveColors));
 

--- a/src/playsim/d_player.h
+++ b/src/playsim/d_player.h
@@ -307,6 +307,18 @@ struct userinfo_t : TMap<FName,FBaseCVar *>
 void ReadUserInfo(FSerializer &arc, userinfo_t &info, FString &skin);
 void WriteUserInfo(FSerializer &arc, userinfo_t &info);
 
+struct FSafePosition
+{
+	sector_t* Sector = nullptr;
+	DVector3 Pos = {};
+	double Height = 0.0, MaxStepHeight = 0.0;
+	bool bValidPos = false;
+
+	void Update(AActor& mobj, bool force = false);
+	bool IsSafe(int tid) const;
+	FSerializer& Serialize(FSerializer& arc, const char* name);
+};
+
 //
 // Extended player object info: player_t
 //
@@ -445,7 +457,7 @@ public:
 	DAngle ConversationNPCAngle = nullAngle;
 	bool ConversationFaceTalker = false;
 
-	DVector3 LastSafePos = {}; // Mark the last known safe location the player was standing.
+	FSafePosition LastSafePos = {}; // Mark the last known safe location the player was standing.
 
 	double GetDeltaViewHeight() const
 	{

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6276,9 +6276,10 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 		&& p->mo != nullptr && p->playerstate == PST_REBORN
 		&& gameaction != ga_worlddone
 		&& !(p->mo->Sector->Flags & SECF_NORESPAWN)
-		&& p->LastDamageType != NAME_Suicide)
+		&& p->LastDamageType != NAME_Suicide
+		&& p->LastSafePos.IsSafe(p->mo->tid))
 	{
-		spawn = p->LastSafePos;
+		spawn = p->LastSafePos.Pos;
 		SpawnAngle = p->mo->Angles.Yaw;
 	}
 	else

--- a/src/playsim/p_spec.cpp
+++ b/src/playsim/p_spec.cpp
@@ -532,6 +532,7 @@ void P_SectorDamage(FLevelLocals *Level, int tag, int amount, FName type, PClass
 	{
 		AActor *actor, *next;
 		sector_t *sec = &Level->sectors[secnum];
+		sec->LastDamage = sec->Level->maptime;
 
 		// Do for actors in this sector.
 		for (actor = sec->thinglist; actor != NULL; actor = next)
@@ -544,6 +545,7 @@ void P_SectorDamage(FLevelLocals *Level, int tag, int amount, FName type, PClass
 		for (unsigned i = 0; i < sec->e->XFloor.attached.Size(); ++i)
 		{
 			sector_t *sec2 = sec->e->XFloor.attached[i];
+			sec2->LastDamage = sec2->Level->maptime;
 
 			for (actor = sec2->thinglist; actor != NULL; actor = next)
 			{


### PR DESCRIPTION
Now validates the spawn point is still safe when respawning in case the sector properties changed.  Added more checks for potential damaging effects when determining if a sector is safe or not.

Checking sector tags on the sector action for making it damage is still missing, but I consider this enough of an edge case to likely not be disruptive.

Needs in-game testing + testing to make sure old saves won't break when loading.

- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.