### PR TITLE
Upload nightly builds using CI

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -171,11 +171,44 @@ jobs:
 
         fi
 
-    - name: Upload
+    - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         path: build/package
         name: ${{ inputs.name }} ${{ inputs.build_type }}
+
+    - name: Rename For Nightly
+      if: github.ref == 'refs/heads/trunk' && inputs.build_type == 'Release'
+      shell: bash
+      run: |
+        newname="${{ runner.os }}-UZDoom-Nightly"
+        if [[ "${{ inputs.name }}" == 'Linux GCC' ]]; then
+            newname="${{ runner.os }}-Legacy-UZDoom-Nightly"
+        fi
+        
+        cd build/package
+        if [[ "${{ runner.os }}" == 'Windows' || "${{ runner.os }}" == 'macOS' ]]; then
+            mv *.zip "${newname}.zip"
+        elif [[ "${{ runner.os }}" == 'Linux' ]]; then
+            mv *.AppImage "${newname}.AppImage"
+        fi
+
+    - name: Upload Nightly
+      uses: softprops/action-gh-release@v2
+      if: github.ref == 'refs/heads/trunk' && inputs.build_type == 'Release'
+      with:
+        name: UZDoom Nightly
+        tag_name: nightly
+        draft: false
+        prerelease: true
+        make_latest: false
+        body: |
+          # These are automatically generated development versions based on latest commit to trunk.
+          ## WARNING: Nightly builds may be unstable and have issues.
+          [Commit:](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          ${{ github.event.head_commit.message }}
+        generate_release_notes: false
+        files: build/package/**
 
     - name: List
       if: always()


### PR DESCRIPTION
Original PR: #415

This PR updates the CI to upload the compiled builds to a release. Release is rotating, meaning only the latest version will be available for download. The description is updated on every release and includes the commit hash with its hyperlink and the commit message. This is how it looks:
<img width="906" height="747" alt="image" src="https://github.com/user-attachments/assets/afacd3e7-5f5c-4738-b917-d69177374df3" />

Two things will need to be done by those who have permissions if this PR is to be merged:

- Create a tag named "nightly".
- Create a release named "UZDoom Nightly" and mark it as a pre-release.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.