### PR TITLE
Remove fatal error in InitWidgetResources

### DIFF
--- a/src/widgets/widgetresourcedata.cpp
+++ b/src/widgets/widgetresourcedata.cpp
@@ -43,15 +43,16 @@ void InitWidgetResources(const char* filename)
 {
 	WidgetResources = new TDeletingArray<FResourceFile*>();
 
-	auto open = [=](const char* filename)
+	auto open = [=](const char* filename, bool required = false)
 	{
 		auto file = FResourceFile::OpenResourceFile(filename);
-		if (!file)
+		if (file)
+			WidgetResources->Push(file);
+		else if (required)
 			I_FatalError("Unable to open %s", filename);
-		WidgetResources->Push(file);
 	};
 
-	open(filename);
+	open(filename, true);
 
 	FString *args;
 	int argc = Args->CheckParmList(FArg_file, &args);


### PR DESCRIPTION
Widget file loading shouldn't fatal error, because
- It prevents `i_exit_on_not_found` from doing its job (someone with lax settings won't be respected)
- We can't show the error pane without having ZWidget initialized

Technically that second point is still an issue for the engine pk3, but I didn't feel comfortable removing the error entirely for it; it's good that it's trying to report that as early as possible. I'm thinking that we should use `IsZWidgetAvailable` to prevent error panes from appearing if we don't have ZWidget, but I wasn't sure what the best way to do this would be. I'm also not sure if the game throws any other proper warning if the engine pk3 is missing, so that's another reason I didn't want to out right remove it yet

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
