### PR TITLE
Move particles to run before all other logic locally

### DIFF
--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -58,6 +58,7 @@
 #include "version.h"
 #include "vm.h"
 
+void P_RunParticleLogic();
 void P_RunClientSideLogic();
 
 EXTERN_CVAR (Int, disableautosave)
@@ -2263,6 +2264,11 @@ void TryRunTics()
 		if (totalTics < availableTics - StabilityBuffer)
 			++runTics;
 	}
+
+	// This needs to be done before anything else so one-tic duration particles
+	// are still captured for a single frame.
+	for (int i = 0; i < totalTics; ++i)
+		P_RunParticleLogic();
 
 	const int worldTimer = primaryLevel->LocalWorldTimer;
 	// If there are no tics to run, check for possible stall conditions and new

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -41,6 +41,15 @@ void C_Ticker();
 void M_Ticker();
 void D_RunCutscene();
 
+void P_RunParticleLogic()
+{
+	if ((gamestate != GS_LEVEL && gamestate != GS_TITLELEVEL) || WorldPaused(false))
+		return;
+
+	for (auto level : AllLevels())
+		P_ThinkParticles(level);	// [RH] make the particles think
+}
+
 //==========================================================================
 //
 // P_RunClientsideLogic
@@ -184,24 +193,7 @@ void P_Ticker (void)
 
 	// run the tic
 	if (paused || P_CheckTickerPaused())
-	{
-		// This must run even when the game is paused to catch changes from netevents before the frame is rendered.
-		for (auto Level : AllLevels())
-		{
-			auto it = Level->GetThinkerIterator<AActor>();
-			AActor* ac;
-
-			while ((ac = it.Next()))
-			{
-				if (ac->flags8 & MF8_RECREATELIGHTS)
-				{
-					ac->flags8 &= ~MF8_RECREATELIGHTS;
-					ac->SetDynamicLights();
-				}
-			}
-		}
 		return;
-	}
 
 	DPSprite::NewTick();
 
@@ -250,8 +242,6 @@ void P_Ticker (void)
 			ac->ClearInterpolation();
 			ac->ClearFOVInterpolation();
 		}
-
-		P_ThinkParticles(Level);	// [RH] make the particles think
 
 		for (i = 0; i < MAXPLAYERS; i++)
 			if (Level->PlayerInGame(i))


### PR DESCRIPTION
This moves them off of the server and onto the client-side handling. Also removes some leftover server code that was being used to handle dynamic lights (this is now always handled properly by the client-side logic).

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
