### PR TITLE
Fixed a few issues with missiles

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -8040,6 +8040,9 @@ AActor *P_SpawnPlayerMissile (AActor *source, double x, double y, double z,
 							  PClassActor *type, DAngle angle, FTranslatedLineTarget *pLineTarget, AActor **pMissileActor,
 							  bool nofreeaim, bool noautoaim, int aimflags)
 {
+	if (pMissileActor != nullptr)
+		*pMissileActor = nullptr;
+
 	if (source == nullptr || type == nullptr)
 	{
 		return nullptr;

--- a/wadsrc/static/zscript/actors/heretic/weaponskullrod.zs
+++ b/wadsrc/static/zscript/actors/heretic/weaponskullrod.zs
@@ -359,7 +359,7 @@ class HornRodFX2 : Actor
 		double newz = mo.CurSector.NextHighestCeilingAt(mo.pos.x, mo.pos.y, mo.pos.z, mo.pos.z, FFCF_NOPORTALS) - mo.height;
 		mo.SetZ(newz);
 
-		if (multiplayer && target.player)
+		if (multiplayer && target && target.player)
 		{
 			mo.A_SetTranslation(translations[target.PlayerNumber()]);
 		}


### PR DESCRIPTION
Make sure one of the returned arguments is always nulled first. Don't crash in Heretic if the owner of a tomed up skullrod projectile leaves the game.

Note that there are other issues with the missile spawning functions, but I'm not sure what the full impact of fixing those will be, so I think it's best to wait for the next dev cycle to fix them.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
