### PR TITLE
Added check for client-side Objects when predicting

### DIFF
--- a/src/common/objects/dobject.cpp
+++ b/src/common/objects/dobject.cpp
@@ -784,7 +784,7 @@ void NetworkEntityManager::VerifyPredictedEntities()
 {
 	for (auto e : s_problemEntities)
 	{
-		if (e->ObjectFlags & (OF_EuthanizeMe | OF_Sentinel))
+		if (e->ObjectFlags & (OF_EuthanizeMe | OF_Sentinel | OF_ClientSide))
 			continue;
 
 		DPrintf(DMSG_WARNING, TEXTCOLOR_RED "Spawned non-client-side Object %s while predicting\n", e->GetClass()->TypeName.GetChars());


### PR DESCRIPTION
These can get into the list if the Object is marked after being created e.g. client-side Thinkers.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
