### PR TITLE
code in "_dbg_common.h" removed duplicate macro definitions UNDNAME_NO_…

### DIFF
--- a/bin/windows/vpx/src/_dbg_common.h
+++ b/bin/windows/vpx/src/_dbg_common.h
@@ -160,9 +160,6 @@ extern "C" {
 #define UNDNAME_NAME_ONLY (0x1000)
 #define UNDNAME_NO_ARGUMENTS (0x2000)
 #define UNDNAME_NO_SPECIAL_SYMS (0x4000)
-
-#define UNDNAME_NO_ARGUMENTS (0x2000)
-#define UNDNAME_NO_SPECIAL_SYMS (0x4000)
 #endif
 
   DWORD IMAGEAPI WINAPI UnDecorateSymbolName(PCSTR DecoratedName,PSTR UnDecoratedName,DWORD UndecoratedLength,DWORD Flags);


### PR DESCRIPTION
\UZDoom\bin\windows\vpx\src\_dbg_common.h presents a file that has duplicate macro definitions affecting redundancy and clean-up. Macros duplicated that were removed and kept:

- [x] UNDNAME_NO_ARGUMENTS
- [x] UNDNAME_NO_SPECIAL_SYMS

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
