### PR TITLE
Marked cvars from optional files as nosave

### DIFF
--- a/src/common/filesystem/include/fs_filesystem.h
+++ b/src/common/filesystem/include/fs_filesystem.h
@@ -162,8 +162,9 @@ public:
 
 	bool IsOptionalResource(int wadnum) const
 	{
-		return wadnum >= 0 && wadnum < (int)Files.size() ? Files[wadnum]->IsOptional() : true;
+		return (size_t)wadnum < Files.size() ? Files[wadnum]->IsOptional() : true;
 	}
+	bool IsOptionalLump(int lump) const;
 
 	int AddFromBuffer(const char* name, char* data, int size, int id, int flags);
 	FileReader* GetFileReader(int wadnum);	// Gets a FileReader object to the entire WAD

--- a/src/common/filesystem/source/filesystem.cpp
+++ b/src/common/filesystem/source/filesystem.cpp
@@ -1187,6 +1187,17 @@ const char* FileSystem::GetResourceHash(int wadNum) const
 
 //==========================================================================
 //
+// IsOptionalLump
+//
+//==========================================================================
+
+bool FileSystem::IsOptionalLump(int lump) const
+{
+	return (size_t)lump < NumEntries ? FileInfo[lump].resfile->IsOptional() : true;
+}
+
+//==========================================================================
+//
 // GetFileContainer
 //
 //==========================================================================

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1879,6 +1879,12 @@ void ParseCVarInfo()
 				cvarflags &= ~CVAR_SERVERINFO;
 				cvarflags &= ~CVAR_USERINFO;
 			}
+			else if (fileSystem.IsOptionalLump(lump))
+			{
+				// For optional files, never network out their values or save them.
+				cvarflags &= ~(CVAR_SERVERINFO | CVAR_USERINFO);
+				cvarflags |= CVAR_CONFIG_ONLY;
+			}
 
 			// Do some sanity checks.
 			// No need to check server-nosave and user-nosave combinations because they


### PR DESCRIPTION
These should never be networked out nor saved as neither of these will work correctly, especially on the initial handshake. While this isn't memory unsafe, the way the handshake works allows users to mess with cvars on other clients in unintentional ways, especially server cvars (the previous file verification PR already fixes this for non-optional files).

Ideally in the future this will be handled more elegantly.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
