### PR TITLE
Accessibility reset

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -258,3 +258,4 @@ Faizan "IndieSunPraiser" Mughal
 William "TorrentialFire" Merzon-Wilson
 Eric Womer
 RichardDS90
+Frank Kloster

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -66,6 +66,15 @@ EXTERN_CVAR(Float, vid_blackpoint)
 EXTERN_CVAR(Float, vid_whitepoint)
 EXTERN_CVAR(Int, gl_satformula)
 
+EXTERN_CVAR(Int, m_tooltip_lines)
+EXTERN_CVAR(Float, m_tooltip_speed)
+EXTERN_CVAR(Float, m_tooltip_delay)
+EXTERN_CVAR(Float, m_tooltip_alpha)
+EXTERN_CVAR(Bool, m_tooltip_capwidth)
+EXTERN_CVAR(Bool, m_tooltip_small)
+EXTERN_CVAR(Int, r_extralight)
+EXTERN_CVAR(Float, r_visibility)
+
 CVAR(Bool, m_simpleoptions, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 CVAR(Bool, m_simpleoptions_view, true, 0);
 
@@ -615,6 +624,18 @@ CCMD(vid_reset2defaults)
 	vid_blackpoint->ResetToDefault();
 	vid_whitepoint->ResetToDefault();
 	gl_satformula->ResetToDefault();
+}
+
+CCMD(acc_reset2defaults)
+{
+	m_tooltip_lines->ResetToDefault();
+	m_tooltip_speed->ResetToDefault();
+	m_tooltip_delay->ResetToDefault();
+	m_tooltip_alpha->ResetToDefault();
+	m_tooltip_capwidth->ResetToDefault();
+	m_tooltip_small->ResetToDefault();
+	r_extralight->ResetToDefault();
+	r_visibility->ResetToDefault();
 }
 
 CCMD(reset2defaults)

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2414,6 +2414,9 @@ OptionMenu ModReplayerOptions protected
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_EXTRA"
 	Slider "$ACCMNU_LIGHT_RADIUS", "r_visibility", 0.0, 16.0, 1.0, 1
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"
+
+	StaticText ""
+	SafeCommand "$ACCMNU_RESET", "acc_reset2defaults"
  }
 
 /*=======================================


### PR DESCRIPTION
## Description
Added a PR that addresses [#866](https://github.com/UZDoom/UZDoom/issues/866). It just adds a "reset" button to the accessibility menu. Note there is a missing request of having a option-by-option reset button. I'm a little unsure what that would look like, but I'm happy to add such an option.

First commit is a tiny somewhat related issue of a missing accessibility menu title; happy to split if requested.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
