### PR TITLE
Fix type mismatch assert in serializer code

### DIFF
--- a/src/common/engine/serializer.cpp
+++ b/src/common/engine/serializer.cpp
@@ -1385,7 +1385,7 @@ FSerializer &Serialize(FSerializer &arc, const char *key, FTextureID &value, FTe
 		if (val != nullptr)
 		{
 			if (arc.IsRollback()) {
-				value.SetIndex(val->GetInt64());
+				value.SetIndex(val->GetUint64());
 			} else {
 				if (val->IsArray())
 				{


### PR DESCRIPTION
This is written as uint64, but was being read as int64. Fix that

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
