### PR TITLE
fix formatting warnings in dap library

### DIFF
--- a/src/common/scripting/dap/DebugExecutionManager.cpp
+++ b/src/common/scripting/dap/DebugExecutionManager.cpp
@@ -269,7 +269,7 @@ void DebugExecutionManager::HandleException(EVMAbortException reason, const std:
 			event.text = message;
 		}
 		event.reason = "exception";
-		event.description = "Paused on exception: " + (reason < exceptionStringsSize ? std::string(exceptionStrings[(int)reason]) : "Unknown");
+		event.description = "Paused on exception: " + (((size_t)reason < exceptionStringsSize) ? std::string(exceptionStrings[(int)reason]) : "Unknown");
 		event.threadId = 1;
 		m_session->send(event);
 	};

--- a/src/common/scripting/dap/Nodes/ArrayStateNode.cpp
+++ b/src/common/scripting/dap/Nodes/ArrayStateNode.cpp
@@ -58,14 +58,14 @@ static int64_t GetElementCount(const VMValue &value, PType *p_type)
 	{
 		type = type->toPointer()->PointedType;
 	}
-	
+
 	if (type->isDynArray() || type->isStaticArray())
 	{
 		if (!IsVMValueValid(&value))
 		{
 			return 0;
 		}
-		
+
 		// FArray has the same layout as TArray, just return count
 		auto *arr = static_cast<FArray *>(array_head);
 		if (arr->Count == UINT_MAX)
@@ -82,7 +82,7 @@ static int64_t GetElementCount(const VMValue &value, PType *p_type)
 		}
 		return static_cast<PArray *>(type)->ElementCount;
 	}
-	else 
+	else
 	return 0;
 }
 
@@ -119,7 +119,7 @@ bool ArrayStateNode::SerializeToProtocol(dap::Variable &variable)
 	}
 	else
 	{
-		variable.value = StringFormat("%s[%ld]", elementTypeName.c_str(), static_cast<int64_t>(variable.indexedVariables.value(0)));
+		variable.value = StringFormat("%s[%lld]", elementTypeName.c_str(), static_cast<int64_t>(variable.indexedVariables.value(0)));
 		if (m_type->toPointer())
 		{
 			variable.value += StringFormat(" (%p)", m_value.a);
@@ -184,7 +184,7 @@ bool ArrayStateNode::GetChildNode(std::string name, std::shared_ptr<StateNodeBas
 		type = static_cast<PPointer *>(m_type)->PointedType;
 		// array_head = *static_cast<void **>(m_value.a);
 	}
-	
+
 	if (type->isDynArray() || type->isStaticArray())
 	{
 		auto elementType = GetElementType(m_type);

--- a/src/common/scripting/dap/Nodes/StackStateNode.cpp
+++ b/src/common/scripting/dap/Nodes/StackStateNode.cpp
@@ -40,13 +40,13 @@ bool StackStateNode::SerializeToProtocol(dap::Thread &thread) const
 
 	if (frames.empty())
 	{
-		thread.name = StringFormat("(%ld)",  static_cast<int64_t>(thread.id));
+		thread.name = StringFormat("(%lld)",  static_cast<int64_t>(thread.id));
 	}
 	else
 	{
 		const auto frame = frames.back();
 		const auto name = frame->Func ? frame->Func->PrintableName : "<unknown>";
-		thread.name = StringFormat("%s (%ld)", name, static_cast<int64_t>(thread.id));
+		thread.name = StringFormat("%s (%lld)", name, static_cast<int64_t>(thread.id));
 	}
 
 	return true;

--- a/src/common/scripting/dap/Nodes/ValueStateNode.cpp
+++ b/src/common/scripting/dap/Nodes/ValueStateNode.cpp
@@ -143,9 +143,9 @@ dap::Variable ValueStateNode::ToVariable(const VMValue &m_variable, PType *m_typ
 	{ // explicitly not TYPE_IntNotInt
 		int64_t val = TruncateVMValue(&m_variable, basic_type).i;
 		if (basic_type == BASIC_uint32 || basic_type == BASIC_uint16 || basic_type == BASIC_uint8){
-			variable.value = StringFormat("%lu", val);
+			variable.value = StringFormat("%llu", static_cast<uint64_t>(val));
 		} else {
-			variable.value = StringFormat("%ld", val);
+			variable.value = StringFormat("%lld", val);
 		}
 	}
 	else if (m_type->isFloat())

--- a/src/common/scripting/dap/ZScriptDebugger.cpp
+++ b/src/common/scripting/dap/ZScriptDebugger.cpp
@@ -465,7 +465,7 @@ dap::ResponseOrError<dap::ScopesResponse> ZScriptDebugger::GetScopes(const dap::
 	std::vector<std::shared_ptr<StateNodeBase>> frameScopes;
 	if (request.frameId < 0)
 	{
-		RETURN_DAP_ERROR(StringFormat("Invalid frameId %ld", static_cast<int64_t>(request.frameId)).c_str());
+		RETURN_DAP_ERROR(StringFormat("Invalid frameId %lld", static_cast<int64_t>(request.frameId)).c_str());
 	}
 	auto frameId = static_cast<uint32_t>(request.frameId);
 	if (!m_runtimeState->ResolveChildrenByParentId(frameId, frameScopes))
@@ -504,8 +504,9 @@ dap::ResponseOrError<dap::VariablesResponse> ZScriptDebugger::GetVariables(const
 
 	if (!m_runtimeState->ResolveChildrenByParentId(static_cast<uint32_t>(request.variablesReference), variableNodes, start, maxCount))
 	{
+
 		// Don't log, this happens as a result of a variables request being sent after a step request that invalidates the state
-		return dap::Error(StringFormat("No such variablesReference %ld", static_cast<int64_t>(request.variablesReference)).c_str());
+		return dap::Error(StringFormat("No such variablesReference %lld", static_cast<int64_t>(request.variablesReference)).c_str());
 	}
 	bool only_indexed = request.filter.value("") == "indexed";
 	bool only_named = request.filter.value("") == "named";
@@ -662,11 +663,11 @@ dap::ResponseOrError<dap::EvaluateResponse> ZScriptDebugger::Evaluate(const dap:
 		if( m_runtimeState->ResolveStateById(frameId, _frameNode)){
 			auto frameNode = std::dynamic_pointer_cast<StackFrameStateNode>(_frameNode);
 			if (!frameNode){
-				RETURN_DAP_ERROR(StringFormat("Could not find frameId %ld", frameId).c_str());
+				RETURN_DAP_ERROR(StringFormat("Could not find frameId %lld", frameId).c_str());
 			}
 			auto frameNodePath = m_runtimeState->GetPathById(frameNode->GetId());
 			if(frameNodePath.empty()){
-				RETURN_DAP_ERROR(StringFormat("Could not find frameId %ld", frameId).c_str());
+				RETURN_DAP_ERROR(StringFormat("Could not find frameId %lld", frameId).c_str());
 			}
 			// try locals first
 			std::string localsPath = StringFormat("%s.%s", frameNodePath.c_str(), StackFrameStateNode::LOCAL_SCOPE_NAME);
@@ -695,7 +696,7 @@ dap::ResponseOrError<dap::EvaluateResponse> ZScriptDebugger::Evaluate(const dap:
 			if (localScope){
 				localScope->GetChildNames(localChildrenNames);
 				caseless_path_set localChildrenNamesSet(localChildrenNames.begin(), localChildrenNames.end());
-				
+
 				path = StringFormat("%s.%s", localsPath.c_str(), request.expression.c_str());
 				if(!TryPath(path)){
 					RETURN_DAP_ERROR(StringFormat("Could not serialize variable %s", request.expression.c_str()).c_str());
@@ -789,7 +790,7 @@ dap::ResponseOrError<dap::EvaluateResponse> ZScriptDebugger::Evaluate(const dap:
 		// try a c_var?
 		auto cvar = FindConsoleVariable(cmdstr);
 		if (cvar){
-			
+
 			if (args.size() > 1){
 				if (cmdstr == "vm_debug" || cmdstr == "vm_debug_port"){
 					return dap::Error(StringFormat("Refusing change %s while debugging!", cmdstr.c_str()).c_str());
@@ -814,7 +815,7 @@ dap::ResponseOrError<dap::EvaluateResponse> ZScriptDebugger::Evaluate(const dap:
 				response.indexedVariables = var.indexedVariables;
 				response.presentationHint = var.presentationHint;
 			}
-			
+
 			return response;
 		}
 		return dap::Error(StringFormat("Command %s not found!", request.expression.c_str()).c_str());


### PR DESCRIPTION
Fixes miscellaneous compiler warnings emitted because of incorrect format specifiers for integer vars.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

> Edit to re-trigger bot (again)