### PR TITLE
support r_visibility on classic lightmode

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_setcolor.cpp
+++ b/src/rendering/hwrenderer/scene/hw_setcolor.cpp
@@ -52,9 +52,11 @@ void SetColor(FRenderState &state, FLevelLocals* Level, ELightMode lightmode, in
 //
 //==========================================================================
 
+EXTERN_CVAR(Float, r_visibility)
+
 void SetShaderLight(FRenderState &state, FLevelLocals* Level, float level, float olight)
 {
-	const float MAXDIST = 256.f;
+	const float MAXDIST = (256.f) * (r_visibility / 8.0f);
 	const float THRESHOLD = 96.f;
 	const float FACTOR = 0.75f;
 


### PR DESCRIPTION
default of 8 will have the same light radius as before, 0 will have no light, and 16 will have double

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
