### PR TITLE
Reimplement cl_debugprediction

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2235,6 +2235,21 @@ void TryRunTics()
 			lowestSequence = ClientStates[client].CurrentSequence;
 	}
 
+	// Test player prediction code in singleplayer by pretending there is another player
+	// that is running exactly x ticks behind us, emulating having a specific amount of ping
+	if (cl_debugprediction > 0
+		&& !netgame && !demoplayback) // would probably function, but there's no reason to
+	{
+		if (lowestSequence > cl_debugprediction)
+		{
+			lowestSequence -= cl_debugprediction;
+		}
+		else
+		{
+			lowestSequence = 0;
+		}
+	}
+
 	// If the lowest confirmed tic matches the server gametic or greater, allow the client
 	// to run some of them.
 	const int availableTics = (lowestSequence - gametic / TicDup) + 1;
@@ -2247,18 +2262,6 @@ void TryRunTics()
 		CalculateNetStabilityBuffer(availableTics - totalTics);
 		if (totalTics < availableTics - StabilityBuffer)
 			++runTics;
-	}
-
-	// Test player prediction code in singleplayer
-	// by running the gametic behind the ClientTic
-	if (!netgame && !demoplayback && cl_debugprediction > 0)
-	{
-		int debugTarget = ClientTic - cl_debugprediction;
-		int debugOffset = gametic - debugTarget;
-		if (debugOffset > 0)
-		{
-			runTics = max<int>(runTics - debugOffset, 0);
-		}
 	}
 
 	const int worldTimer = primaryLevel->LocalWorldTimer;


### PR DESCRIPTION
It's intended to emulate having a consistent amount of delay from the server in order to feel prediction, but at some point it started having a strange low framerate effect. (I didn't notice exactly when it broke, but I've been meaning to fix it for a while.)

I made it arbitrarily nudge `lowestSequence` by a specific amount now. This is a better emulation of what actually happens when playing with delay. It also just makes more straight-forward sense than the old pacing hack.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
