### PR TITLE
fix MDL_ROTATING

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -170,6 +170,9 @@ VSMatrix FSpriteModelFrame::ObjectToWorldMatrix(FLevelLocals *Level, DVector3 tr
 		objectToWorldMatrix.scale(1, stretch, 1);
 	}
 
+	bool rotating_xzy = (flags & MDL_ROTATING) && (flags & MDL_FIXROTATING);
+	bool rotating_xyz = (flags & MDL_ROTATING) && !(flags & MDL_FIXROTATING);
+
 	// Applying model transformations:
 	// 1) Applying actor angle, pitch and roll to the model
 	if (flags & MDL_USEROTATIONCENTER)
@@ -182,12 +185,19 @@ VSMatrix FSpriteModelFrame::ObjectToWorldMatrix(FLevelLocals *Level, DVector3 tr
 
 		// 2) Applying Doomsday like rotation of the weapon pickup models
 		// The rotation angle is based on the elapsed time.
-		if(flags & MDL_ROTATING)
+		if(rotating_xzy)
 		{
 			objectToWorldMatrix.rotate(rotateOffset, xrotate, yrotate, zrotate);
 		}
 
 		objectToWorldMatrix.translate(-rotationCenterX, -rotationCenterZ/stretch, -rotationCenterY);
+
+		if(rotating_xyz)
+		{
+			objectToWorldMatrix.translate(rotationCenterX, rotationCenterY/stretch, rotationCenterZ);
+			objectToWorldMatrix.rotate(rotateOffset, xrotate, yrotate, zrotate);
+			objectToWorldMatrix.translate(-rotationCenterX, -rotationCenterY/stretch, -rotationCenterZ);
+		}
 	}
 	else
 	{
@@ -195,14 +205,19 @@ VSMatrix FSpriteModelFrame::ObjectToWorldMatrix(FLevelLocals *Level, DVector3 tr
 		objectToWorldMatrix.rotate(rotation.Pitch.Degrees(), 0, 0, 1);
 		objectToWorldMatrix.rotate(-rotation.Roll.Degrees(), 1, 0, 0);
 
-
 		// 2) Applying Doomsday like rotation of the weapon pickup models
 		// The rotation angle is based on the elapsed time.
-		if(flags & MDL_ROTATING)
+		if(rotating_xzy)
 		{
 			objectToWorldMatrix.translate(rotationCenterX, rotationCenterZ/stretch, rotationCenterY);
 			objectToWorldMatrix.rotate(rotateOffset, xrotate, yrotate, zrotate);
 			objectToWorldMatrix.translate(-rotationCenterX, -rotationCenterZ/stretch, -rotationCenterY);
+		}
+		else if(rotating_xyz)
+		{
+			objectToWorldMatrix.translate(rotationCenterX, rotationCenterY/stretch, rotationCenterZ);
+			objectToWorldMatrix.rotate(rotateOffset, xrotate, yrotate, zrotate);
+			objectToWorldMatrix.translate(-rotationCenterX, -rotationCenterY/stretch, -rotationCenterZ);
 		}
 	}
 
@@ -967,6 +982,10 @@ void ParseModelDefLump(int Lump)
 					smf.rotationCenterY = 0.;
 					smf.rotationCenterZ = 0.;
 					smf.rotationSpeed = 1.;
+				}
+				else if (sc.Compare("fix-rotating"))
+				{
+					smf.flags |= MDL_FIXROTATING;
 				}
 				else if (sc.Compare("rotation-speed"))
 				{

--- a/src/r_data/models.h
+++ b/src/r_data/models.h
@@ -50,11 +50,12 @@ enum
 	MDL_BADROTATION					= 1<<7,
 	MDL_DONTCULLBACKFACES			= 1<<8,
 	MDL_USEROTATIONCENTER			= 1<<9,
-	MDL_NOPERPIXELLIGHTING			= 1<<10, // forces a model to not use per-pixel lighting. useful for voxel-converted-to-model objects.
+	MDL_NOPERPIXELLIGHTING			= 1<<10,	// forces a model to not use per-pixel lighting. useful for voxel-converted-to-model objects.
 	MDL_SCALEWEAPONFOV				= 1<<11,	// scale weapon view model with higher user FOVs
 	MDL_MODELSAREATTACHMENTS		= 1<<12,	// any model index after 0 is treated as an attachment, and therefore will use the bone results of index 0
 	MDL_CORRECTPIXELSTRETCH			= 1<<13,	// ensure model does not distort with pixel stretch when pitch/roll is applied
 	MDL_FORCECULLBACKFACES			= 1<<14,
+	MDL_FIXROTATING					= 1<<15,
 };
 
 FSpriteModelFrame * FindModelFrame(AActor * thing, int sprite, int frame, bool dropped);


### PR DESCRIPTION
before the refactoring, MDL_USEROTATIONCENTER used Rotation-Center as XZY but MDL_ROTATING used Rotation-Center as XYZ

after the refactoring, both used it as XZY, because i didn't even consider there could possibly be a discrepancy between two flags that use the same field for coordinates

this reverts MDL_ROTATING to XYZ for compatibility, and adds a new MDL_FIXROTATING flag to make it use the same coordinate system as MDL_USEROTATIONCENTER so that both flags can be safely combined

fixes #1059

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
