### PR TITLE
Fixed missiles not respecting the FF_SHOOTHROUGH flag

### DIFF
--- a/src/playsim/p_3dfloors.cpp
+++ b/src/playsim/p_3dfloors.cpp
@@ -687,7 +687,8 @@ void P_LineOpening_XFloors (FLineOpening &open, AActor * thing, const line_t *li
 			
 			highestfloorpic.SetInvalid();
 			lowestceilingpic.SetInvalid();
-			
+
+			const bool missile = (thing->flags & MF_MISSILE) || (thing->BounceFlags & BOUNCE_MBF);
 			for(int j=0;j<2;j++)
 			{
 				for(unsigned i=0;i<xf[j]->ffloors.Size();i++)
@@ -695,7 +696,7 @@ void P_LineOpening_XFloors (FLineOpening &open, AActor * thing, const line_t *li
 					F3DFloor *rover = xf[j]->ffloors[i];
 
 					if (!(rover->flags & FF_EXISTS)) continue;
-					if (!(rover->flags & FF_SOLID)) continue;
+					if (!(rover->flags & FF_SOLID) || (missile && (rover->flags & FF_SHOOTTHROUGH))) continue;
 					
 					double ff_bottom=rover->bottom.plane->ZatPoint(x, y);
 					double ff_top=rover->top.plane->ZatPoint(x, y);

--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -1804,11 +1804,11 @@ bool P_CheckPosition(AActor *thing, const DVector2 &pos, FCheckPosition &tm, boo
 
 		F3DFloor*  rover;
 		double thingtop = thing->Height > 0 ? thing->Top() : thing->Z() + 1;
-
+		const bool missile = (thing->flags & MF_MISSILE) || (thing->BounceFlags & BOUNCE_MBF);
 		for (unsigned i = 0; i<newsec->e->XFloor.ffloors.Size(); i++)
 		{
 			rover = newsec->e->XFloor.ffloors[i];
-			if (!(rover->flags & FF_SOLID) || !(rover->flags & FF_EXISTS)) continue;
+			if (!(rover->flags & FF_SOLID) || !(rover->flags & FF_EXISTS) || (missile && (rover->flags & FF_SHOOTTHROUGH))) continue;
 
 			double ff_bottom = rover->bottom.plane->ZatPoint(pos);
 			double ff_top = rover->top.plane->ZatPoint(pos);


### PR DESCRIPTION
Hitscans were already allowed to pass through 3D floors marked with these, so allow missiles to do so as well. I'm not sure if this will have any compatibility problems but I simply can't see this being a very useful flag otherwise if it only applies to half the player's arsenal at any given time.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
