### PR TITLE
Fix casting integer to texture ID not working

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -1934,6 +1934,14 @@ FxExpression *FxTypeCast::Resolve(FCompileContext &ctx)
 		delete this;
 		return x;
 	}
+	else if (ValueType == TypeTextureID && basex->IsInteger())
+	{
+		basex->ValueType = TypeTextureID;
+		auto x = basex;
+		basex = nullptr;
+		delete this;
+		return x;
+	}
 	else if (ValueType->isClassPointer())
 	{
 		FxExpression *x = new FxClassTypeCast(static_cast<PClassPointer*>(ValueType), basex, Explicit);


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Type cast expressions on ints to TextureIDs don't currently work because that eval branch is missing in the compiler. Adding that fixes the issue.