### PR TITLE
Update devbuild release logic

### DIFF
--- a/.github/workflows/upload_nightly.yml
+++ b/.github/workflows/upload_nightly.yml
@@ -16,6 +16,8 @@ jobs:
       contents: write
       actions: read
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -39,6 +41,13 @@ jobs:
           move "artifacts/MacOS LLVM Release"/*.zip release/MacOS-UZDoom-Nightly.zip
           move "artifacts/Linux LLVM Release"/*.AppImage release/Linux-UZDoom-Nightly.AppImage
 
+      - name: Update Tag
+        run: |
+          git tag -d nightly || true
+          git push origin :refs/tags/nightly || true
+          git tag nightly
+          git push origin nightly
+
       - name: Upload
         uses: softprops/action-gh-release@v2
         with:
@@ -47,6 +56,8 @@ jobs:
           draft: false
           prerelease: true
           make_latest: false
+          generate_release_notes: false
+          files: release/**
           body: |
             These builds are automatically generated based on the latest commit to trunk.
 
@@ -54,5 +65,3 @@ jobs:
 
             **Commit:** ${{ github.event.workflow_run.head_sha || github.sha }}
             **Message:** ${{ github.event.workflow_run.head_commit.message || github.event.head_commit.message }}
-          generate_release_notes: false
-          files: release/**

--- a/.github/workflows/upload_nightly.yml
+++ b/.github/workflows/upload_nightly.yml
@@ -38,7 +38,6 @@ jobs:
           move "artifacts/Windows MSVC Release"/*.zip release/Windows-UZDoom-Nightly.zip
           move "artifacts/MacOS LLVM Release"/*.zip release/MacOS-UZDoom-Nightly.zip
           move "artifacts/Linux LLVM Release"/*.AppImage release/Linux-UZDoom-Nightly.AppImage
-          move "artifacts/Linux GCC Release"/*.AppImage release/Linux-Legacy-UZDoom-Nightly.AppImage
 
       - name: Upload
         uses: softprops/action-gh-release@v2
@@ -49,9 +48,11 @@ jobs:
           prerelease: true
           make_latest: false
           body: |
-            # These are automatically generated development versions based on latest commit to trunk.
-            ## WARNING: Nightly builds may be unstable and have issues.
-            [Commit:](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }})
-            ${{ github.event.head_commit.message }}
+            These builds are automatically generated based on the latest commit to trunk.
+
+            They are development builds, so they may be unstable and have issues. Please report any problems you find.
+
+            **Commit:** ${{ github.event.workflow_run.head_sha || github.sha }}
+            **Message:** ${{ github.event.workflow_run.head_commit.message || github.event.head_commit.message }}
           generate_release_notes: false
           files: release/**


### PR DESCRIPTION
- Clean-up messaging
- Don't release GCC builds (they weren't the 'legacy' builds)
- Rotate `nightly` tag, so the release metadata and source code is correct

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
