### PR TITLE
Allow CI to see all git tags in order to fix build pipeline

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -31,12 +31,8 @@ jobs:
     steps:
     - name: Setup
       uses: actions/checkout@v4
-
-    - name: Setup
-      id: ghd
-      uses: proudust/gh-describe@v2
       with:
-        exclude: "nightly"
+        fetch-depth: 0
 
     - name: Setup
       uses: ilammy/msvc-dev-cmd@v1
@@ -73,10 +69,12 @@ jobs:
           -G Ninja
 
     - name: Build
+      id: build
       shell: bash
       run: |
-        export GIT_DESCRIBE="${{ steps.ghd.outputs.describe }}"
-        export MAKEFLAGS=--keep-going
+        export GIT_DESCRIBE="$(git describe --tags --exclude nightly)"
+        echo "This will be $GIT_DESCRIBE"
+        echo "version=$GIT_DESCRIBE" >> "$GITHUB_OUTPUT"
         cmake --build build --config ${{ inputs.build_type }}
 
     - name: Package
@@ -86,7 +84,7 @@ jobs:
 
         cd build
         mkdir package
-        packagename="${{ runner.os }}-${{ runner.arch }}"-UZDoom-"${{ steps.ghd.outputs.describe }}"
+        packagename="${{ runner.os }}-${{ runner.arch }}"-UZDoom-"${{ steps.build.outputs.version }}"
 
         7z a package/licenses.zip ../docs/licenses/*
 
@@ -179,7 +177,7 @@ jobs:
                 https://github.com/AppImageCrafters/appimage-builder/releases/download/v1.1.0/appimage-builder-1.1.0-x86_64.AppImage
             chmod +x appimage-builder
 
-            export GIT_DESCRIBE="${{ steps.ghd.outputs.describe }}"
+            export GIT_DESCRIBE="${{ steps.build.outputs.version }}"
             ./appimage-builder --skip-tests --recipe ../tools/AppImageBuilder.yml
             mv *.AppImage "package/${packagename}.AppImage"
 

--- a/.github/workflows/upload_nightly.yml
+++ b/.github/workflows/upload_nightly.yml
@@ -17,11 +17,10 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@v4
-
-      - id: tag
-        uses: proudust/gh-describe@v2
         with:
-          exclude: "nightly"
+          fetch-depth: 0
+          sparse-checkout: |
+            README.md
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -46,8 +45,10 @@ jobs:
           move "artifacts/MacOS LLVM Release"/*.zip release/MacOS-UZDoom-Nightly.zip
           move "artifacts/Linux LLVM Release"/*.AppImage release/Linux-UZDoom-Nightly.AppImage
 
-      - name: Update Tag
+      - id: tag
+        name: Update Tag
         run: |
+          echo "describe=$(git describe --tags --exclude nightly)" >> "$GITHUB_OUTPUT"
           git tag -d nightly || true
           git push origin :refs/tags/nightly || true
           git tag nightly


### PR DESCRIPTION
Doing a full clone adds about 10s to the build time. Not using the action and just running git-describe ourselves fixes things.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
