### PR TITLE
add missing nullcheck to ProcessModelFrame

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -573,7 +573,7 @@ const TArray<VSMatrix> * ProcessModelFrame(FModel * animation, bool nextFrame, i
 				frameinfo.decoupled_frame,
 				frameinfo.inter,
 				animationData,
-				modelData->modelBoneOverrides.SSize() > i
+				(modelData && modelData->modelBoneOverrides.SSize() > i)
 				? &modelData->modelBoneOverrides[i]
 				: nullptr,
 				out,
@@ -582,7 +582,7 @@ const TArray<VSMatrix> * ProcessModelFrame(FModel * animation, bool nextFrame, i
 		else
 		{
 			boneData = animation->CalculateBonesOnlyOffsets(
-				modelData->modelBoneOverrides.SSize() > i
+				(modelData && modelData->modelBoneOverrides.SSize() > i)
 				? &modelData->modelBoneOverrides[i]
 				: nullptr,
 				out,


### PR DESCRIPTION
this would crash if a decoupled model tried to render with no actual frame data present

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
