### PR TITLE
Add id24's MinRespawnTics and RespawnDice

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -265,3 +265,4 @@ Piotr "stared" Migdał
 Francisco Ortega
 Adam Pliszka
 Vortex (vortexdesign)
+RageSpark

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -1376,6 +1376,9 @@ public:
 	int RipLevelMin;
 	int RipLevelMax;
 
+	int MinRespawnTics; // id24 Minimal Nightmare respawn time
+	int RespawnDice; // id24
+
 	int ConversationRoot;				// THe root of the current dialogue
 	FStrifeDialogueNode* Conversation;	// [RH] The dialogue to show when this actor is "used."
 

--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -402,7 +402,9 @@ void AActor::Serialize(FSerializer &arc)
 		("morphexitflash", MorphExitFlash)
 		("damagesource", damagesource)
 		("behaviors", Behaviors)
-		A("decalgenerator", DecalGenerator);
+		A("decalgenerator", DecalGenerator)
+		A("minrespawntics", MinRespawnTics)
+		A("respawndice", RespawnDice);
 
 		SerializeTerrain(arc, "floorterrain", floorterrain, &def->floorterrain);
 		SerializeArgs(arc, "args", args, def->args, special);
@@ -5113,6 +5115,12 @@ void AActor::Tick ()
 	if (tics == -1 || state->GetCanRaise())
 	{
 		int respawn_monsters = G_SkillProperty(SKILLP_Respawn);
+
+		if (MinRespawnTics > 0)
+			respawn_monsters = MinRespawnTics;
+		else if (MinRespawnTics < 0)
+			respawn_monsters = -MinRespawnTics * TICRATE;
+
 		// check for nightmare respawn
 		if (!(flags5 & MF5_ALWAYSRESPAWN))
 		{
@@ -5132,7 +5140,7 @@ void AActor::Tick ()
 		if (Level->time & 31)
 			return;
 
-		if (pr_nightmarerespawn() > 4)
+		if (pr_nightmarerespawn() > RespawnDice)
 			return;
 
 		P_NightmareRespawn (this);

--- a/src/scripting/vmthunks_actors.cpp
+++ b/src/scripting/vmthunks_actors.cpp
@@ -2078,6 +2078,8 @@ DEFINE_FIELD(AActor, PoisonDamageTypeReceived)
 DEFINE_FIELD(AActor, PoisonDurationReceived)
 DEFINE_FIELD(AActor, PoisonPeriodReceived)
 DEFINE_FIELD(AActor, Poisoner)
+DEFINE_FIELD(AActor, MinRespawnTics)
+DEFINE_FIELD(AActor, RespawnDice)
 DEFINE_FIELD_NAMED(AActor, Inventory, Inv)		// clashes with type 'Inventory'.
 DEFINE_FIELD(AActor, smokecounter)
 DEFINE_FIELD(AActor, FriendPlayer)

--- a/wadsrc/static/zscript/actors/actor.zs
+++ b/wadsrc/static/zscript/actors/actor.zs
@@ -313,6 +313,9 @@ class Actor : Thinker native
 	native int PoisonDurationReceived;
 	native int PoisonPeriodReceived;
 	native Actor Poisoner;
+	native int MinRespawnTics;
+	native int RespawnDice;
+
 	native Inventory Inv;
 	native uint8 smokecounter;
 	native uint8 FriendPlayer;
@@ -470,6 +473,8 @@ class Actor : Thinker native
 	property ShadowPenaltyFactor: ShadowPenaltyFactor;
 	property AutomapOffsets : AutomapOffsets;
 	property LandingSpeed: LandingSpeed;
+	property MinRespawnTics: MinRespawnTics;
+	property RespawnDice: RespawnDice;
 
 	// need some definition work first
 	//FRenderStyle RenderStyle;
@@ -561,6 +566,8 @@ class Actor : Thinker native
 		RenderRequired 0;
 		FriendlySeeBlocks 10; // 10 (blocks) * 128 (one map unit block)
 		LandingSpeed -8; // landing speed from a jump with normal gravity (squats the player's view)
+		MinRespawnTics 0; //0 is default value defined in SKILLP_Respawn, negative is seconds
+		RespawnDice 4;
 	}
 
 	// Functions

--- a/wadsrc/static/zscript/actors/doom/id24/id24tyrant.zs
+++ b/wadsrc/static/zscript/actors/doom/id24/id24tyrant.zs
@@ -78,14 +78,12 @@ class ID24Tyrant : Cyberdemon
 // minimum instead of the default 12, so Nightmare
 // sucks a bit less ;)
 
-// (this id24 feature isn't implemented yet!)
-
 class ID24TyrantBoss1 : ID24Tyrant
 {
 	Default
 	{
-		// RespawnTics 2100;
-		// RespawnDice 64;
+		MinRespawnTics 2100;
+		RespawnDice 64;
 	}
 }
 
@@ -93,7 +91,7 @@ class ID24TyrantBoss2 : ID24Tyrant
 {
 	Default
 	{
-		// RespawnTics 2100;
-		// RespawnDice 64;
+		MinRespawnTics 2100;
+		RespawnDice 64;
 	}
 }


### PR DESCRIPTION
The default value of 0 uses the RespawnTime defined in the Skill Definition. Negative values are interpreted as seconds.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
