### PR TITLE
Cleared Behaviors on the previous pawn when spawning a new one

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -6444,6 +6444,8 @@ AActor *FLevelLocals::SpawnPlayer (FPlayerStart *mthing, int playernum, int flag
 	{ // Remove any inventory left from the old actor. Coop handles
 	  // it above, but the other modes don't.
 		DestroyAllInventory(oldactor);
+		// Clean these up as well, otherwise pointer substitution will break a lot of things.
+		oldactor->ClearBehaviors();
 	}
 	// [BC] Handle temporary invulnerability when respawned
 	if (state == PST_REBORN || state == PST_ENTER)


### PR DESCRIPTION
This is important for traveling as the previous map pawn's Behaviors will accidentally get transferred to the new pawn's via pointer substitution before being destroyed.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
