### PR TITLE
Keep load order when loading optional files

### DIFF
--- a/src/common/console/c_dispatch.cpp
+++ b/src/common/console/c_dispatch.cpp
@@ -1010,11 +1010,11 @@ void FExecList::ExecCommands() const
 	}
 }
 
-void FExecList::AddPullins(std::vector<std::string>& wads, FConfigFile *config) const
+void FExecList::AddPullins(std::vector<FileSys::ResourceName>& wads, FConfigFile *config) const
 {
 	for (unsigned i = 0; i < Pullins.Size(); ++i)
 	{
-		D_AddFile(wads, Pullins[i].GetChars(), true, -1, config);
+		D_AddFile(wads, Pullins[i].GetChars(), true, -1, config, false);
 	}
 }
 

--- a/src/common/console/c_dispatch.h
+++ b/src/common/console/c_dispatch.h
@@ -33,6 +33,7 @@
 #include "tarray.h"
 #include "c_commandline.h"
 #include "zstring.h"
+#include "fs_filesystem.h"
 #include <array>
 
 class FConfigFile;
@@ -46,7 +47,7 @@ struct FExecList
 
 	void AddCommand(const char *cmd, const char *file = nullptr);
 	void ExecCommands() const;
-	void AddPullins(std::vector<std::string> &wads, FConfigFile *config) const;
+	void AddPullins(std::vector<FileSys::ResourceName> &wads, FConfigFile *config) const;
 };
 
 extern bool ParsingKeyConf, UnsafeExecutionContext;

--- a/src/common/filesystem/include/fs_filesystem.h
+++ b/src/common/filesystem/include/fs_filesystem.h
@@ -44,6 +44,13 @@ struct FolderEntry
 	unsigned lumpnum;
 };
 
+struct ResourceName
+{
+	std::string Name;
+	bool bOptional;
+	ResourceName(std::string& name, bool optional) : Name(name), bOptional(optional) {}
+};
+
 class FileSystem
 {
 public:
@@ -58,7 +65,7 @@ public:
 	void SetMaxIwadNum(int x) { MaxIwadIndex = x; }
 
 	bool InitSingleFile(const char *filename, FileSystemMessageFunc Printf = nullptr);
-	bool InitMultipleFiles (std::vector<std::string>& filenames, std::vector<std::string>& optfilenames, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, bool allowduplicates = false);
+	bool InitMultipleFiles (std::vector<ResourceName>& filenames, LumpFilterInfo* filter = nullptr, FileSystemMessageFunc Printf = nullptr, bool allowduplicates = false);
 	void AddFile (const char *filename, FileReader *wadinfo, LumpFilterInfo* filter, FileSystemMessageFunc Printf, bool optional);
 	int CheckIfResourceFileLoaded (const char *name) noexcept;
 	void AddAdditionalFile(const char* filename, FileReader* wadinfo = NULL) {}
@@ -162,7 +169,7 @@ public:
 
 	bool IsOptionalResource(int wadnum) const
 	{
-		return wadnum >= 0 && wadnum < (int)Files.size() ? Files[wadnum]->IsOptional() : true;
+		return (size_t)wadnum < Files.size() ? Files[wadnum]->IsOptional() : true;
 	}
 
 	int AddFromBuffer(const char* name, char* data, int size, int id, int flags);

--- a/src/common/filesystem/source/filesystem.cpp
+++ b/src/common/filesystem/source/filesystem.cpp
@@ -223,12 +223,12 @@ void FileSystem::DeleteAll ()
 
 bool FileSystem::InitSingleFile(const char* filename, FileSystemMessageFunc Printf)
 {
-	std::vector<std::string> filenames = { filename };
-	std::vector<std::string> empty;
-	return InitMultipleFiles(filenames, empty, nullptr, Printf);
+	std::string f = filename;
+	std::vector<ResourceName> filenames = { { f, false } };
+	return InitMultipleFiles(filenames, nullptr, Printf);
 }
 
-bool FileSystem::InitMultipleFiles (std::vector<std::string>& filenames, std::vector<std::string>& optfilenames, LumpFilterInfo* filter, FileSystemMessageFunc Printf, bool allowduplicates)
+bool FileSystem::InitMultipleFiles (std::vector<ResourceName>& filenames, LumpFilterInfo* filter, FileSystemMessageFunc Printf, bool allowduplicates)
 {
 	int numfiles;
 
@@ -248,21 +248,9 @@ bool FileSystem::InitMultipleFiles (std::vector<std::string>& filenames, std::ve
 		{
 			for (size_t j=i+1;j<filenames.size(); j++)
 			{
-				if (filenames[i] == filenames[j])
+				if (filenames[i].Name == filenames[j].Name)
 				{
 					filenames.erase(filenames.begin() + j);
-					j--;
-				}
-			}
-		}
-
-		for (size_t i=0;i<optfilenames.size(); i++)
-		{
-			for (size_t j=i+1;j<optfilenames.size(); j++)
-			{
-				if (optfilenames[i] == optfilenames[j])
-				{
-					optfilenames.erase(optfilenames.begin() + j);
 					j--;
 				}
 			}
@@ -271,17 +259,7 @@ bool FileSystem::InitMultipleFiles (std::vector<std::string>& filenames, std::ve
 
 	for(size_t i=0;i<filenames.size(); i++)
 	{
-		AddFile(filenames[i].c_str(), nullptr, filter, Printf, false);
-
-		if (i == (unsigned)MaxIwadIndex) MoveLumpsInFolder("after_iwad/");
-		std::string path = "filter/%s";
-		path += Files.back()->GetHash();
-		MoveLumpsInFolder(path.c_str());
-	}
-
-	for(size_t i=0;i<optfilenames.size(); i++)
-	{
-		AddFile(optfilenames[i].c_str(), nullptr, filter, Printf, true);
+		AddFile(filenames[i].Name.c_str(), nullptr, filter, Printf, filenames[i].bOptional);
 
 		if (i == (unsigned)MaxIwadIndex) MoveLumpsInFolder("after_iwad/");
 		std::string path = "filter/%s";

--- a/src/common/utility/findfile.cpp
+++ b/src/common/utility/findfile.cpp
@@ -52,7 +52,7 @@ static constexpr char PATH_SEPARATOR = ':';
 //
 //==========================================================================
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config)
+bool D_AddFile(std::vector<FileSys::ResourceName>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional)
 {
 	if (file == nullptr || *file == '\0')
 	{
@@ -118,8 +118,8 @@ bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check,
 
 	std::string f = file;
 	for (auto& c : f) if (c == '\\') c = '/';
-	if (position == -1) wadfiles.push_back(f);
-	else wadfiles.insert(wadfiles.begin() + position, f);
+	if (position == -1) wadfiles.push_back({ f, optional });
+	else wadfiles.insert(wadfiles.begin() + position, { f, optional });
 	return true;
 }
 
@@ -129,7 +129,7 @@ bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check,
 //
 //==========================================================================
 
-void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional)
+void D_AddWildFile(std::vector<FileSys::ResourceName>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional)
 {
 	if (value == nullptr || *value == '\0')
 	{
@@ -140,7 +140,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 
 	if (wadfile != nullptr)
 	{
-		D_AddFile(wadfiles, wadfile, true, -1, config);
+		D_AddFile(wadfiles, wadfile, true, -1, config, optional);
 		return;
 	}
 
@@ -155,7 +155,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 	{
 		for(auto& entry : list)
 		{
-			D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
+			D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
 			found = true;
 		}
 	}
@@ -181,7 +181,7 @@ void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const 
 //
 //==========================================================================
 
-void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile *config, bool optional)
+void D_AddConfigFiles(std::vector<FileSys::ResourceName>& wadfiles, const char* section, const char* extension, FConfigFile *config, bool optional)
 {
 	if (config && config->SetSection(section))
 	{
@@ -211,7 +211,7 @@ void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, c
 //
 //==========================================================================
 
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config)
+void D_AddDirectory(std::vector<FileSys::ResourceName>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional)
 {
 	FileSys::FileList list;
 	if (FileSys::ScanDirectory(list, dir, "*.wad", true))
@@ -220,7 +220,7 @@ void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const c
 		{
 			if (!entry.isDirectory)
 			{
-				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config);
+				D_AddFile(wadfiles, entry.FilePath.c_str(), true, -1, config, optional);
 			}
 		}
 	}

--- a/src/common/utility/findfile.h
+++ b/src/common/utility/findfile.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "fs_filesystem.h"
 
 class FConfigFile;
 
@@ -42,9 +43,9 @@ enum EFileRequirements
     REQUIRE_ALL = REQUIRE_IWAD|REQUIRE_FILE|REQUIRE_OPTFILE
 };
 
-bool D_AddFile(std::vector<std::string>& wadfiles, const char* file, bool check, int position, FConfigFile* config);
-void D_AddWildFile(std::vector<std::string>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional = false);
-void D_AddConfigFiles(std::vector<std::string>& wadfiles, const char* section, const char* extension, FConfigFile* config, bool optional = false);
-void D_AddDirectory(std::vector<std::string>& wadfiles, const char* dir, const char *filespec, FConfigFile* config);
+bool D_AddFile(std::vector<FileSys::ResourceName>& wadfiles, const char* file, bool check, int position, FConfigFile* config, bool optional);
+void D_AddWildFile(std::vector<FileSys::ResourceName>& wadfiles, const char* value, const char *extension, FConfigFile* config, bool optional);
+void D_AddConfigFiles(std::vector<FileSys::ResourceName>& wadfiles, const char* section, const char* extension, FConfigFile* config, bool optional);
+void D_AddDirectory(std::vector<FileSys::ResourceName>& wadfiles, const char* dir, const char *filespec, FConfigFile* config, bool optional);
 const char* BaseFileSearch(const char* file, const char* ext, bool lookfirstinprogdir, FConfigFile* config);
 void D_FileNotFound(EFileRequirements test, const char* type, const char* file);

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -320,14 +320,18 @@ void GetReserved(FileSys::LumpFilterInfo& lfi);
 FIWadManager::FIWadManager(const char *firstfn, const char *optfn)
 {
 	FileSystem check;
-	std::vector<std::string> fns;
-	fns.push_back(firstfn);
-	if (optfn) fns.push_back(optfn);
+	std::vector<FileSys::ResourceName> fns;
+	std::string f = firstfn;
+	fns.push_back({ f, false });
+	if (optfn)
+	{
+		f = optfn;
+		fns.push_back({ f, true });
+	}
 	FileSys::LumpFilterInfo lfi;
 	GetReserved(lfi);
 
-	std::vector<std::string> empty;
-	if (check.InitMultipleFiles(fns, empty, &lfi, nullptr))
+	if (check.InitMultipleFiles(fns, &lfi, nullptr))
 	{
 		// this is for the IWAD picker. As we have a filesystem open here that contains the base files, it is the easiest place to load the strings early.
 		GStrings.LoadStrings(check, language);
@@ -409,9 +413,9 @@ int FIWadManager::CheckIWADInfo(const char* fn)
 	FileSys::LumpFilterInfo lfi;
 	GetReserved(lfi);
 
-	std::vector<std::string> filenames = { fn };
-	std::vector<std::string> empty;
-	if (check.InitMultipleFiles(filenames, empty, &lfi, nullptr))
+	std::string f = fn;
+	std::vector<FileSys::ResourceName> filenames = { { f, false } };
+	if (check.InitMultipleFiles(filenames, &lfi, nullptr))
 	{
 		int num = check.CheckNumForName("IWADINFO");
 		if (num >= 0)
@@ -612,7 +616,7 @@ FString FIWadManager::IWADPathFileSearch(const FString &file)
 	return "";
 }
 
-int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad)
+int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad)
 {
 	const char *iwadparm = Args->CheckValue (FArg_iwad);
 	FString custwad;
@@ -863,12 +867,11 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 
 	// zdoom.pk3 must always be the first file loaded and the IWAD second.
 	wadfiles.clear();
-	optwadfiles.clear();
-	D_AddFile (wadfiles, zdoom_wad, true, -1, GameConfig);
+	D_AddFile (wadfiles, zdoom_wad, true, -1, GameConfig, false);
 
 	// [SP] Load non-free assets if available. This must be done before the IWAD.
 	int iwadnum = 1;
-	if (optional_wad && D_AddFile(optwadfiles, optional_wad, true, -1, GameConfig))
+	if (optional_wad && D_AddFile(wadfiles, optional_wad, true, -1, GameConfig, true))
 	{
 		iwadnum++;
 	}
@@ -876,10 +879,10 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 	fileSystem.SetIwadNum(iwadnum);
 	if (picks[pick].mRequiredPath.IsNotEmpty())
 	{
-		D_AddFile (wadfiles, picks[pick].mRequiredPath.GetChars(), true, -1, GameConfig);
+		D_AddFile (wadfiles, picks[pick].mRequiredPath.GetChars(), true, -1, GameConfig, false);
 		iwadnum++;
 	}
-	D_AddFile (wadfiles, picks[pick].mFullPath.GetChars(), true, -1, GameConfig);
+	D_AddFile (wadfiles, picks[pick].mFullPath.GetChars(), true, -1, GameConfig, false);
 	fileSystem.SetMaxIwadNum(iwadnum);
 
 	auto info = mIWadInfos[picks[pick].mInfoIndex];
@@ -894,7 +897,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 
 			if(supportWAD.IsNotEmpty())
 			{
-				D_AddFile(optwadfiles, supportWAD.GetChars(), true, -1, GameConfig);
+				D_AddFile(wadfiles, supportWAD.GetChars(), true, -1, GameConfig, true);
 			}
 		}
 	}
@@ -916,12 +919,12 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 				path = FString(picks[pick].mFullPath.GetChars(), lastslash + 1);
 			}
 			path += info.Load[i];
-			D_AddFile(wadfiles, path.GetChars(), true, -1, GameConfig);
+			D_AddFile(wadfiles, path.GetChars(), true, -1, GameConfig, false);
 		}
 		else
 		{
 			auto wad = BaseFileSearch(info.Load[i].GetChars() + 1, NULL, true, GameConfig);
-			if (wad) D_AddFile(wadfiles, wad, true, -1, GameConfig);
+			if (wad) D_AddFile(wadfiles, wad, true, -1, GameConfig, false);
 		}
 
 	}
@@ -935,9 +938,9 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 //
 //==========================================================================
 
-const FIWADInfo *FIWadManager::FindIWAD(std::vector<std::string>& wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *basewad, const char *optionalwad)
+const FIWADInfo *FIWadManager::FindIWAD(std::vector<FileSys::ResourceName>& wadfiles, const char *iwad, const char *basewad, const char *optionalwad)
 {
-	int iwadType = IdentifyVersion(wadfiles, optwadfiles, iwad, basewad, optionalwad);
+	int iwadType = IdentifyVersion(wadfiles, iwad, basewad, optionalwad);
 	if (iwadType == -1) return nullptr;
 	//gameiwad = iwadType;
 	const FIWADInfo *iwad_info = &mIWadInfos[iwadType];

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -882,11 +882,9 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 		D_AddFile (wadfiles, picks[pick].mRequiredPath.GetChars(), true, -1, GameConfig, false);
 		iwadnum++;
 	}
-	D_AddFile (wadfiles, picks[pick].mFullPath.GetChars(), true, -1, GameConfig, false);
-	fileSystem.SetMaxIwadNum(iwadnum);
-
 	auto info = mIWadInfos[picks[pick].mInfoIndex];
 
+	// Support WADs also need to be loaded before the IWAD as per the spec.
 	if(info.SupportWAD.IsNotEmpty())
 	{
 		// For net games all wads must be explicitly named to make it easier for the host to know
@@ -901,6 +899,8 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 			}
 		}
 	}
+	D_AddFile (wadfiles, picks[pick].mFullPath.GetChars(), true, -1, GameConfig, false);
+	fileSystem.SetMaxIwadNum(iwadnum);
 
 	// Load additional resources from the same directory as the IWAD itself.
 	for (unsigned i=0; i < info.Load.Size(); i++)

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2008,7 +2008,7 @@ FExecList *D_MultiExec (FArgs *list, FExecList *exec)
 	return exec;
 }
 
-static void GetCmdLineFiles(std::vector<std::string>& wadfiles, bool optional)
+static void GetCmdLineFiles(std::vector<FileSys::ResourceName>& wadfiles, bool optional)
 {
 	FString *args;
 	int i;
@@ -2022,11 +2022,20 @@ static void GetCmdLineFiles(std::vector<std::string>& wadfiles, bool optional)
 	// ones we added earlier.
 	for (i = optional ? 0 : int(wadfiles.size()); i < argc; ++i)
 	{
+		// Since optfiles shouldn't trigger the check but must still not be marked as optional
+		// for online purposes, any newly added files will need to be forcefully set to non-optional
+		// for the time being.
+		const size_t s = wadfiles.size();
 		D_AddWildFile(wadfiles, args[i].GetChars(), ".wad", GameConfig, optional);
+		if (wadfiles.size() > s)
+		{
+			for (size_t j = 0u; j < wadfiles.size() - s; ++j)
+				wadfiles[s + j].bOptional = false;
+		}
 	}
 }
 
-static FString ParseGameInfo(std::vector<std::string> &pwads, const char *fn, const char *data, int size)
+static FString ParseGameInfo(std::vector<FileSys::ResourceName> &pwads, const char *fn, const char *data, int size)
 {
 	FScanner sc;
 	FString iwad;
@@ -2068,11 +2077,11 @@ static FString ParseGameInfo(std::vector<std::string> &pwads, const char *fn, co
 				}
 				if (!DirEntryExists(checkpath.GetChars(), &isDir))
 				{
-					pos += D_AddFile(pwads, sc.String, true, pos, GameConfig);
+					pos += D_AddFile(pwads, sc.String, true, pos, GameConfig, false);
 				}
 				else
 				{
-					pos += D_AddFile(pwads, checkpath.GetChars(), true, pos, GameConfig);
+					pos += D_AddFile(pwads, checkpath.GetChars(), true, pos, GameConfig, false);
 				}
 			}
 			while (sc.CheckToken(','));
@@ -2160,7 +2169,7 @@ void GetReserved(LumpFilterInfo& lfi)
 	lfi.blockednames = { "*.bat", "*.exe", "__macosx/*", "*/__macosx/*", "*~" };
 }
 
-static FString CheckGameInfo(std::vector<std::string> & pwads)
+static FString CheckGameInfo(std::vector<FileSys::ResourceName>& pwads)
 {
 	FileSystem check;
 
@@ -2168,8 +2177,7 @@ static FString CheckGameInfo(std::vector<std::string> & pwads)
 	GetReserved(lfi);
 
 	// Open the entire list as a temporary file system and look for a GAMEINFO lump. The last one will automatically win.
-	std::vector<std::string> empty;
-	if (check.InitMultipleFiles(pwads, empty, &lfi, nullptr))
+	if (check.InitMultipleFiles(pwads, &lfi, nullptr))
 	{
 		int num = check.CheckNumForName("GAMEINFO");
 		if (num >= 0)
@@ -2229,7 +2237,7 @@ static void D_DoomInit()
 //
 //==========================================================================
 
-static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& allwads)
+static void AddAutoloadFiles(const char *autoname, std::vector<FileSys::ResourceName>& allwads)
 {
 	LumpFilterIWAD.Format("%s.", autoname);	// The '.' is appened to simplify parsing the string
 
@@ -2240,19 +2248,19 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 		{
 			const char *lightswad = BaseFileSearch ("lights.pk3", NULL, true, GameConfig);
 			if (lightswad)
-				D_AddFile (allwads, lightswad, true, -1, GameConfig);
+				D_AddFile (allwads, lightswad, true, -1, GameConfig, true);
 		}
 		if ((GameStartupInfo.LoadBrightmaps == 1 || (GameStartupInfo.LoadBrightmaps != 0 && autoloadbrightmaps)) && !(Args->CheckParm(FArg_nobrightmaps)))
 		{
 			const char *bmwad = BaseFileSearch ("brightmaps.pk3", NULL, true, GameConfig);
 			if (bmwad)
-				D_AddFile (allwads, bmwad, true, -1, GameConfig);
+				D_AddFile (allwads, bmwad, true, -1, GameConfig, true);
 		}
 		if ((GameStartupInfo.LoadWidescreen == 1 || (GameStartupInfo.LoadWidescreen != 0 && autoloadwidescreen)) && !(Args->CheckParm(FArg_nowidescreen)))
 		{
 			const char *wswad = BaseFileSearch ("game_widescreen_gfx.pk3", NULL, true, GameConfig);
 			if (wswad)
-				D_AddFile (allwads, wswad, true, -1, GameConfig);
+				D_AddFile (allwads, wswad, true, -1, GameConfig, true);
 		}
 	}
 
@@ -2268,7 +2276,7 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 		// it for something else, so this gets to stay here.
 		const char *wad = BaseFileSearch ("zvox.wad", NULL, false, GameConfig);
 		if (wad)
-			D_AddFile (allwads, wad, true, -1, GameConfig);
+			D_AddFile (allwads, wad, true, -1, GameConfig, true);
 
 		// [RH] Add any .wad files in the skins directory
 #ifdef __unix__
@@ -2277,12 +2285,12 @@ static void AddAutoloadFiles(const char *autoname, std::vector<std::string>& all
 		file = progdir;
 #endif
 		file += "skins";
-		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig);
+		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig, true);
 
 #ifdef __unix__
 		FString skinDir = FStringf("%s/games/" GAMENAMELOWERCASE "/skins", GetDataPath());
 		file = NicePath(skinDir.GetChars());
-		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig);
+		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig, true);
 #endif
 
 		// Add common (global) wads
@@ -3377,7 +3385,7 @@ static int FileSystemPrintf(FSMessageLevel level, const char* fmt, ...)
 //
 //==========================================================================
 
-static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allwads, std::vector<std::string>& optwads, std::vector<std::string>& pwads)
+static int D_InitGame(const FIWADInfo* iwad_info, std::vector<FileSys::ResourceName>& allwads, std::vector<FileSys::ResourceName>& pwads)
 {
 	NetworkEntityManager::InitializeNetworkEntities();
 
@@ -3421,7 +3429,7 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	FBaseCVar::DisableCallbacks();
 	GameConfig->DoGameSetup (gameinfo.ConfigName.GetChars());
 
-	AddAutoloadFiles(iwad_info->Autoname.GetChars(), optwads);
+	AddAutoloadFiles(iwad_info->Autoname.GetChars(), allwads);
 
 	// Process automatically executed files
 	FExecList *exec;
@@ -3486,14 +3494,12 @@ static int D_InitGame(const FIWADInfo* iwad_info, std::vector<std::string>& allw
 	);
 
 	bool allowduplicates = Args->CheckParm(FArg_allowduplicates);
-	if (!fileSystem.InitMultipleFiles(allwads, optwads, &lfi, FileSystemPrintf, allowduplicates))
+	if (!fileSystem.InitMultipleFiles(allwads, &lfi, FileSystemPrintf, allowduplicates))
 	{
 		I_FatalError("FileSystem: no files found");
 	}
 	allwads.clear();
 	allwads.shrink_to_fit();
-	optwads.clear();
-	optwads.shrink_to_fit();
 	SetMapxxFlag();
 
 	D_GrabCVarDefaults(); //parse DEFCVARS
@@ -4081,7 +4087,7 @@ static int D_DoomMain_Internal (void)
 		// Load zdoom.pk3 alone so that we can get access to the internal gameinfos before
 		// the IWAD is known.
 
-		std::vector<std::string> pwads;
+		std::vector<FileSys::ResourceName> pwads;
 		GetCmdLineFiles(pwads, false);
 		FString iwad = CheckGameInfo(pwads);
 
@@ -4089,10 +4095,9 @@ static int D_DoomMain_Internal (void)
 		// restart is initiated without a defined IWAD assume for now that it's not going to change.
 		if (iwad.IsEmpty()) iwad = lastIWAD;
 
-		std::vector<std::string> allwads;
-		std::vector<std::string> optwads;
+		std::vector<FileSys::ResourceName> allwads;
 
-		const FIWADInfo *iwad_info = iwad_man->FindIWAD(allwads, optwads, iwad.GetChars(), basewad.GetChars(), optionalwad.GetChars());
+		const FIWADInfo *iwad_info = iwad_man->FindIWAD(allwads, iwad.GetChars(), basewad.GetChars(), optionalwad.GetChars());
 
 		GetCmdLineFiles(pwads, false); // [RL0] Update with files passed on the launcher extra args
 		// For now these need to remain verifiable over the network.
@@ -4141,13 +4146,11 @@ static int D_DoomMain_Internal (void)
 				GameStartupInfo.SteamAppId = "";
 		}
 
-		int ret = D_InitGame(iwad_info, allwads, optwads, pwads);
+		int ret = D_InitGame(iwad_info, allwads, pwads);
 		pwads.clear();
 		pwads.shrink_to_fit();
 		allwads.clear();
 		allwads.shrink_to_fit();
-		optwads.clear();
-		optwads.shrink_to_fit();
 		delete iwad_man;	// now we won't need this anymore
 		iwad_man = NULL;
 		if (ret != 0) return ret;

--- a/src/d_main.h
+++ b/src/d_main.h
@@ -26,6 +26,7 @@
 #include "startupinfo.h"
 #include "c_cvars.h"
 #include "v_video.h"
+#include "fs_filesystem.h"
 #include <csignal>
 
 extern bool		advancedemo;
@@ -142,7 +143,7 @@ class FIWadManager
 	void ParseIWadInfo(const char *fn, const char *data, int datasize, FIWADInfo *result = nullptr);
 	int ScanIWAD (const char *iwad);
 	int CheckIWADInfo(const char *iwad);
-	int IdentifyVersion (std::vector<std::string>& wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad);
+	int IdentifyVersion (std::vector<FileSys::ResourceName>& wadfiles, const char *iwad, const char *zdoom_wad, const char *optional_wad);
 	void CollectSearchPaths();
 	void AddIWADCandidates(const char *dir, bool nosubdir = true);
 	void ValidateIWADs();
@@ -150,7 +151,7 @@ class FIWadManager
 public:
 
 	FIWadManager(const char *fn, const char *fnopt);
-	const FIWADInfo *FindIWAD(std::vector<std::string>& wadfiles, std::vector<std::string>& optwadfiles, const char *iwad, const char *basewad, const char *optionalwad);
+	const FIWADInfo *FindIWAD(std::vector<FileSys::ResourceName>& wadfiles, const char *iwad, const char *basewad, const char *optionalwad);
 	const FString *GetAutoname(unsigned int num) const
 	{
 		if (num < mIWadInfos.Size()) return &mIWadInfos[num].Autoname;


### PR DESCRIPTION
This is needed to ensure assets aren't accidentally overwritten. Fixes #1011 and #1028

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
