### PR TITLE
Allow for higher-quality shadowmaps

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_shadowmap.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_shadowmap.cpp
@@ -63,14 +63,17 @@ ADD_STAT(shadowmap)
 	return out;
 }
 
-CUSTOM_CVAR(Int, gl_shadowmap_quality, 512, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CUSTOM_CVAR(Int, gl_shadowmap_quality, 1024, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
 	switch (self)
 	{
-	case 128:
-	case 256:
-	case 512:
-	case 1024:
+	case 2<<6: // 128
+	case 2<<7: // 256
+	case 2<<8: // 512
+	case 2<<9: // 1024
+	case 2<<10: // 2048
+	case 2<<11: // 4096
+	case 2<<12: // 8192
 		break;
 	default:
 		self = 128;

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2804,6 +2804,9 @@ OptionValue ShadowMapQuality
 	256, "256"
 	512, "512"
 	1024, "1024"
+	2048, "2048"
+	4096, "4096"
+	8192, "8192"
 }
 
 OptionValue ShadowMapFilter


### PR DESCRIPTION
## Description

Closes #898 

Allows for higher quality shadowmaps. My laptop does not come close to breaking a sweat at the new maximum value, so I also bumped the default up from 512 to 1024

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
