### PR TITLE
Run metainfo linter on PRs too

### DIFF
--- a/.github/workflows/lint_metainfo.yml
+++ b/.github/workflows/lint_metainfo.yml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - '**.metainfo.xml'
+  pull_request:
+    paths:
+      - '**.metainfo.xml'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

For some reason, creating a PR with a change to the metainfo doesn't seem to count as a push.


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
