### PR TITLE
Set SHARE_DIR to a subdirectory of CMAKE_INSTALL_PREFIX by default

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1310,6 +1310,13 @@ if(BUILD_FLATPAK)
 	target_compile_definitions(zdoom PRIVATE IS_FLATPAK=1)
 endif()
 
+# Set SHARE_DIR to a subdirectory of the cmake install prefix, rather than hardcoding
+if(UNIX AND NOT APPLE)
+  set(SHARE_DIR "\"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}\"")
+  target_compile_definitions(zdoom PRIVATE SHARE_DIR=${SHARE_DIR})
+  message(STATUS "Set SHARE_DIR to ${SHARE_DIR}")
+endif()
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "SunOS")
 	# [BL] Solaris requires these to be explicitly linked.
 	set( PROJECT_LIBRARIES ${PROJECT_LIBRARIES} nsl socket)


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Currently on Linux, the `uzdoom.pk3` (and other supplementary files) is installed to a subdirectory of the `CMAKE_INSTALL_PREFIX`, which is correct behaviour. However, the default lookup paths added to a freshly-generated `uzdoom.ini` only include the hardcoded `DEFAULT_SHARE_DIR` of `/usr/local/share`.

As such, if the `CMAKE_INSTALL_PREFIX` is not `/usr/`, the correct path will not be added to a new default `uzdoom.ini` and uzdoom will fail to start as it isn't checking the correct path for `uzdoom.pk3`.

This is e.g. the case when building uzdoom into a Flatpak, where the `CMAKE_INSTALL_PREFIX` is `/app/` - so `uzdoom.pk3` correctly ends up in `/app/share/games/uzdoom/`, but a newly-generated config tries to look for it in `/usr/local/share/games/uzdoom/`.

This fixes this by simply setting the `SHARE_PATH` macro to the `share` directory below the `CMAKE_INSTALL_PREFIX`.

The only thing I am unsure about here is how this will behave on non-Linux Unixes. It *should* be fine since it just uses a standard CMake path and will leave `SHARE_DIR` untouched if not compiling via CMake but I don't really have much of a way to test it.

This will retain the default hardcoded `SHARE_DIR` of `/usr/local/share/` when generating new `uzdoom.ini` files but also add the one inside the `CMAKE_INSTALL_PREFIX` to the defaults. Fully replacing this with the CMake prefix would be cleaner; however doing so would need some more changes to how the default lookup paths are generated in `src/gameconfigfile.cpp` which currently forces `/usr/local/share/` to be included via the `DEFAULT_SHARE_DIR` macro.