### PR TITLE
Show error pane widget on Linux

### DIFF
--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -60,7 +60,22 @@ void Mac_I_FatalError(const char* errortext);
 
 #ifdef __linux__
 void Linux_I_FatalError(const char* errortext);
+
+static void Linux_I_TryRestart(char **argv)
+{
+	int self_file = open("/proc/self/exe", O_RDONLY);
+	fexecve(self_file, argv, environ);
+}
 #endif
+
+static void I_TryRestart(char **argv)
+{
+	// TODO: Mac support
+
+#ifdef __linux__
+	Linux_I_TryRestart(argv);
+#endif
+}
 
 bool SDL_I_CheckForRestart(void);
 
@@ -203,8 +218,7 @@ int main (int argc, char **argv)
 
 	if (SDL_I_CheckForRestart())
 	{
-		int self_file = open("/proc/self/exe", O_RDONLY);
-		fexecve(self_file, argv, environ);
+		I_TryRestart(argv);
 	}
 
 	SDL_Quit();

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -26,10 +26,12 @@
 
 #include <SDL2/SDL.h>
 #include <csignal>
+#include <fcntl.h>
 #include <locale.h>
 #include <new>
 #include <signal.h>
 #include <sys/param.h>
+#include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -59,6 +61,8 @@ void Mac_I_FatalError(const char* errortext);
 #ifdef __linux__
 void Linux_I_FatalError(const char* errortext);
 #endif
+
+bool SDL_I_CheckForRestart(void);
 
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 int GameMain();
@@ -196,6 +200,12 @@ int main (int argc, char **argv)
 	I_StartupJoysticks();
 
 	const int result = GameMain();
+
+	if (SDL_I_CheckForRestart())
+	{
+		int self_file = open("/proc/self/exe", O_RDONLY);
+		fexecve(self_file, argv, environ);
+	}
 
 	SDL_Quit();
 

--- a/src/common/platform/posix/sdl/i_system.cpp
+++ b/src/common/platform/posix/sdl/i_system.cpp
@@ -22,17 +22,17 @@
 **
 */
 
+#include <SDL2/SDL.h>
+
 #include <dirent.h>
+#include <fcntl.h>
 #include <fnmatch.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-#include <fcntl.h>
-#include <stdarg.h>
 #include <sys/ioctl.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -46,21 +46,15 @@
 #include <termios.h>
 #endif
 
-#include <SDL2/SDL.h>
-
 #include "c_cvars.h"
-#include "cmdlib.h"
 #include "i_interface.h"
-#include "i_sound.h"
-#include "widgets/launcherwindow.h"
-#include "m_argv.h"
 #include "palutil.h"
 #include "printf.h"
 #include "st_start.h"
 #include "v_font.h"
-#include "version.h"
 #include "vm.h"
-#include "common/widgets/errorwindow.h"
+#include "widgets/errorwindow.h"
+#include "widgets/launcherwindow.h"
 
 #if defined(__APPLE__)
 int I_PickIWad_Cocoa (WadStuff *wads, int numwads, bool showwin, int defaultiwad);


### PR DESCRIPTION
Partially addresses #900, is related to #260

<img width="1363" height="898" alt="image" src="https://github.com/user-attachments/assets/19296fa7-0f3f-49fb-8f44-db54b5146bf6" />

Allows the error pane widget to appear on Linux. The Copy Clipboard and Restart buttons should function completely.

#957 had a clear path to refactoring to make its widget happen on all systems. However, the flow for showing errors is very specialized, even if it might be possible to reconcile. I've made the call to do purely as a Linux-only change since it's what I can test, and I don't want to make guesses for Mac.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
