### PR TITLE
Ignore 'Update headers'

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@
 55142078d81c30c80c981f0a5ad5860e73444247
 # Add eol=lf, renormalize
 e75ed9e9dae661e2e8f5dcb5c37dc4db12667df1
+# Update headers
+cb10f66a75dd00dc4b1a45b09b9aba055190cabd


### PR DESCRIPTION
Since that's a big commit that is 90% formatting, added to the blame ignore file. Would've added it in the initial PR, but the commit hash is not known at that point