### PR TITLE
Fix hardcoded 320x200 bounds check in drawOnLnode for custom Screensize

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -264,3 +264,4 @@ heiko123abc
 Piotr "stared" Migdał
 Francisco Ortega
 Adam Pliszka
+Vortex (vortexdesign)

--- a/src/wi_stuff.cpp
+++ b/src/wi_stuff.cpp
@@ -267,7 +267,7 @@ private:
 			right += left;
 			bottom += top;
 
-			if (left >= 0 && right < 320 && top >= 0 && bottom < 200)
+			if (left >= 0 && right < backwidth && top >= 0 && bottom < backheight)
 			{
 				DrawTexture(twod, tex, lnodes[n].x, lnodes[n].y, DTA_FullscreenScale, FSMode_ScaleToFit43, DTA_VirtualWidthF, backwidth, DTA_VirtualHeightF, backheight, TAG_DONE);
 				break;


### PR DESCRIPTION
## Bug

The `drawOnLnode` function in `wi_stuff.cpp` checks whether splats and "You Are Here" pointers fit within the screen bounds before drawing them. However, the bounds check on line 270 is hardcoded to `320x200`:
```cpp
if (left >= 0 && right < 320 && top >= 0 && bottom < 200)
```

This means any spots defined at coordinates beyond 320x200 are silently skipped, even when the intermission script uses `Screensize` to define a larger virtual canvas (e.g. 640x400). The `backwidth` and `backheight` parameters are already passed into the function and correctly used in the `DrawTexture` call, but the bounds check ignores them.

## Fix

Replace the hardcoded `320` and `200` with `backwidth` and `backheight`:
```cpp
if (left >= 0 && right < backwidth && top >= 0 && bottom < backheight)
```

## Testing

Built UZDoom locally with and without the fix using a test pk3 with a 640x400 intermission background and spots placed beyond 320x200:

- **Without fix, 640x400 coords**: Splats and pointer do not render (bug confirmed)
- **Without fix, halved coords (320x200)**: Pointer renders correctly (workaround confirmed)
- **With fix, 640x400 coords**: Pointer renders correctly
- **With fix, 640x400 coords + visited maps**: Both splats and pointer render correctly

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
