### PR TITLE
Added tilde-suffix regex to blocked filenames.

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2164,7 +2164,7 @@ void GetReserved(LumpFilterInfo& lfi)
 	lfi.reservedFolders = { "flats/", "textures/", "hires/", "sprites/", "voxels/", "colormaps/", "acs/", "maps/", "voices/", "patches/", "graphics/", "sounds/", "music/",
 	"materials/", "models/", "fonts/", "brightmaps/" };
 	lfi.requiredPrefixes = { "mapinfo", "zmapinfo", "umapinfo", "gameinfo", "sndinfo", "sndseq", "sbarinfo", "menudef", "gldefs", "animdefs", "decorate", "zscript", "iwadinfo", "complvl", "terrain", "maps/" };
-	lfi.blockednames = { "*.bat", "*.exe", "__macosx/*", "*/__macosx/*" };
+	lfi.blockednames = { "*.bat", "*.exe", "__macosx/*", "*/__macosx/*", "*~" };
 }
 
 static FString CheckGameInfo(std::vector<std::string> & pwads)


### PR DESCRIPTION
 Eases developing mods from folders when text-editors/IDEs (such as Emacs) create backup files in the root location with tilde suffix.