### PR TITLE
[discuss] Prediction GC hack

### DIFF
--- a/src/common/objects/dobjgc.cpp
+++ b/src/common/objects/dobjgc.cpp
@@ -154,6 +154,17 @@ static cycle_t GCTime;			// Track time spent in GC
 
 void CheckGC()
 {
+	if (bPredictionGuard)
+	{
+		// HACK: GC running during prediction is terrifying,
+		// because it runs off of copious amounts of memcpy.
+
+		// This (and the related hack in P_UnPredictPlayer)
+		// will not be needed whenever the prediction
+		// is updated to use serialization instead.
+		return;
+	}
+
 	AllocHistory.AddAlloc(RunningAllocBytes);
 	RunningAllocBytes = 0;
 	if (State > GCS_Pause || AllocBytes >= Threshold)

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -1455,9 +1455,10 @@ void P_PredictPlayer (player_t *player)
 		return;
 	}
 
-	bPredictionGuard = true;
 	// Avoid memcpying in bad pointers.
 	GC::CheckGC();
+
+	bPredictionGuard = true;
 
 	FRandom::SaveRNGState(PredictionRNG);
 
@@ -1697,6 +1698,7 @@ void P_UnPredictPlayer ()
 		player->inventorytics = inventorytics;
 
 		bPredictionGuard = false;
+		GC::CheckGC(); // HACK: See the comment in the bPredictionGuard block of CheckGC
 	}
 }
 


### PR DESCRIPTION
## Description

I spent a lot of time looking at #560 + #362 + my own mod getting this crash, w/ ASAN + debugger + print spam, and I'm fairly sure that these are all the same problem: a save occurring soon after a GC sweep happening in the middle of a player prediction. Unmodded doesn't do as much garbage collection as some crazy ZScript mods can, so I wasn't able to fully confirm that it happens there, but it's theoretically possible all of the time.

The proper fix for this problem would be #585, but that's planned for 5.1. I came up with this temporary band-aid instead; don't run GC during predictions, make sure GC is checked before + after every prediction to accommodate instead. This appears to be the best solution that doesn't introduce any full sweeps or break GC behavior.

From testing, this change has made my game significantly more stable; I haven't experienced a new crash since integrating this change in my fork, when I used to be able to reliably crash multiple times a day.  But it still feels pretty gross, and I'm not *completely* convinced this alone can get rid of the crash entirely.

I opened this to feel out what other people think about doing this as a temporary measure for 5.0. Feel free to close if there's no consensus. If accepted, I'd suggest not closing #560 or #362 until #585 has been done instead.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
