### PR TITLE
Added file verification for net games

### DIFF
--- a/src/common/engine/i_net.cpp
+++ b/src/common/engine/i_net.cpp
@@ -655,7 +655,7 @@ static void SendVerificationError(const sockaddr_in& to, const FVerificationErro
 		NetBuffer[5] = (ar->Size() >> 8);
 		NetBuffer[6] = ar->Size();
 		size_t i = 7u;
-		for (const auto& file : *ar)
+		for (auto& file : *ar)
 		{
 			memcpy(&NetBuffer[i], file.GetChars(), file.Len() + 1u);
 			i += file.Len() + 1u;
@@ -1038,7 +1038,10 @@ static FString ReadVerificationError(TArrayView<uint8_t> stream)
 		if (!fileSystem.IsOptionalResource(i))
 		{
 			const FString crc = fileSystem.GetResourceHash(i);
-			files[crc] = fileSystem.GetResourceFileName(i);
+			FString name = fileSystem.GetResourceFileName(i);
+			FixPathSeperator(name);
+			auto a = name.Split('/', FString::TOK_SKIPEMPTY);
+			files[crc] = a.Last();
 		}
 	}
 

--- a/src/common/engine/i_net.h
+++ b/src/common/engine/i_net.h
@@ -64,6 +64,26 @@ enum ENetFlags
 	NCMD_LATENCY = 0x01,		// Latency packet, used for measuring RTT.		
 };
 
+struct FVerificationError
+{
+	enum EVerifyError : uint8_t
+	{
+		VE_NONE,
+		VE_ENGINE,
+		VE_FILE_UNKNOWN,
+		VE_FILE_MISSING,
+		VE_FILE_ORDER,
+	};
+
+	EVerifyError Error = VE_NONE;
+	uint8_t Major = 0u, Minor = 0u, Revision = 0u;
+	uint8_t NetMajor = 0u, NetMinor = 0u, NetRevision = 0u;
+	TArray<FString> UnknownFiles = {};
+	TArray<FString> ExpectedOrder = {};
+	// Since the guest didn't load these, we have no checksum to fetch the proper name, so send over our own.
+	TArray<FString> MissingFiles = {};
+};
+
 struct FClientStack : public TArray<int>
 {
 	inline bool InGame(int i) const { return Find(i) < Size(); }

--- a/src/common/filesystem/include/fs_filesystem.h
+++ b/src/common/filesystem/include/fs_filesystem.h
@@ -58,8 +58,8 @@ public:
 	void SetMaxIwadNum(int x) { MaxIwadIndex = x; }
 
 	bool InitSingleFile(const char *filename, FileSystemMessageFunc Printf = nullptr);
-	bool InitMultipleFiles (std::vector<std::string>& filenames, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, bool allowduplicates = false);
-	void AddFile (const char *filename, FileReader *wadinfo, LumpFilterInfo* filter, FileSystemMessageFunc Printf);
+	bool InitMultipleFiles (std::vector<std::string>& filenames, std::vector<std::string>& optfilenames, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, bool allowduplicates = false);
+	void AddFile (const char *filename, FileReader *wadinfo, LumpFilterInfo* filter, FileSystemMessageFunc Printf, bool optional);
 	int CheckIfResourceFileLoaded (const char *name) noexcept;
 	void AddAdditionalFile(const char* filename, FileReader* wadinfo = NULL) {}
 
@@ -146,6 +146,7 @@ public:
 	void SetFileNamespace(int lump, int ns);
 	int GetResourceId(int lump) const;				// Returns the RFF index number for this lump
 	const char* GetResourceType(int lump) const;
+	const char* GetResourceHash(int wadNum) const;
 	bool CheckFileName (int lump, const char *name) const;	// [RH] Returns true if the names match
 	unsigned GetFilesInFolder(const char *path, std::vector<FolderEntry> &result, bool atomic) const;
 
@@ -157,6 +158,11 @@ public:
 	int GetNumWads() const
 	{
 		return (int)Files.size();
+	}
+
+	bool IsOptionalResource(int wadnum) const
+	{
+		return wadnum >= 0 && wadnum < (int)Files.size() ? Files[wadnum]->IsOptional() : true;
 	}
 
 	int AddFromBuffer(const char* name, char* data, int size, int id, int flags);

--- a/src/common/filesystem/include/resourcefile.h
+++ b/src/common/filesystem/include/resourcefile.h
@@ -149,6 +149,7 @@ protected:
 	char Hash[48];
 	bool HashGenerated;
 	StringPool* stringpool;
+	bool bOptional;
 
 	// for archives that can contain directories
 	virtual void SetEntryAddress(uint32_t entry)
@@ -165,12 +166,13 @@ private:
 	bool FindPrefixRange(const char* filter, uint32_t max, uint32_t &start, uint32_t &end);
 	void JunkLeftoverFilters(uint32_t max);
 	void FindCommonFolder(LumpFilterInfo* filter);
-	static FResourceFile *DoOpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp);
+	void SetOptional(bool optional) { bOptional = optional; }
+	static FResourceFile *DoOpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp, bool optional);
 
 public:
-	static FResourceFile *OpenResourceFile(const char *filename, FileReader &file, bool containeronly = false, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr);
-	static FResourceFile *OpenResourceFile(const char *filename, bool containeronly = false, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr);
-	static FResourceFile *OpenDirectory(const char *filename, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr);
+	static FResourceFile *OpenResourceFile(const char *filename, FileReader &file, bool containeronly = false, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr, bool optional = false);
+	static FResourceFile *OpenResourceFile(const char *filename, bool containeronly = false, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr, bool optional = false);
+	static FResourceFile *OpenDirectory(const char *filename, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, StringPool* sp = nullptr, bool optional = false);
 	virtual ~FResourceFile();
 	// If this FResourceFile represents a directory, the Reader object is not usable so don't return it.
 	FileReader *GetContainerReader() { return Reader.isOpen()? &Reader : nullptr; }
@@ -227,6 +229,8 @@ public:
 	virtual FileData Read(uint32_t entry);
 
 	virtual FCompressedBuffer GetRawData(uint32_t entry);
+
+	bool IsOptional() const { return bOptional; }
 
 	FileReader Destroy()
 	{

--- a/src/common/filesystem/source/files.cpp
+++ b/src/common/filesystem/source/files.cpp
@@ -28,6 +28,8 @@
 #include <assert.h>
 #include <string.h>
 #include "files_internal.h"
+#include "m_crc32.h"
+#include "engineerrors.h"
 
 namespace FileSys {
 	

--- a/src/common/filesystem/source/resourcefile.cpp
+++ b/src/common/filesystem/source/resourcefile.cpp
@@ -147,7 +147,7 @@ static int nulPrintf(FSMessageLevel msg, const char* fmt, ...)
 	return 0;
 }
 
-FResourceFile *FResourceFile::DoOpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp)
+FResourceFile *FResourceFile::DoOpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp, bool optional)
 {
 	if (!file.isOpen()) return nullptr;
 	if (Printf == nullptr) Printf = nulPrintf;
@@ -155,28 +155,35 @@ FResourceFile *FResourceFile::DoOpenResourceFile(const char *filename, FileReade
 	{
 		if (containeronly && func == CheckLump) break;
 		FResourceFile *resfile = func(filename, file, filter, Printf, sp);
-		if (resfile != NULL) return resfile;
+		if (resfile != NULL)
+		{
+			resfile->SetOptional(optional);
+			return resfile;
+		}
 	}
 	return NULL;
 }
 
-FResourceFile *FResourceFile::OpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp)
+FResourceFile *FResourceFile::OpenResourceFile(const char *filename, FileReader &file, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp, bool optional)
 {
-	return DoOpenResourceFile(filename, file, containeronly, filter, Printf, sp);
+	return DoOpenResourceFile(filename, file, containeronly, filter, Printf, sp, optional);
 }
 
 
-FResourceFile *FResourceFile::OpenResourceFile(const char *filename, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp)
+FResourceFile *FResourceFile::OpenResourceFile(const char *filename, bool containeronly, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp, bool optional)
 {
 	FileReader file;
 	if (!file.OpenFile(filename)) return nullptr;
-	return DoOpenResourceFile(filename, file, containeronly, filter, Printf, sp);
+	return DoOpenResourceFile(filename, file, containeronly, filter, Printf, sp, optional);
 }
 
-FResourceFile *FResourceFile::OpenDirectory(const char *filename, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp)
+FResourceFile *FResourceFile::OpenDirectory(const char *filename, LumpFilterInfo* filter, FileSystemMessageFunc Printf, StringPool* sp, bool optional)
 {
 	if (Printf == nullptr) Printf = nulPrintf;
-	return CheckDir(filename, false, filter, Printf, sp);
+	auto resFile = CheckDir(filename, false, filter, Printf, sp);
+	if (resFile != nullptr)
+		resFile->SetOptional(optional);
+	return resFile;
 }
 
 //==========================================================================

--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -52,7 +52,7 @@ static constexpr char PATH_SEPARATOR = ':';
 //
 //==========================================================================
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional)
+bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config)
 {
 	if (file == nullptr || *file == '\0')
 	{
@@ -140,7 +140,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 
 	if (wadfile != nullptr)
 	{
-		D_AddFile(wadfiles, wadfile, true, -1, config, optional);
+		D_AddFile(wadfiles, wadfile, true, -1, config);
 		return;
 	}
 
@@ -155,7 +155,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 	{
 		for(auto& entry : list)
 		{
-			D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
+			D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
 			found = true;
 		}
 	}
@@ -211,7 +211,7 @@ void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, c
 //
 //==========================================================================
 
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional)
+void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config)
 {
 	FileSys::FileList list;
 	if (FileSys::ScanDirectory(list, dir, "*.wad", true))
@@ -220,7 +220,7 @@ void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const c
 		{
 			if (!entry.isDirectory)
 			{
-				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
+				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
 			}
 		}
 	}

--- a/src/common/utility/findfile.h
+++ b/src/common/utility/findfile.h
@@ -42,9 +42,9 @@ enum EFileRequirements
     REQUIRE_ALL = REQUIRE_IWAD|REQUIRE_FILE|REQUIRE_OPTFILE
 };
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional = false);
+bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config);
 void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional = false);
 void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile* config, bool optional = false);
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional = false);
+void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config);
 const char* BaseFileSearch(const char* file, const char* ext, bool lookfirstinprogdir, FConfigFile* config);
 void D_FileNotFound(EFileRequirements test, const char* type, const char* file);

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -142,7 +142,7 @@ class FIWadManager
 	void ParseIWadInfo(const char *fn, const char *data, int datasize, FIWADInfo *result = nullptr);
 	int ScanIWAD (const char *iwad);
 	int CheckIWADInfo(const char *iwad);
-	int IdentifyVersion (std::vector<std::string>& wadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad);
+	int IdentifyVersion (std::vector<std::string>& wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad);
 	void CollectSearchPaths();
 	void AddIWADCandidates(const char *dir, bool nosubdir = true);
 	void ValidateIWADs();
@@ -150,7 +150,7 @@ class FIWadManager
 public:
 
 	FIWadManager(const char *fn, const char *fnopt);
-	const FIWADInfo *FindIWAD(std::vector<std::string>& wadfiles, const char *iwad, const char *basewad, const char *optionalwad);
+	const FIWADInfo *FindIWAD(std::vector<std::string>& wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *basewad, const char *optionalwad);
 	const FString *GetAutoname(unsigned int num) const
 	{
 		if (num < mIWadInfos.Size()) return &mIWadInfos[num].Autoname;

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -1847,7 +1847,11 @@ FVerificationError Net_VerifyEngine(uint8_t*& stream, size_t& offset)
 	if (error.Error == FVerificationError::VE_FILE_MISSING)
 	{
 		for (auto i : unverified)
-			error.MissingFiles.Push(names[i]);
+		{
+			FixPathSeperator(names[i]);
+			auto ar = names[i].Split('/', FString::TOK_SKIPEMPTY);
+			error.MissingFiles.Push(ar.Last());
+		}
 	}
 	else if (error.Error == FVerificationError::VE_FILE_ORDER)
 	{


### PR DESCRIPTION
This will account for missing files, added files, file order, and mismatched hashes on top of the engine version. Files loaded via `-optfile` are ignored entirely. This also hooks the idea of optional resources up to the engine, marking them as appropriate.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
