### PR TITLE
Multiple scoreboard fixes

### DIFF
--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -240,25 +240,25 @@ void CT_PasteChat(const char *clip)
 //
 //===========================================================================
 
+static int IsScoreboardOpen()
+{
+	return buttonMap.ButtonDown(Button_ShowScores) || bScoreboardToggled;
+}
+
+DEFINE_ACTION_FUNCTION_NATIVE(DBaseStatusBar, IsScoreboardOpen, IsScoreboardOpen)
+{
+	PARAM_PROLOGUE;
+	ACTION_RETURN_BOOL(IsScoreboardOpen());
+}
+
 void CT_Drawer (void)
 {
 	auto &vp = r_viewpoint;
 	auto drawer = twod;
 	FFont *displayfont = NewConsoleFont;
 
-	if (players[consoleplayer].camera != NULL &&
-		(buttonMap.ButtonDown(Button_ShowScores) ||
-		 players[consoleplayer].playerstate == PST_DEAD ||
-		 bScoreboardToggled))
-	{
-		bool skipit = false;
-		if (gamestate != GS_LEVEL)
-		{
-			bScoreboardToggled = false;
-			skipit = true;
-		}
-		if (!skipit) HU_DrawScores (vp.TicFrac);
-	}
+	HU_DrawScores(vp.TicFrac);
+
 	if (chatmodeon)
 	{
 		// [MK] allow the status bar to take over chat prompt drawing

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1413,6 +1413,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 		laststartpos = position;
 
 	Init();
+	bScoreboardToggled = false;
 	StatusBar->DetachAllMessages ();
 
 	// Force 'teamplay' to 'true' if need be.

--- a/src/g_statusbar/sbar.h
+++ b/src/g_statusbar/sbar.h
@@ -447,6 +447,9 @@ public:
 
 	FMugShot mugshot;
 
+	FFont* ScoreboardFont;
+	FFont* BigScoreboardFont;
+
 private:
 	bool RepositionCoords (int &x, int &y, int xo, int yo, const int w, const int h) const;
 	void DrawMessages (int layer, int bottom);

--- a/src/hu_scores.cpp
+++ b/src/hu_scores.cpp
@@ -147,10 +147,16 @@ bool bScoreboardToggled = false;
 
 void HU_DrawScores(double ticFrac)
 {
+	bool res = false;
 	if (StatusBar != nullptr)
 	{
 		IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawScoreboard)
-			CallVM<void>(func, StatusBar, ticFrac);
+			res = CallVM<int>(func, StatusBar, ticFrac);
+	}
+
+	if (!res)
+	{
+		bScoreboardToggled = false;
 	}
 }
 

--- a/src/hu_scores.cpp
+++ b/src/hu_scores.cpp
@@ -147,8 +147,11 @@ bool bScoreboardToggled = false;
 
 void HU_DrawScores(double ticFrac)
 {
-	IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawScoreboard)
-		CallVM<void>(func, StatusBar, ticFrac);
+	if (StatusBar != nullptr)
+	{
+		IFVIRTUALPTR(StatusBar, DBaseStatusBar, DrawScoreboard)
+			CallVM<void>(func, StatusBar, ticFrac);
+	}
 }
 
 CCMD(togglescoreboard)

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -740,7 +740,7 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, Resurrect)
 
 player_t* player_t::GetNextPlayer(player_t* p, bool noBots)
 {
-	int pNum = player_t::GetNextPlayerNumber(p == nullptr ? -1 : p - players);
+	int pNum = player_t::GetNextPlayerNumber(p == nullptr ? -1 : p - players, noBots);
 	return pNum != -1 ? &players[pNum] : nullptr;
 }
 
@@ -756,13 +756,13 @@ DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, GetNextPlayer, player_t::GetNextPlaye
 int player_t::GetNextPlayerNumber(int pNum, bool noBots)
 {
 	int i = max<int>(pNum + 1, 0);
-	for (; i < MaxClients; ++i)
+	for (; i < MAXPLAYERS; ++i)
 	{
 		if (playeringame[i] && (!noBots || players[i].Bot == nullptr))
 			break;
 	}
 
-	return i < MaxClients ? i : -1;
+	return i < MAXPLAYERS ? i : -1;
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(_PlayerInfo, GetNextPlayerNumber, player_t::GetNextPlayerNumber)

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -3106,6 +3106,8 @@ DEFINE_FIELD(DBaseStatusBar, CPlayer);
 DEFINE_FIELD(DBaseStatusBar, ShowLog);
 DEFINE_FIELD(DBaseStatusBar, artiflashTick);
 DEFINE_FIELD(DBaseStatusBar, itemflashFade);
+DEFINE_FIELD(DBaseStatusBar, ScoreboardFont);
+DEFINE_FIELD(DBaseStatusBar, BigScoreboardFont);
 
 
 DEFINE_GLOBAL(StatusBar);

--- a/wadsrc/static/zscript/ui/statusbar/scoreboard.zs
+++ b/wadsrc/static/zscript/ui/statusbar/scoreboard.zs
@@ -5,8 +5,8 @@ extend class BaseStatusBar
 	const MAX_TEAM_SCORE_ROWS = 2;
 	const SCOREBOARD_PADDING = 5;
 
-	Font ScoreboardFont;
-	Font BigScoreboardFont;
+	native Font ScoreboardFont;
+	native Font BigScoreboardFont;
 
 	native static bool IsScoreboardOpen();
 

--- a/wadsrc/static/zscript/ui/statusbar/scoreboard.zs
+++ b/wadsrc/static/zscript/ui/statusbar/scoreboard.zs
@@ -116,12 +116,12 @@ extend class BaseStatusBar
 		BigScoreboardFont = BigFont;
 	}
 
-    version("4.15.1") virtual void DrawScoreboard(double ticFrac)
+    version("4.15.1") virtual bool DrawScoreboard(double ticFrac)
     {
 		if (!ScoreboardFont || GameState != GS_LEVEL || !CPlayer
 			|| (CPlayer.PlayerState != PST_DEAD && !IsScoreboardOpen()))
 		{
-			return;
+			return false;
 		}
 
 	    if (deathmatch)
@@ -129,16 +129,16 @@ extend class BaseStatusBar
 		    if (teamplay)
 		    {
 			    if(!sb_teamdeathmatch_enable)
-				    return;
+				    return false;
 		    }
 		    else if (!sb_deathmatch_enable)
 		    {
-			    return;
+			    return false;
 		    }
 	    }
 	    else if (!multiplayer || !sb_cooperative_enable)
 	    {
-		    return;
+		    return false;
 	    }
 
 		DrawRemainingTime(ticFrac);
@@ -146,6 +146,7 @@ extend class BaseStatusBar
         Array<int> sortedPlayers;
 		SortScoreboardPlayers(sortedPlayers, ComparePlayerPoints);
 		DrawPlayerScores(sortedPlayers, ticFrac);
+		return true;
     }
 
 	version("4.15.1") virtual void DrawRemainingTime(double ticFrac)


### PR DESCRIPTION
Allow full control over when the scoreboard should or shouldn't be drawn. Also shortens up the width a little to better fit the real name length and adds a return value for later use with the planned UI mode. The ` (ms)` will be removed from the Delay column title after this is merged.