### PR TITLE
Generate hash when loading a lump as a file

### DIFF
--- a/src/common/filesystem/source/file_lump.cpp
+++ b/src/common/filesystem/source/file_lump.cpp
@@ -40,6 +40,7 @@ static bool OpenLump(FResourceFile* file, LumpFilterInfo*)
 	Entries[0].CompressedSize = Entries[0].Length = file->GetContainerReader()->GetLength();
 	Entries[0].Method = METHOD_STORED;
 	Entries[0].Flags = 0;
+	file->GenerateHash();
 	return true;
 }
 


### PR DESCRIPTION
Loading a single lump (ex: `-file zscript.txt`) does not generate a hash for it, causing debug builds to throw an assert designed to catch uninitialized memory that was added in #715. This is a simple patch to fix this.

I noticed it while testing #990, but this should apply to all systems.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
