### PR TITLE
Allow restart button to work on AppImage

### DIFF
--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -63,6 +63,16 @@ void Linux_I_FatalError(const char* errortext);
 
 static void Linux_I_TryRestart(char **argv)
 {
+	// TODO: Check how Flatpak interacts with this, too
+
+	const char *appimage = getenv("APPIMAGE");
+	if (appimage)
+	{
+		int appimage_file = open(appimage, O_RDONLY);
+		fexecve(appimage_file, argv, environ);
+		return;
+	}
+
 	int self_file = open("/proc/self/exe", O_RDONLY);
 	fexecve(self_file, argv, environ);
 }


### PR DESCRIPTION
The `/proc/self/exe` file descriptor doesn't work for the AppImage, so we need to use the `APPIMAGE` environment variable instead: https://docs.appimage.org/packaging-guide/environment-variables.html

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
