### PR TITLE
Increase retry delay

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -64,14 +64,14 @@ jobs:
 
         function attempt() {
           echo "$*"
-          local delay=5
+          local delay=10
           local i
-          for i in {1..5}; do
+          for i in {1..4}; do
             # timeout 10m bash -c "$*" && return 0
             perl -e "alarm 600; exec @ARGV" bash -c "$*" && return 0
             echo "Attempt $i failed. Retrying in ${delay}s" >&2
             sleep "${delay}"
-            ((delay*=2))
+            ((delay*=3))
           done
           return 1
         }


### PR DESCRIPTION
Apparently a max delay of around 2 min isn't enough. Upper bound is around 15 min now. (10s, 30s, 90s, 270s, 810s)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.