### PR TITLE
Fix CI deprecation warnings

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -40,17 +40,17 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
     - name: Setup MSVC
       if: runner.os == 'Windows' && !contains(inputs.name, 'MinGW')
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@v1 # FIXME: update this
 
     - name: Setup MSYS2
       if: runner.os == 'Windows' && contains(inputs.name, 'MinGW')
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@v2 # FIXME: update this
       with:
         msystem: MINGW64
         update: true
@@ -228,7 +228,7 @@ jobs:
         fi
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: build/package
         name: ${{ inputs.name }} ${{ inputs.build_type }}

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       json_refs: ${{ steps.generate-matrix.outputs.json_refs }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Generate Matrix
@@ -51,13 +51,13 @@ jobs:
       - name: Display zscdoc version
         run: |
           zscdoc --version
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ matrix.ref_info.ref }}
       - name: Document ref
         run: |
           zscdoc -f ./wadsrc/static -o ./output --delete-without-confirm --base-url "/UZDoom/docs/<version>" --target-version '${{ matrix.ref_info.url_part }}' --versions '${{ needs.build_matrix.outputs.json_refs }}' --canonical-domain "https://${{ github.repository_owner }}.github.io"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.ref_info.url_part }}
           path: output
@@ -72,7 +72,7 @@ jobs:
       - build_matrix
       - build
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/configure-pages@v5

--- a/.github/workflows/trigger_pages.yml
+++ b/.github/workflows/trigger_pages.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: gh workflow run pages_deploy.yml --ref trunk

--- a/.github/workflows/upload_nightly.yml
+++ b/.github/workflows/upload_nightly.yml
@@ -16,14 +16,14 @@ jobs:
       contents: write
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           sparse-checkout: |
             README.md
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
@@ -55,7 +55,7 @@ jobs:
           git push origin nightly
 
       - name: Upload
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2 # FIXME: update this
         with:
           name: UZDoom Nightly
           tag_name: nightly


### PR DESCRIPTION
Github is removing node 20 from actions in June. This updates some actions we use to newer versions. There are 3 that don't have update yet, but they all have issues tracking the need for the update. After June these will still work, but be forced to use node 24. I've checked if this introduces any issues, and have not noticed any.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
