### PR TITLE
Extract macOS plist bundle version from version.h

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -261,3 +261,4 @@ RichardDS90
 Frank Kloster
 Santtu "MFG38" Pesonen
 heiko123abc
+Piotr "stared" Migdał

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,24 +1,5 @@
 cmake_minimum_required( VERSION 3.16.0 )
 
-function(extract_version_define output_var define_name capture_pattern)
-    set(strict_regex "^#define ${define_name} ${capture_pattern}$")
-    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version.h" match_lines REGEX "${strict_regex}")
-    list(LENGTH match_lines match_count)
-    if(NOT match_count EQUAL 1)
-        message(FATAL_ERROR "Expected exactly one ${define_name}, found ${match_count}")
-    endif()
-    list(GET match_lines 0 match_line)
-    string(REGEX REPLACE "${strict_regex}" "\\1" extracted_value "${match_line}")
-    set(${output_var} "${extracted_value}" PARENT_SCOPE)
-endfunction()
-
-extract_version_define(UZDOOM_VERSION_STRING   "VERSIONSTR"   "\"([^\"]+)\"")
-extract_version_define(UZDOOM_VERSION_MAJOR    "VER_MAJOR"    "([0-9]+)")
-extract_version_define(UZDOOM_VERSION_MINOR    "VER_MINOR"    "([0-9]+)")
-extract_version_define(UZDOOM_VERSION_REVISION "VER_REVISION" "([0-9]+)")
-
-message(STATUS "UZDoom version: ${UZDOOM_VERSION_STRING} (${UZDOOM_VERSION_MAJOR}.${UZDOOM_VERSION_MINOR}.${UZDOOM_VERSION_REVISION})")
-
 include(precompiled_headers)
 
 if( COMMAND cmake_policy )
@@ -1526,10 +1507,17 @@ if( APPLE )
 	set_target_properties(zdoom PROPERTIES
 		LINK_FLAGS "${LINK_FRAMEWORKS}"
 		MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/posix/osx/zdoom-info.plist"
-		MACOSX_BUNDLE_SHORT_VERSION_STRING "${UZDOOM_VERSION_STRING}"
-		MACOSX_BUNDLE_BUNDLE_VERSION "${UZDOOM_VERSION_MAJOR}.${UZDOOM_VERSION_MINOR}.${UZDOOM_VERSION_REVISION}"
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "org.zdoom.UZDoom"
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" )
+
+	# Update plist bundle version from git describe at build time
+	add_custom_command(TARGET zdoom POST_BUILD
+		COMMAND "${CMAKE_COMMAND}"
+			-DPLIST_FILE="$<TARGET_BUNDLE_DIR:zdoom>/Contents/Info.plist"
+			-P "${CMAKE_CURRENT_SOURCE_DIR}/posix/osx/UpdatePlistVersion.cmake"
+		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+		COMMENT "Updating bundle version in Info.plist"
+	)
 
 	# Dymanic libraries like libvulkan.dylib or libMoltenVK.dylib will be loaded by dlopen()
 	# if placed in the directory with the main executable

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,24 @@
 cmake_minimum_required( VERSION 3.16.0 )
 
+function(extract_version_define output_var define_name capture_pattern)
+    set(strict_regex "^#define ${define_name} ${capture_pattern}$")
+    file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/version.h" match_lines REGEX "${strict_regex}")
+    list(LENGTH match_lines match_count)
+    if(NOT match_count EQUAL 1)
+        message(FATAL_ERROR "Expected exactly one ${define_name}, found ${match_count}")
+    endif()
+    list(GET match_lines 0 match_line)
+    string(REGEX REPLACE "${strict_regex}" "\\1" extracted_value "${match_line}")
+    set(${output_var} "${extracted_value}" PARENT_SCOPE)
+endfunction()
+
+extract_version_define(UZDOOM_VERSION_STRING   "VERSIONSTR"   "\"([^\"]+)\"")
+extract_version_define(UZDOOM_VERSION_MAJOR    "VER_MAJOR"    "([0-9]+)")
+extract_version_define(UZDOOM_VERSION_MINOR    "VER_MINOR"    "([0-9]+)")
+extract_version_define(UZDOOM_VERSION_REVISION "VER_REVISION" "([0-9]+)")
+
+message(STATUS "UZDoom version: ${UZDOOM_VERSION_STRING} (${UZDOOM_VERSION_MAJOR}.${UZDOOM_VERSION_MINOR}.${UZDOOM_VERSION_REVISION})")
+
 include(precompiled_headers)
 
 if( COMMAND cmake_policy )
@@ -1507,6 +1526,8 @@ if( APPLE )
 	set_target_properties(zdoom PROPERTIES
 		LINK_FLAGS "${LINK_FRAMEWORKS}"
 		MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/posix/osx/zdoom-info.plist"
+		MACOSX_BUNDLE_SHORT_VERSION_STRING "${UZDOOM_VERSION_STRING}"
+		MACOSX_BUNDLE_BUNDLE_VERSION "${UZDOOM_VERSION_MAJOR}.${UZDOOM_VERSION_MINOR}.${UZDOOM_VERSION_REVISION}"
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "org.zdoom.UZDoom"
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1510,12 +1510,12 @@ if( APPLE )
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "org.zdoom.UZDoom"
 		XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "" )
 
-	# Update plist bundle version from git describe at build time
+	# Update plist bundle version from gitinfo.h at build time
 	add_custom_command(TARGET zdoom POST_BUILD
 		COMMAND "${CMAKE_COMMAND}"
+			-DGITINFO_H="${CMAKE_BINARY_DIR}/gitinfo.h"
 			-DPLIST_FILE="$<TARGET_BUNDLE_DIR:zdoom>/Contents/Info.plist"
 			-P "${CMAKE_CURRENT_SOURCE_DIR}/posix/osx/UpdatePlistVersion.cmake"
-		WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 		COMMENT "Updating bundle version in Info.plist"
 	)
 

--- a/src/posix/osx/UpdatePlistVersion.cmake
+++ b/src/posix/osx/UpdatePlistVersion.cmake
@@ -1,76 +1,27 @@
 #!/usr/bin/cmake -P
 
-# UpdatePlistVersion.cmake
-#
-# Runs as a POST_BUILD step to stamp the macOS bundle Info.plist
-# with the version derived from git describe (or the GIT_DESCRIBE
-# env var).  Follows the same pattern as UpdateRevision.cmake.
+# Stamp macOS bundle Info.plist with version from gitinfo.h.
+# Called as POST_BUILD with -DGITINFO_H=... -DPLIST_FILE=...
 
-# Populate variable "Version" with X.Y.Z parsed from git describe.
-# Falls back to "0.0.0" if anything goes wrong.
-function(query_version_info)
-	execute_process(
-		COMMAND git rev-parse --is-inside-work-tree
-		RESULT_VARIABLE is_git
-		OUTPUT_QUIET
-	)
+if(NOT EXISTS "${GITINFO_H}")
+	message(STATUS "'${GITINFO_H}' not found, skipping plist version stamp")
+	return()
+endif()
 
-	set(Version "0.0.0")
+file(READ "${GITINFO_H}" _gitinfo)
+string(REGEX MATCH "GIT_DESCRIPTION \"([^\"]*)\"" _match "${_gitinfo}")
+set(_tag "${CMAKE_MATCH_1}")
 
-	if(DEFINED ENV{GIT_DESCRIBE})
-		set(Tag "$ENV{GIT_DESCRIBE}")
+string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" _match "${_tag}")
+if(NOT _match)
+	message(STATUS "Git tag '${_tag}' has no X.Y.Z version, skipping plist stamp")
+	return()
+endif()
+set(Version "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
 
-		if(is_git EQUAL "0")
-			message(STATUS "Version tag overridden by GIT_DESCRIBE env var")
-		endif()
-	elseif(is_git EQUAL "0")
-		execute_process(
-			COMMAND git describe --tags
-			RESULT_VARIABLE Error
-			OUTPUT_VARIABLE Tag
-			ERROR_QUIET
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-		)
-
-		if(NOT "${Error}" STREQUAL "0")
-			message(STATUS "No git tags found! Using fallback '${Version}'")
-			set(Version "${Version}" PARENT_SCOPE)
-			return()
-		endif()
-	else()
-		message(STATUS "Not a git repo! Set version tag by setting GIT_DESCRIBE env var")
-		set(Version "${Version}" PARENT_SCOPE)
-		return()
-	endif()
-
-	string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" _match "${Tag}")
-	if(NOT _match)
-		message(STATUS "Cannot parse X.Y.Z from '${Tag}'! Using fallback '${Version}'")
-	else()
-		set(Version "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
-	endif()
-
-	set(Version "${Version}" PARENT_SCOPE)
-endfunction()
-
-function(main)
-	if(NOT DEFINED PLIST_FILE)
-		message(FATAL_ERROR "PLIST_FILE not set. Pass -DPLIST_FILE=<path>")
-	endif()
-
-	query_version_info()
-	message(STATUS "Plist bundle version: ${Version}")
-
-	execute_process(
-		COMMAND /usr/libexec/PlistBuddy
-			-c "Set :CFBundleShortVersionString ${Version}"
-			-c "Set :CFBundleVersion ${Version}"
-			"${PLIST_FILE}"
-		RESULT_VARIABLE _pb_result
-	)
-	if(NOT _pb_result EQUAL 0)
-		message(FATAL_ERROR "PlistBuddy failed (${_pb_result})")
-	endif()
-endfunction()
-
-main()
+message(STATUS "Plist bundle version: ${Version}")
+execute_process(COMMAND /usr/libexec/PlistBuddy
+	-c "Set :CFBundleShortVersionString ${Version}"
+	-c "Set :CFBundleVersion ${Version}"
+	"${PLIST_FILE}"
+)

--- a/src/posix/osx/UpdatePlistVersion.cmake
+++ b/src/posix/osx/UpdatePlistVersion.cmake
@@ -1,0 +1,76 @@
+#!/usr/bin/cmake -P
+
+# UpdatePlistVersion.cmake
+#
+# Runs as a POST_BUILD step to stamp the macOS bundle Info.plist
+# with the version derived from git describe (or the GIT_DESCRIBE
+# env var).  Follows the same pattern as UpdateRevision.cmake.
+
+# Populate variable "Version" with X.Y.Z parsed from git describe.
+# Falls back to "0.0.0" if anything goes wrong.
+function(query_version_info)
+	execute_process(
+		COMMAND git rev-parse --is-inside-work-tree
+		RESULT_VARIABLE is_git
+		OUTPUT_QUIET
+	)
+
+	set(Version "0.0.0")
+
+	if(DEFINED ENV{GIT_DESCRIBE})
+		set(Tag "$ENV{GIT_DESCRIBE}")
+
+		if(is_git EQUAL "0")
+			message(STATUS "Version tag overridden by GIT_DESCRIBE env var")
+		endif()
+	elseif(is_git EQUAL "0")
+		execute_process(
+			COMMAND git describe --tags
+			RESULT_VARIABLE Error
+			OUTPUT_VARIABLE Tag
+			ERROR_QUIET
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+		)
+
+		if(NOT "${Error}" STREQUAL "0")
+			message(STATUS "No git tags found! Using fallback '${Version}'")
+			set(Version "${Version}" PARENT_SCOPE)
+			return()
+		endif()
+	else()
+		message(STATUS "Not a git repo! Set version tag by setting GIT_DESCRIBE env var")
+		set(Version "${Version}" PARENT_SCOPE)
+		return()
+	endif()
+
+	string(REGEX MATCH "([0-9]+)\\.([0-9]+)\\.([0-9]+)" _match "${Tag}")
+	if(NOT _match)
+		message(STATUS "Cannot parse X.Y.Z from '${Tag}'! Using fallback '${Version}'")
+	else()
+		set(Version "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+	endif()
+
+	set(Version "${Version}" PARENT_SCOPE)
+endfunction()
+
+function(main)
+	if(NOT DEFINED PLIST_FILE)
+		message(FATAL_ERROR "PLIST_FILE not set. Pass -DPLIST_FILE=<path>")
+	endif()
+
+	query_version_info()
+	message(STATUS "Plist bundle version: ${Version}")
+
+	execute_process(
+		COMMAND /usr/libexec/PlistBuddy
+			-c "Set :CFBundleShortVersionString ${Version}"
+			-c "Set :CFBundleVersion ${Version}"
+			"${PLIST_FILE}"
+		RESULT_VARIABLE _pb_result
+	)
+	if(NOT _pb_result EQUAL 0)
+		message(FATAL_ERROR "PlistBuddy failed (${_pb_result})")
+	endif()
+endfunction()
+
+main()

--- a/src/posix/osx/zdoom-info.plist
+++ b/src/posix/osx/zdoom-info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<string>0.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<string>0.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSApplicationCategoryType</key>

--- a/src/posix/osx/zdoom-info.plist
+++ b/src/posix/osx/zdoom-info.plist
@@ -17,7 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Development Version</string>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
The macOS app bundle (`UZDoom.app/Contents/Info.plist`) showed "Development Version" instead of the actual version.

I discovered while developing https://github.com/stared/rusted-doom-launcher, as I wanted to provide information of the Doom engine for debugging. GZDoom provides correct version.

```bash
$ defaults read "/Applications/GZDoom.app/Contents/Info.plist" CFBundleShortVersionString
g4.14.2
```

```bash
$ defaults read "/Applications/UZDoom.app/Contents/Info.plist" CFBundleShortVersionString
Development Version
```

At the same time, running it gives the correct version:

```bash
$ /Applications/UZDoom.app/Contents/MacOS/uzdoom
UZDoom 4.14.3 - 2025-11-28 23:17:36 +0000 - Cocoa version
Compiled on Nov 28 2025

MacBookPro18,1 running macOS Unknown version 15.7.3 (24G419) 64-bit ARM
UZDoom version 4.14.3
```

So, I expect that the version in `Info.plist` is the same.

<img width="474" height="874" alt="Screenshot 2026-01-21 at 23 41 47" src="https://github.com/user-attachments/assets/2bd6f4e0-77e8-4687-b9d3-f814879edee2" />
<img width="474" height="858" alt="Screenshot 2026-01-21 at 23 42 04" src="https://github.com/user-attachments/assets/12b0d853-b46b-48b3-a6f3-4c42f7b1d441" />


See Apple documentation for [CFBundleShortVersionString](https://developer.apple.com/documentation/bundleresources/information-property-list/cfbundleshortversionstring).

One think I do not understand though is that GZDoom also has "Development Version" in https://github.com/ZDoom/gzdoom/blob/master/src/posix/osx/zdoom-info.plist. It seems that they have some private release pipeline not shown here. Yet, it is good have a proper way to do it.

As an important disclaimer - I am not an expert in macOS build systems. So I would be grateful if someone with better knowledge checked that.

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
