### PR TITLE
Rollback data optimizations

### DIFF
--- a/src/common/engine/serializer.cpp
+++ b/src/common/engine/serializer.cpp
@@ -124,6 +124,19 @@ bool FSerializer::OpenWriter(bool pretty, bool predicting)
 	return true;
 }
 
+bool FSerializer::OpenWriter(FWriterBuffer buffer, bool pretty, bool predicting)
+{
+	if (w != nullptr || r != nullptr) return false;
+
+	bPredictionBackup = predicting;
+	mErrors = 0;
+	w = new FWriter(pretty);
+	buffer.buffer.Clear();
+	w->mOutString = std::move(buffer.buffer);
+	BeginObject(nullptr);
+	return true;
+}
+
 //==========================================================================
 //
 //
@@ -137,6 +150,17 @@ bool FSerializer::OpenReader(const char *buffer, size_t length, bool predicting)
 	bPredictionBackup = predicting;
 	mErrors = 0;
 	r = new FReader(buffer, length);
+	return true;
+}
+
+bool FSerializer::OpenReader(FReaderAllocator allocator, const char *buffer, size_t length, bool predicting)
+{
+	if (w != nullptr || r != nullptr) return false;
+
+	bPredictionBackup = predicting;
+	mErrors = 0;
+	allocator.buffer.Clear();
+	r = new FReader(allocator, buffer, length);
 	return true;
 }
 
@@ -166,11 +190,11 @@ bool FSerializer::OpenReader(FCompressedBuffer *input, bool predicting)
 	return true;
 }
 
-//==========================================================================
-//
-//
-//
-//==========================================================================
+FWriterBuffer FSerializer::CloseAndGetBuffer() {
+	auto ret = w->MoveBufferOut();
+	Close();
+	return ret;
+}
 
 void FSerializer::Close()
 {	

--- a/src/common/engine/serializer.h
+++ b/src/common/engine/serializer.h
@@ -36,6 +36,22 @@
 #include "tflags.h"
 #include "vectors.h"
 
+#include "rapidjson/stringbuffer.h"
+
+struct FWriterBuffer {
+	rapidjson::StringBuffer buffer;
+	FWriterBuffer() : buffer(rapidjson::StringBuffer {}) {}
+	FWriterBuffer(rapidjson::StringBuffer buffer) : buffer(std::move(buffer)) {}
+};
+
+struct FReaderAllocator {
+	rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> buffer;
+	FReaderAllocator() : buffer({}) {}
+	FReaderAllocator(char* userBuffer, size_t len) : buffer({ userBuffer, len }) {}
+	FReaderAllocator(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> buffer) : buffer(std::move(buffer)) {}
+	void Clear() { buffer.Clear(); }
+};
+
 struct FWriter;
 struct FReader;
 class PClass;
@@ -113,9 +129,12 @@ public:
 	bool MarkRollbackObject(DObject* obj);
 	void SetUniqueSoundNames() { soundNamesAreUnique = true; }
 	bool OpenWriter(bool pretty = true, bool predicting = false);
+	bool OpenWriter(FWriterBuffer buffer, bool pretty = true, bool predicting = false);
 	bool OpenReader(const char *buffer, size_t length, bool predicting = false);
+	bool OpenReader(FReaderAllocator allocator, const char *buffer, size_t length, bool predicting = false);
 	bool OpenReader(FileSys::FCompressedBuffer *input, bool predicting = false);
 	void Close();
+	FWriterBuffer CloseAndGetBuffer();
 	void ReadObjectsFrom(TArray<TObjPtr<DObject*>>& from);
 	void ReadObjects(bool hubtravel);
 	bool BeginObject(const char *name);

--- a/src/common/engine/serializer_internal.h
+++ b/src/common/engine/serializer_internal.h
@@ -70,8 +70,10 @@ struct FWriter
 	TArray<DObject *> mDObjects;
 	TMap<DObject *, int> mObjectMap;
 
-	FWriter(bool pretty)
+	FWriter(bool pretty, FWriterBuffer existingBuffer)
 	{
+		existingBuffer.buffer.Clear();
+		mOutString = std::move(existingBuffer.buffer);
 		if (!pretty)
 		{
 			mWriter = new Writer(mOutString);
@@ -81,10 +83,15 @@ struct FWriter
 			mWriter = new PrettyWriter(mOutString);
 		}
 	}
+	FWriter(bool pretty) : FWriter(pretty, FWriterBuffer(rapidjson::StringBuffer {})) {}
 
 	~FWriter()
 	{
 		if (mWriter) delete mWriter;
+	}
+
+	FWriterBuffer MoveBufferOut() {
+		return FWriterBuffer(std::move(mOutString));
 	}
 
 
@@ -187,6 +194,12 @@ struct FReader
 	TArray<DObject *> mDObjects;
 	rapidjson::Value *mKeyValue = nullptr;
 	bool mObjectsRead = false;
+
+	FReader(FReaderAllocator allocator, const char *buffer, size_t length) : mDoc(rapidjson::Document(&allocator.buffer))
+	{
+		mDoc.Parse(buffer, length);
+		mObjects.Push(FJSONObject(&mDoc));
+	}
 
 	FReader(const char *buffer, size_t length)
 	{

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -395,7 +395,7 @@ struct FPredictionData
 	TArray<FActorBackup> RollbackActors = {};
 	TArray<size_t> RollbackPlayers = {};				// Store by index instead of pointer so it'll never be invalid when deserializing.
 	FLevelLocals* RollbackLevel = nullptr;				// Save this for when opening the reader.
-	FileSys::FCompressedBuffer RollbackData = {};		// Snapshot of all saved Objects.
+	std::string RollbackData;		// Snapshot of all saved Objects.
 
 	struct
 	{
@@ -416,7 +416,7 @@ struct FPredictionData
 		RollbackActors.Clear();
 		RollbackPlayers.Clear();
 		RollbackLevel = nullptr;
-		RollbackData.Clean();
+		RollbackData = "";
 	}
 
 	void Mark()
@@ -468,7 +468,7 @@ DEFINE_ACTION_FUNCTION(FPlayerClass, CheckSkin)
 //===========================================================================
 
 FString GetPrintableDisplayName(PClassActor *cls)
-{ 
+{
 	// Fixme; This needs a decent way to access the string table without creating a mess.
 	// [RH] ????
 	return cls->GetDisplayName();
@@ -875,8 +875,8 @@ DEFINE_ACTION_FUNCTION(FPlayerClass, GetColorSetName)
 
 static int GetPainFlash(AActor *info, int type)
 {
-	// go backwards through the list and return the first item with a 
-	// matching damage type for an ancestor of our class. 
+	// go backwards through the list and return the first item with a
+	// matching damage type for an ancestor of our class.
 	// This will always return the best fit because any parent class
 	// must be processed before its children.
 	for (int i = PainFlashes.Size() - 1; i >= 0; i--)
@@ -973,7 +973,7 @@ bool player_t::Resurrect()
 	mo->renderflags &= ~RF_INVISIBLE;
 	mo->Height = mo->GetDefault()->Height;
 	mo->radius = mo->GetDefault()->radius;
-	mo->special1 = 0;	// required for the Hexen fighter's fist attack. 
+	mo->special1 = 0;	// required for the Hexen fighter's fist attack.
 								// This gets set by AActor::Die as flag for the wimpy death and must be reset here.
 	mo->SetState(mo->SpawnState);
 	int pnum = mo->Level->PlayerNum(this);
@@ -1173,7 +1173,7 @@ DEFINE_ACTION_FUNCTION(_PlayerInfo, GetStillBob)
 
 //===========================================================================
 //
-// 
+//
 //
 //===========================================================================
 
@@ -1246,7 +1246,7 @@ void PlayIdle (AActor *player)
 //
 // A_PlayerScream
 //
-// try to find the appropriate death sound and use suitable 
+// try to find the appropriate death sound and use suitable
 // replacements if necessary
 //
 //===========================================================================
@@ -1346,7 +1346,7 @@ void P_CheckPlayerSprite(AActor *actor, int &spritenum, DVector2 &scale)
 	if (player->mo == actor && player->crouchfactor < 0.75)
 	{
 		int crouchsprite = player->mo->IntVar(NAME_crouchsprite);
-		if (spritenum == actor->SpawnState->sprite || spritenum == crouchsprite) 
+		if (spritenum == actor->SpawnState->sprite || spritenum == crouchsprite)
 		{
 			crouchspriteno = crouchsprite;
 		}
@@ -1361,7 +1361,7 @@ void P_CheckPlayerSprite(AActor *actor, int &spritenum, DVector2 &scale)
 			crouchspriteno = -1;
 		}
 
-		if (crouchspriteno > 0) 
+		if (crouchspriteno > 0)
 		{
 			spritenum = crouchspriteno;
 		}
@@ -1395,7 +1395,7 @@ void P_FallingDamage (AActor *actor)
 
 	if (damagestyle == 0)
 		return;
-		
+
 	if (actor->floorsector->Flags & SECF_NOFALLINGDAMAGE)
 		return;
 
@@ -1427,7 +1427,7 @@ void P_FallingDamage (AActor *actor)
 			}
 		}
 		break;
-	
+
 	case DF_FORCE_FALLINGZD:		// ZDoom falling damage
 		if (vel <= 19)
 		{ // Not fast enough to hurt
@@ -1795,7 +1795,7 @@ void P_PredictClient()
 				fullRollback.Push(a.GetObject<DObject>());
 			for (auto& o : PredictionData.RollbackObjects)
 				fullRollback.Push(o.GetObject<DObject>());
-			PredictionData.RollbackData = writer.GetCompressedOutput(&PredictionData.RollbackObjectRefs, &fullRollback);
+			PredictionData.RollbackData.assign(writer.GetOutput(nullptr, &PredictionData.RollbackObjectRefs, &fullRollback));
 			PredictionData.RollbackLevel = player->mo->Level;
 			writer.Close();
 
@@ -1899,7 +1899,7 @@ void P_UnPredictClient()
 	NetworkEntityManager::DisablePrediction();
 
 	FDoomSerializer reader = { PredictionData.RollbackLevel };
-	if (reader.OpenReader(&PredictionData.RollbackData, true))
+	if (reader.OpenReader(PredictionData.RollbackData.c_str(), PredictionData.RollbackData.size(), true))
 	{
 		for (auto& a : PredictionData.RollbackActors)
 			a.PreRollback();

--- a/src/playsim/p_user.cpp
+++ b/src/playsim/p_user.cpp
@@ -395,7 +395,12 @@ struct FPredictionData
 	TArray<FActorBackup> RollbackActors = {};
 	TArray<size_t> RollbackPlayers = {};				// Store by index instead of pointer so it'll never be invalid when deserializing.
 	FLevelLocals* RollbackLevel = nullptr;				// Save this for when opening the reader.
-	std::string RollbackData;		// Snapshot of all saved Objects.
+	std::string_view RollbackData;		// Snapshot of all saved Objects.
+	FWriterBuffer RollbackWriterBuffer;
+	char ParseBuffer[262144] = {};
+	FReaderAllocator RollbackReaderAllocator;
+
+	FPredictionData() : RollbackReaderAllocator(ParseBuffer, sizeof(ParseBuffer)) {}
 
 	struct
 	{
@@ -1795,9 +1800,9 @@ void P_PredictClient()
 				fullRollback.Push(a.GetObject<DObject>());
 			for (auto& o : PredictionData.RollbackObjects)
 				fullRollback.Push(o.GetObject<DObject>());
-			PredictionData.RollbackData.assign(writer.GetOutput(nullptr, &PredictionData.RollbackObjectRefs, &fullRollback));
+			PredictionData.RollbackData = writer.GetOutput(nullptr, &PredictionData.RollbackObjectRefs, &fullRollback);
 			PredictionData.RollbackLevel = player->mo->Level;
-			writer.Close();
+			PredictionData.RollbackWriterBuffer = writer.CloseAndGetBuffer();
 
 			for (auto& a : PredictionData.RollbackActors)
 				a.PostBackup();
@@ -1899,7 +1904,7 @@ void P_UnPredictClient()
 	NetworkEntityManager::DisablePrediction();
 
 	FDoomSerializer reader = { PredictionData.RollbackLevel };
-	if (reader.OpenReader(PredictionData.RollbackData.c_str(), PredictionData.RollbackData.size(), true))
+	if (reader.OpenReader(PredictionData.RollbackReaderAllocator, PredictionData.RollbackData.data(), PredictionData.RollbackData.size(), true))
 	{
 		for (auto& a : PredictionData.RollbackActors)
 			a.PreRollback();


### PR DESCRIPTION
Makes two main optimizations to the rollback data:

- Don't compress it in memory (it's expensive and hurts frame timing quite significantly)
- Add some additional serializer API surface to allow the memory allocations to be mostly re-used by the caller if desired since they do show up in profiling

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
