### PR TITLE
Video mode switching imprivements

### DIFF
--- a/src/common/platform/posix/cocoa/i_video.mm
+++ b/src/common/platform/posix/cocoa/i_video.mm
@@ -364,7 +364,7 @@ class CocoaVideo : public IVideo
 public:
 	CocoaVideo()
 	{
-		ms_isVulkanEnabled = V_GetBackend() == 1 && NSAppKitVersionNumber >= 1404; // NSAppKitVersionNumber10_11
+		ms_isVulkanEnabled = vid_preferbackend == BACKEND_VULKAN && NSAppKitVersionNumber >= 1404; // NSAppKitVersionNumber10_11
 	}
 
 	~CocoaVideo()
@@ -455,7 +455,7 @@ public:
 		if (fb == nullptr)
 		{
 #ifdef HAVE_GLES2
-			if(V_GetBackend() != 0)
+			if(vid_preferbackend != BACKEND_OPENGL)
 				fb = new OpenGLESRenderer::OpenGLFrameBuffer(0, vid_fullscreen);
 			else
 #endif

--- a/src/common/platform/posix/cocoa/i_video.mm
+++ b/src/common/platform/posix/cocoa/i_video.mm
@@ -21,19 +21,17 @@
 **
 */
 
-#include "gl_load.h"
-
 #ifdef HAVE_VULKAN
 #include <zvulkan/vulkanbuilders.h>
 #include <zvulkan/vulkansurface.h>
 #endif
 
-#include "i_common.h"
-
 #include "bitmap.h"
 #include "c_dispatch.h"
 #include "gl_framebuffer.h"
+#include "gl_load.h"
 #include "hardware.h"
+#include "i_common.h"
 #include "i_system.h"
 #include "m_argv.h"
 #include "m_png.h"
@@ -42,13 +40,16 @@
 #include "v_text.h"
 #include "v_video.h"
 #include "version.h"
+
 #ifdef HAVE_GLES2
 #include "gles_framebuffer.h"
 #endif
 
 #ifdef HAVE_VULKAN
 #include "vulkan/system/vk_renderdevice.h"
+#endif
 
+#ifdef HAVE_VULKAN
 bool I_CreateVulkanSurface(VkInstance instance, VkSurfaceKHR *surface);
 #endif
 

--- a/src/common/platform/posix/sdl/gl_sysfb.h
+++ b/src/common/platform/posix/sdl/gl_sysfb.h
@@ -26,6 +26,7 @@
 
 #include <SDL2/SDL.h>
 
+#include "gl_system.h"
 #include "v_video.h"
 
 class SystemBaseFrameBuffer : public DFrameBuffer

--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -334,7 +334,7 @@ SDLVideo::SDLVideo ()
 	}
 
 #ifdef HAVE_VULKAN
-	Priv::vulkanEnabled = V_GetBackend() == 1;
+	Priv::vulkanEnabled = vid_preferbackend == BACKEND_VULKAN;
 
 	if (Priv::vulkanEnabled)
 	{
@@ -416,7 +416,7 @@ DFrameBuffer *SDLVideo::CreateFrameBuffer ()
 	if (fb == nullptr)
 	{
 #ifdef HAVE_GLES2
-		if (V_GetBackend() != 0)
+		if (vid_preferbackend != BACKEND_OPENGL)
 			fb = new OpenGLESRenderer::OpenGLFrameBuffer(0, vid_fullscreen);
 		else
 #endif

--- a/src/common/platform/posix/sdl/sdlglvideo.cpp
+++ b/src/common/platform/posix/sdl/sdlglvideo.cpp
@@ -24,23 +24,26 @@
 
 // HEADER FILES ------------------------------------------------------------
 
-#include "c_console.h"
+#include <SDL2/SDL.h>
+
+#ifdef HAVE_VULKAN
+#include <SDL2/SDL_vulkan.h>
+#include <zvulkan/vulkanbuilders.h>
+#include <zvulkan/vulkandevice.h>
+#include <zvulkan/vulkaninstance.h>
+#include <zvulkan/vulkansurface.h>
+#endif
+
+#include "basics.h"
 #include "c_dispatch.h"
-#include "i_module.h"
+#include "gl_framebuffer.h"
+#include "gl_sysfb.h"
 #include "i_soundinternal.h"
-#include "i_system.h"
 #include "i_video.h"
 #include "m_argv.h"
 #include "printf.h"
 #include "v_video.h"
 #include "version.h"
-
-#include "gl_sysfb.h"
-#include "gl_system.h"
-#include "hardware.h"
-
-#include "gl_framebuffer.h"
-#include "gl_renderer.h"
 
 #ifdef HAVE_GLES2
 #include "gles_framebuffer.h"
@@ -48,17 +51,9 @@
 
 #ifdef HAVE_VULKAN
 #include "vulkan/system/vk_renderdevice.h"
-#include <zvulkan/vulkanbuilders.h>
-#include <zvulkan/vulkandevice.h>
-#include <zvulkan/vulkaninstance.h>
-#include <zvulkan/vulkansurface.h>
 #endif
 
 // MACROS ------------------------------------------------------------------
-
-#if defined HAVE_VULKAN
-#include <SDL2/SDL_vulkan.h>
-#endif // HAVE_VULKAN
 
 // TYPES -------------------------------------------------------------------
 
@@ -67,6 +62,7 @@
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
 
 // EXTERNAL DATA DECLARATIONS ----------------------------------------------
+
 extern IVideo *Video;
 
 EXTERN_CVAR (Int, vid_adapter)

--- a/src/common/platform/win32/hardware.cpp
+++ b/src/common/platform/win32/hardware.cpp
@@ -81,7 +81,7 @@ void I_InitGraphics ()
 	}
 
 #ifdef HAVE_VULKAN
-	if (V_GetBackend() == 1)
+	if (vid_preferbackend == BACKEND_VULKAN)
 	{
 		// first try Vulkan, if that fails OpenGL
 		try

--- a/src/common/platform/win32/win32glvideo.cpp
+++ b/src/common/platform/win32/win32glvideo.cpp
@@ -99,7 +99,7 @@ DFrameBuffer *Win32GLVideo::CreateFrameBuffer()
 	SystemGLFrameBuffer *fb;
 
 #ifdef HAVE_GLES2
-	if (V_GetBackend() != 0)
+	if (vid_preferbackend != BACKEND_OPENGL)
 		fb = new OpenGLESRenderer::OpenGLFrameBuffer(m_hMonitor, vid_fullscreen);
 	else
 #endif

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -95,7 +95,7 @@ enum {
 #endif
 };
 
-CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
 	// [SP] This may seem pointless - but I don't want to implement live switching just
 	// yet - I'm pretty sure it's going to require a lot of reinits and destructions to
@@ -105,10 +105,13 @@ CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALC
 
 	switch(self)
 	{
+	default:
+		if (self < 0) self = NUM_BACKEND-1;
+		else if (self >= NUM_BACKEND) self = 0;
+		else if (prev > self || prev <= 0) self = self-1;
+		else if (prev < self || prev >= NUM_BACKEND-1) self = self+1;
+		return;
 #ifdef HAVE_GLES2
-	case NUM_BACKEND:
-		self = BACKEND_OPENGLES;
-		return; // beware of recursions here. Assigning to 'self' will recursively call this handler again.
 	case BACKEND_OPENGLES:
 		Printf("Selecting OpenGLES 2.0 backend...\n");
 		break;
@@ -118,13 +121,17 @@ CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALC
 		Printf("Selecting Vulkan backend...\n");
 		break;
 #endif
-	default:
+	case BACKEND_OPENGL:
 		Printf("Selecting OpenGL backend...\n");
+		break;
 	}
 
-	Printf("Changing the video backend requires a restart for " GAMENAME ".\n");
+	static bool notice = false;
+	if (notice) Printf("Changing the video backend requires a restart for " GAMENAME ".\n");
+	else notice = true;
 }
 
+// why does this function need to exist? - Marcus
 int V_GetBackend()
 {
 	int v = vid_preferbackend;

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -80,7 +80,16 @@ CUSTOM_CVAR(Int, vid_maxfps, 500, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	}
 }
 
-CUSTOM_CVAR(Int, vid_preferbackend, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
+enum {
+	BACKEND_OPENGL,
+	BACKEND_VULKAN,
+	BACKEND_OPENGLES,
+	NUM_BACKEND,
+
+	BACKEND_DEFAULT = BACKEND_VULKAN,
+};
+
+CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
 {
 	// [SP] This may seem pointless - but I don't want to implement live switching just
 	// yet - I'm pretty sure it's going to require a lot of reinits and destructions to
@@ -89,15 +98,15 @@ CUSTOM_CVAR(Int, vid_preferbackend, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_N
 	switch(self)
 	{
 #ifdef HAVE_GLES2
-	case 3:
-		self = 2;
+	case NUM_BACKEND:
+		self = BACKEND_OPENGLES;
 		return; // beware of recursions here. Assigning to 'self' will recursively call this handler again.
-	case 2:
+	case BACKEND_OPENGLES:
 		Printf("Selecting OpenGLES 2.0 backend...\n");
 		break;
 #endif
 #ifdef HAVE_VULKAN
-	case 1:
+	case BACKEND_VULKAN:
 		Printf("Selecting Vulkan backend...\n");
 		break;
 #endif
@@ -111,8 +120,8 @@ CUSTOM_CVAR(Int, vid_preferbackend, 1, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_N
 int V_GetBackend()
 {
 	int v = vid_preferbackend;
-	if (v == 3) vid_preferbackend = v = 2;
-	else if (v < 0 || v > 3) v = 0;
+	if (v == NUM_BACKEND) vid_preferbackend = v = BACKEND_OPENGLES;
+	else if (v < 0 || v > NUM_BACKEND) v = BACKEND_OPENGL;
 	return v;
 }
 

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -80,21 +80,6 @@ CUSTOM_CVAR(Int, vid_maxfps, 500, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 	}
 }
 
-enum {
-	BACKEND_OPENGL,
-	BACKEND_VULKAN,
-	BACKEND_OPENGLES,
-	NUM_BACKEND,
-
-#if defined(VID_BACKEND)
-	BACKEND_DEFAULT = VID_BACKEND,
-#elif defined(HAVE_VULKAN) and not defined(__APPLE__)
-	BACKEND_DEFAULT = BACKEND_VULKAN,
-#else
-	BACKEND_DEFAULT = BACKEND_OPENGL,
-#endif
-};
-
 CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 {
 	// [SP] This may seem pointless - but I don't want to implement live switching just
@@ -129,15 +114,6 @@ CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALC
 	static bool notice = false;
 	if (notice) Printf("Changing the video backend requires a restart for " GAMENAME ".\n");
 	else notice = true;
-}
-
-// why does this function need to exist? - Marcus
-int V_GetBackend()
-{
-	int v = vid_preferbackend;
-	if (v == NUM_BACKEND) vid_preferbackend = v = BACKEND_OPENGLES;
-	else if (v < 0 || v > NUM_BACKEND) v = BACKEND_OPENGL;
-	return v;
 }
 
 CUSTOM_CVAR(Int, uiscale, 0, CVAR_ARCHIVE | CVAR_NOINITCALL)

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -86,7 +86,13 @@ enum {
 	BACKEND_OPENGLES,
 	NUM_BACKEND,
 
+#if defined(VID_BACKEND)
+	BACKEND_DEFAULT = VID_BACKEND,
+#elif defined(HAVE_VULKAN) and not defined(__APPLE__)
 	BACKEND_DEFAULT = BACKEND_VULKAN,
+#else
+	BACKEND_DEFAULT = BACKEND_OPENGL,
+#endif
 };
 
 CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
@@ -94,6 +100,8 @@ CUSTOM_CVAR(Int, vid_preferbackend, BACKEND_DEFAULT, CVAR_ARCHIVE | CVAR_GLOBALC
 	// [SP] This may seem pointless - but I don't want to implement live switching just
 	// yet - I'm pretty sure it's going to require a lot of reinits and destructions to
 	// do it right without memory leaks
+
+	static_assert(0 <= BACKEND_DEFAULT && BACKEND_DEFAULT < NUM_BACKEND, "default back-end out of range");
 
 	switch(self)
 	{

--- a/src/common/rendering/v_video.cpp
+++ b/src/common/rendering/v_video.cpp
@@ -25,33 +25,20 @@
 
 #include <stdio.h>
 
-#include "i_system.h"
-#include "c_cvars.h"
-#include "x86.h"
-#include "i_video.h"
-
 #include "c_console.h"
-
-#include "m_argv.h"
-
-#include "v_video.h"
-#include "v_text.h"
-#include "sc_man.h"
-
-#include "filesystem.h"
+#include "c_cvars.h"
 #include "c_dispatch.h"
-#include "cmdlib.h"
-#include "hardware.h"
-#include "m_png.h"
-#include "menu.h"
-#include "vm.h"
-#include "r_videoscale.h"
-#include "i_time.h"
-#include "version.h"
-#include "texturemanager.h"
 #include "i_interface.h"
+#include "i_time.h"
+#include "i_video.h"
+#include "m_argv.h"
+#include "printf.h"
 #include "v_draw.h"
-
+#include "v_font.h"
+#include "v_video.h"
+#include "version.h"
+#include "vm.h"
+#include "x86.h"
 
 EXTERN_CVAR(Int, menu_resolution_custom_width)
 EXTERN_CVAR(Int, menu_resolution_custom_height)
@@ -128,7 +115,6 @@ int V_GetBackend()
 	else if (v < 0 || v > 3) v = 0;
 	return v;
 }
-
 
 CUSTOM_CVAR(Int, uiscale, 0, CVAR_ARCHIVE | CVAR_NOINITCALL)
 {

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -65,6 +65,21 @@ enum EHWCaps
 	RFL_DEBUG = 128,
 };
 
+enum {
+	BACKEND_OPENGL,
+	BACKEND_VULKAN,
+	BACKEND_OPENGLES,
+	NUM_BACKEND,
+
+#if defined(VID_BACKEND)
+	BACKEND_DEFAULT = VID_BACKEND,
+#elif defined(HAVE_VULKAN) and not defined(__APPLE__)
+	BACKEND_DEFAULT = BACKEND_VULKAN,
+#else
+	BACKEND_DEFAULT = BACKEND_OPENGL,
+#endif
+};
+
 extern int DisplayWidth, DisplayHeight;
 
 void V_UpdateModeSize (int width, int height);
@@ -292,6 +307,7 @@ extern DFrameBuffer *screen;
 #define SCREENHEIGHT (screen->GetHeight ())
 
 EXTERN_CVAR (Float, vid_gamma)
+EXTERN_CVAR (Int, vid_preferbackend)
 
 // Allocates buffer screens, call before R_Init.
 void V_InitScreenSize();
@@ -301,7 +317,6 @@ void V_InitScreen();
 void V_Init2 ();
 
 void V_Shutdown ();
-int V_GetBackend();
 
 inline bool IsRatioWidescreen(int ratio) { return (ratio & 3) != 0; }
 extern bool setsizeneeded, setmodeneeded;

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -22,22 +22,19 @@
 **
 */
 
-#ifndef __V_VIDEO_H__
-#define __V_VIDEO_H__
+#pragma once
 
 #include <functional>
-#include "basics.h"
-#include "vectors.h"
-#include "m_png.h"
-#include "renderstyle.h"
-#include "c_cvars.h"
-#include "v_2ddrawer.h"
-#include "intrect.h"
-#include "hw_shadowmap.h"
-#include "hw_levelmesh.h"
-#include "buffers.h"
-#include "files.h"
 
+#include "basics.h"
+#include "buffers.h"
+#include "c_cvars.h"
+#include "hw_levelmesh.h"
+#include "hw_shadowmap.h"
+#include "intrect.h"
+#include "m_png.h"
+#include "v_2ddrawer.h"
+#include "vectors.h"
 
 struct FPortalSceneState;
 class FSkyVertexBuffer;
@@ -67,7 +64,6 @@ enum EHWCaps
 	RFL_INVALIDATE_BUFFER = 64,
 	RFL_DEBUG = 128,
 };
-
 
 extern int DisplayWidth, DisplayHeight;
 
@@ -289,7 +285,6 @@ private:
 	bool isIn2D = false;
 };
 
-
 // This is the screen updated by I_FinishUpdate.
 extern DFrameBuffer *screen;
 
@@ -297,7 +292,6 @@ extern DFrameBuffer *screen;
 #define SCREENHEIGHT (screen->GetHeight ())
 
 EXTERN_CVAR (Float, vid_gamma)
-
 
 // Allocates buffer screens, call before R_Init.
 void V_InitScreenSize();
@@ -311,6 +305,3 @@ int V_GetBackend();
 
 inline bool IsRatioWidescreen(int ratio) { return (ratio & 3) != 0; }
 extern bool setsizeneeded, setmodeneeded;
-
-
-#endif // __V_VIDEO_H__


### PR DESCRIPTION
- Video mode selector will now skip unsupported video modes.
- Default video mode on mac is OpenGL until #1116 is resolved
- Added default video mode override for those that may want it

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
