### PR TITLE
Message Queue and Stacking

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -260,3 +260,4 @@ Eric Womer
 RichardDS90
 Frank Kloster
 Santtu "MFG38" Pesonen
+heiko123abc

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -69,6 +69,7 @@ CVAR (Bool, sv_unlimited_pickup, false, CVAR_SERVERINFO)
 CVAR (Int, cl_blockcheats, 0, 0)
 
 CVARD(Bool, show_messages, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "enable/disable showing messages")
+CVAR(Bool, con_stackident, true, CVAR_ARCHIVE)
 CVAR(Bool, show_obituaries, true, CVAR_ARCHIVE)
 
 

--- a/src/menu/doommenu.cpp
+++ b/src/menu/doommenu.cpp
@@ -55,6 +55,7 @@ EXTERN_CVAR(Bool, m_quickexit)
 EXTERN_CVAR(Bool, saveloadconfirmation) // [mxd]
 EXTERN_CVAR(Bool, quicksaverotation)
 EXTERN_CVAR(Bool, show_messages)
+EXTERN_CVAR(Bool, con_stackident)
 EXTERN_CVAR(Bool, haptics_do_menus)
 EXTERN_CVAR(Float, hud_scalefactor)
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1657,6 +1657,8 @@ OptionMenu MessageOptions protected
 {
 	Title 	"$MSGMNU_TITLE"
 	Option "$MSGMNU_SHOWMESSAGES",				"show_messages", "OnOff"
+	Slider "$MSGMNU_MESSAGEQUEUE",				"con_notifylines", 1, 10, 1,0
+	Option "$MSGMNU_STACKIDENTICAL",			"con_stackident", "OnOff"
 	Option "$MSGMNU_SHOWOBITUARIES",			"show_obituaries", "OnOff"
 	Option "$MSGMNU_SHOWSECRETS",				"cl_showsecretmessage", "OnOff"
 	Option "$MSGMNU_MESSAGELEVEL", 				"msg", "MessageLevels"


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Fixes #962.

I have added 2 new features in the message menu to adress the named problems. Now one can customize how many messages show up and if they should stack with e.g (x3)

Before 
<img width="1147" height="576" alt="grafik" src="https://github.com/user-attachments/assets/aed5f8dd-3bd8-490c-8c50-aaefef484de5" />

After

<img width="568" height="210" alt="grafik" src="https://github.com/user-attachments/assets/6130e7e0-b5e9-43f5-b21c-5cd11f80f4f0" />

Options

<img width="1436" height="411" alt="grafik" src="https://github.com/user-attachments/assets/d942c3f6-4b48-47f1-bf50-e6a689036019" />
