### PR TITLE
Stopped ticking client-sided Thinkers when paused

### DIFF
--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -61,10 +61,13 @@ void P_RunClientSideLogic()
 
 	if (gamestate == GS_LEVEL || gamestate == GS_TITLELEVEL)
 	{
-		for (unsigned int i = 0; i < MAXPLAYERS; ++i)
+		if (!WorldPaused(false))
 		{
-			if (playeringame[i] && players[i].inventorytics > 0)
-				--players[i].inventorytics;
+			for (unsigned int i = 0; i < MAXPLAYERS; ++i)
+			{
+				if (playeringame[i] && players[i].inventorytics > 0)
+					--players[i].inventorytics;
+			}
 		}
 
 		for (auto level : AllLevels())

--- a/src/playsim/a_dynlight.cpp
+++ b/src/playsim/a_dynlight.cpp
@@ -244,8 +244,6 @@ void FDynamicLight::Tick()
 
 	// Don't bother if the light won't be shown
 	if (!IsActive()) return;
-	if (!target->IsClientSide() && WorldPaused(false))
-		return;
 
 	// I am doing this with a type field so that I can dynamically alter the type of light
 	// without having to create or maintain multiple objects.

--- a/src/playsim/a_dynlight.h
+++ b/src/playsim/a_dynlight.h
@@ -242,7 +242,7 @@ struct FDynamicLight
 	int GetIntensity() const { return pArgs[LIGHT_INTENSITY]; }
 	int GetSecondaryIntensity() const { return pArgs[LIGHT_SECONDARY_INTENSITY]; }
 	double GetLightDefIntensity() const { return lightDefIntensity; }
-	int GetTimer() const { return target->IsClientSide() ? Level->LocalTimer : Level->LocalWorldTimer; }
+	int GetTimer() const { return Level->LocalWorldTimer; }
 
 	bool IsSubtractive() const { return !!((*pLightFlags) & LF_SUBTRACTIVE); }
 	bool IsAdditive() const { return !!((*pLightFlags) & LF_ADDITIVE); }


### PR DESCRIPTION
For now this will be done to keep parity between the Actor ticking and model rendering (this relies on the game being unpaused to advance properly).

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
