### PR TITLE
Fix counting iwadnum

### DIFF
--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -870,7 +870,7 @@ int FIWadManager::IdentifyVersion (std::vector<std::string>&wadfiles, std::vecto
 	int iwadnum = 1;
 	if (optional_wad && D_AddFile(optwadfiles, optional_wad, true, -1, GameConfig))
 	{
-		iwadnum++;
+		// iwadnum++; // optional_wad is always "game_support.pk3", that should be not counted
 	}
 
 	fileSystem.SetIwadNum(iwadnum);


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

This patch resolved all the left localization issues in `Harmony` and some others.
Incorrect `iwadnum` causes the code to mistakenly process `DeleteLumps = ..."LANGUAGE"...` in the `iwadinfo.txt`.
