### PR TITLE
Light Level & Extra Lighting Fix

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_lighting.h
+++ b/src/rendering/hwrenderer/scene/hw_lighting.h
@@ -32,9 +32,12 @@ inline int hw_ClampLight(int lightlevel)
 }
 
 template<bool doClamp = true>
-inline int RescaleLightLevel(int lightlevel) // TODO/tidy: move out of hwrenderer namespace
+inline int RescaleLightLevel(int lightlevel, AActor *mo = nullptr, DVisualThinker *vt = nullptr) // TODO/tidy: move out of hwrenderer namespace
 {
-	if constexpr(doClamp)
+	if ((mo && mo->LightLevel > -1 && !(mo->flags8 & MF8_ADDLIGHTLEVEL)) ||
+	    (vt && vt->LightLevel > -1 && !(vt->flags & VTF_AddLightLevel)))
+		return hw_ClampLight(lightlevel);
+	else if constexpr(doClamp)
 	{
 		//max is needed for negative r_extralight values
 		return max(int((clamp(lightlevel, 0, 255) / 255.0) * (255.0 - r_extralight)) + r_extralight, 0);

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1253,7 +1253,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		((thing->renderflags & RF_FULLBRIGHT) && (!texture || !texture->isFullbrightDisabled()));
 
 	if (fullbright)	lightlevel = 255;
-	else lightlevel = RescaleLightLevel(thing->GetLightLevel(rendersector));
+	else lightlevel = RescaleLightLevel(thing->GetLightLevel(rendersector), thing);
 
 	foglevel = (uint8_t)clamp<short>(rendersector->lightlevel, 0, 255); // this *must* use the sector's light level or the fog will just look bad.
 
@@ -1481,7 +1481,7 @@ void HWSprite::ProcessParticle(HWDrawInfo *di, particle_t *particle, sector_t *s
 	if (spr && !spr->ValidTexture())
 		return;
 
-	lightlevel = RescaleLightLevel(spr ? spr->GetLightLevel(sector) : sector->GetSpriteLight());
+	lightlevel = RescaleLightLevel(spr ? spr->GetLightLevel(sector) : sector->GetSpriteLight(), nullptr, spr);
 	foglevel = (uint8_t)clamp<short>(sector->lightlevel, 0, 255);
 
 	trans = particle->alpha;


### PR DESCRIPTION
- Fixed: Actor's and VisualThinker's `LightLevel`, when set to > -1, was not properly respected with the Extra Lighting accessibility option.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
