### PR TITLE
speed up deserializing by assuming fields are ordered the same as when serializing

### DIFF
--- a/src/common/engine/serializer.cpp
+++ b/src/common/engine/serializer.cpp
@@ -26,7 +26,6 @@
 #define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
 #define RAPIDJSON_HAS_CXX11_RANGE_FOR 1
 #define RAPIDJSON_PARSE_DEFAULT_FLAGS kParseFullPrecisionFlag
-#define RAPIDJSON_USE_MEMBERSMAP 1
 
 #include <miniz.h>
 #include "rapidjson/rapidjson.h"
@@ -736,12 +735,12 @@ void FSerializer::ReadObjectsFrom(TArray<TObjPtr<DObject*>>& from)
 			// First iteration: create all the objects but do nothing with them yet.
 			while (BeginObject(nullptr))
 			{
+				FString clsname;	// do not deserialize the class type directly so that we can print appropriate errors.
+				Serialize(*this, "classtype", clsname, nullptr);
 				unsigned i = 0u;
 				Serialize(*this, "rollbackindex", i, nullptr);
 				if (r->mDObjects[i] == nullptr)
 				{
-					FString clsname;	// do not deserialize the class type directly so that we can print appropriate errors.
-					Serialize(*this, "classtype", clsname, nullptr);
 					PClass* cls = PClass::FindClass(clsname);
 					if (cls == nullptr)
 					{
@@ -767,6 +766,8 @@ void FSerializer::ReadObjectsFrom(TArray<TObjPtr<DObject*>>& from)
 				r->mObjects.Last().mIndex = 0;
 				while (BeginObject(nullptr))
 				{
+					FString clsname;	// do not deserialize the class type directly so that we can print appropriate errors.
+					Serialize(*this, "classtype", clsname, nullptr);
 					unsigned i = 0u;
 					Serialize(*this, "rollbackindex", i, nullptr);
 					auto obj = r->mDObjects[i];

--- a/src/common/engine/serializer_internal.h
+++ b/src/common/engine/serializer_internal.h
@@ -35,12 +35,16 @@ struct FJSONObject
 {
 	rapidjson::Value* mObject;
 	rapidjson::Value::MemberIterator mIterator;
+	rapidjson::Value::MemberIterator mHopefulIterator;
 	int mIndex;
 
 	FJSONObject(rapidjson::Value* v)
 	{
 		mObject = v;
-		if (v->IsObject()) mIterator = v->MemberBegin();
+		if (v->IsObject()) {
+			mIterator = v->MemberBegin();
+			mHopefulIterator = v->MemberBegin();
+		}
 		else if (v->IsArray())
 		{
 			mIndex = 0;
@@ -205,6 +209,19 @@ struct FReader
 			}
 			else
 			{
+				while (obj.mHopefulIterator != obj.mObject->MemberEnd()) [[likely]] {
+					auto name = std::string_view(obj.mHopefulIterator->name.GetString(), obj.mHopefulIterator->name.GetStringLength());
+					if (key == name) [[likely]] {
+						auto ret = &obj.mHopefulIterator->value;
+						++obj.mHopefulIterator;
+						return ret;
+					}
+					if (name.starts_with("class:")) [[unlikely]] {
+						++obj.mHopefulIterator;
+						continue;
+					}
+					break;
+				}
 				// Find the given key by name;
 				auto it = obj.mObject->FindMember(key);
 				if (it == obj.mObject->MemberEnd()) return nullptr;

--- a/src/serializer_doom.cpp
+++ b/src/serializer_doom.cpp
@@ -26,7 +26,6 @@
 #define RAPIDJSON_HAS_CXX11_RVALUE_REFS 1
 #define RAPIDJSON_HAS_CXX11_RANGE_FOR 1
 #define RAPIDJSON_PARSE_DEFAULT_FLAGS kParseFullPrecisionFlag
-#define RAPIDJSON_USE_MEMBERSMAP 1
 
 #include <miniz.h>
 #include "rapidjson/rapidjson.h"


### PR DESCRIPTION
rather than using the rapidjson membersmap define which is verifiably slow to build during serialization, this produces an actually better speed-up by assuming that the object is probably in the same order as when it was serialized (which requires a couple minor changes to make sure that's actually true in some contexts)

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
