### PR TITLE
still calculate bone getters if no anim is playing

### DIFF
--- a/src/common/models/model.h
+++ b/src/common/models/model.h
@@ -140,7 +140,7 @@ public:
 	virtual ModelAnimFrame PrecalculateFrame(const ModelAnimFrame &from, const ModelAnimFrameInterp &to, float inter, const TArray<TRS>* animationData) { return nullptr; };
 
 	virtual const TArray<VSMatrix>* CalculateBones(const ModelAnimFrame &from, const ModelAnimFrameInterp &to, float inter, const TArray<TRS>* animationData, TArray<BoneOverride> *in, BoneInfo *out, double time) { return nullptr; };
-	virtual const TArray<VSMatrix>* CalculateBonesOnlyOffsets(TArray<BoneOverride> *in, double time) { return nullptr; };
+	virtual const TArray<VSMatrix>* CalculateBonesOnlyOffsets(TArray<BoneOverride> *in, BoneInfo *out, double time) { return nullptr; };
 
 	virtual const TArray<VSMatrix>* GetBasePose() {return nullptr;}
 

--- a/src/common/models/model_iqm.h
+++ b/src/common/models/model_iqm.h
@@ -143,7 +143,7 @@ public:
 
 	ModelAnimFrame PrecalculateFrame(const ModelAnimFrame &from, const ModelAnimFrameInterp &to, float inter, const TArray<TRS>* animationData) override;
 	const TArray<VSMatrix>* CalculateBones(const ModelAnimFrame &from, const ModelAnimFrameInterp &to, float inter, const TArray<TRS>* animationData, TArray<BoneOverride> *in, BoneInfo *out, double time) override;
-	const TArray<VSMatrix>* CalculateBonesOnlyOffsets(TArray<BoneOverride> *in, double time) override;
+	const TArray<VSMatrix>* CalculateBonesOnlyOffsets(TArray<BoneOverride> *in, BoneInfo *out, double time) override;
 
 	ModelAnimFramePrecalculatedIQM CalculateFrameIQM(int frame1, int frame2, float inter, int frame1_prev, float inter1_prev, int frame2_prev, float inter2_prev, const ModelAnimFramePrecalculatedIQM* precalculated, const TArray<TRS>* animationData);
 	const TArray<VSMatrix>* CalculateBonesIQM(int frame1, int frame2, float inter, int frame1_prev, float inter1_prev, int frame2_prev, float inter2_prev, const ModelAnimFramePrecalculatedIQM* precalculated, const TArray<TRS>* animationData, TArray<BoneOverride> *in, BoneInfo *out, double time);

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -579,6 +579,15 @@ const TArray<VSMatrix> * ProcessModelFrame(FModel * animation, bool nextFrame, i
 				out,
 				tic);
 		}
+		else
+		{
+			boneData = animation->CalculateBonesOnlyOffsets(
+				modelData->modelBoneOverrides.SSize() > i
+				? &modelData->modelBoneOverrides[i]
+				: nullptr,
+				out,
+				tic);
+		}
 	}
 	else
 	{
@@ -622,7 +631,7 @@ static inline void RenderModelFrame(FModelRenderer *renderer, int i, const FSpri
 		{
 			if(!boneData && is_decoupled)
 			{
-				boneData = mdl->CalculateBonesOnlyOffsets((modelData && modelData->modelBoneOverrides.SSize() > i)? &modelData->modelBoneOverrides[i] : nullptr, tic);
+				boneData = mdl->CalculateBonesOnlyOffsets((modelData && modelData->modelBoneOverrides.SSize() > i)? &modelData->modelBoneOverrides[i] : nullptr, nullptr, tic);
 			}
 
 			boneStartingPosition = boneData ? screen->mBones->UploadBones(*boneData) : -1;


### PR DESCRIPTION
this was missing from https://github.com/UZDoom/UZDoom/commit/8b8623903f506fc8101d0f2695df38fa0998f09e (part of https://github.com/UZDoom/UZDoom/pull/658)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
