### PR TITLE
Set non-grey brand colours in Linux FreeDesktop metainfo.xml

### DIFF
--- a/src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
+++ b/src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
@@ -20,8 +20,8 @@
 	<url type="vcs-browser">https://github.com/UZDoom/UZDoom</url>
 
 	<branding>
-	  <color type="primary" scheme_preference="light">#77bdc9</color>
-	  <color type="primary" scheme_preference="dark">#23393d</color>
+		<color type="primary" scheme_preference="light">#77bdc9</color>
+		<color type="primary" scheme_preference="dark">#23393d</color>
 	</branding>
 
 	<description>

--- a/src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
+++ b/src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
@@ -20,8 +20,8 @@
 	<url type="vcs-browser">https://github.com/UZDoom/UZDoom</url>
 
 	<branding>
-		<color type="primary" scheme_preference="light">#999999</color>
-		<color type="primary" scheme_preference="dark">#222222</color>
+	  <color type="primary" scheme_preference="light">#77bdc9</color>
+	  <color type="primary" scheme_preference="dark">#23393d</color>
 	</branding>
 
 	<description>


### PR DESCRIPTION
## Description

[Flathub's quality guidelines](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#good-brand-colors) specifically note that branding colours should ideally not just be shades of grey.

As suggested there I've taken the icon's teal colour and adjusted lightness and saturation to come to these two with decent contrast with the icon (previews generated using the [Flathub banner preview tool](https://docs.flathub.org/banner-preview)):

<img width="1765" height="595" alt="uzdoom-brandpreview-light" src="https://github.com/user-attachments/assets/f41679da-7482-4ff3-862c-6ad514072376" />
<img width="1745" height="576" alt="uzdoom-brandpreview-dark" src="https://github.com/user-attachments/assets/34ba58f5-1805-4538-a16f-f1f4e447e594" />

For reference, these colours are used by Flathub in OpenGraph link previews (see below) or in the feature slot at the top of flathub.org. Graphical package managers may also use them when displaying the package metadata or listing (e.g. Bazzite's Bazaar uses them to frame the screenshot preview in search results).

<img width="555" height="387" alt="LibreQuake Flathub listing preview in Discord" src="https://github.com/user-attachments/assets/060589c3-7541-45b0-96f3-15592774ee0c" />


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
