### PR TITLE
PP Expansion - Weapon & UI

### DIFF
--- a/src/common/rendering/gl/gl_framebuffer.cpp
+++ b/src/common/rendering/gl/gl_framebuffer.cpp
@@ -49,6 +49,7 @@
 
 #include "flatvertices.h"
 #include "hw_cvars.h"
+#include "hwrenderer/postprocessing/hw_postprocess.h"
 
 EXTERN_CVAR (Bool, vid_vsync)
 EXTERN_CVAR(Int, gl_tonemap)
@@ -540,11 +541,30 @@ TArray<uint8_t> OpenGLFrameBuffer::GetScreenshotBuffer(int &pitch, ESSType &colo
 
 void OpenGLFrameBuffer::Draw2D()
 {
-	if (GLRenderer != nullptr)
+	if (GLRenderer == nullptr)
+		return;
+
+	if (hw_postprocess.customShaders.HasUIShaders())
+	{
+		GLRenderer->RunUILayerPostProcess([this]() { ::Draw2D(twod, gl_RenderState); });
+	}
+	else
 	{
 		GLRenderer->mBuffers->BindCurrentFB();
 		::Draw2D(twod, gl_RenderState);
 	}
+}
+
+void OpenGLFrameBuffer::FlushGameUI()
+{
+	if (GLRenderer == nullptr) return;
+	if (!hw_postprocess.customShaders.HasUIShaders()) return;
+	if (!GLRenderer->mSceneRenderedThisFrame) return;
+
+	twod->End();
+	Draw2D();
+	twod->Clear();
+	twod->Begin(GetWidth(), GetHeight());
 }
 
 void OpenGLFrameBuffer::PostProcessScene(bool swscene, int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D)

--- a/src/common/rendering/gl/gl_framebuffer.h
+++ b/src/common/rendering/gl/gl_framebuffer.h
@@ -86,6 +86,7 @@ public:
 	void SetVSync(bool vsync) override;
 
 	void Draw2D() override;
+	void FlushGameUI() override;
 	void PostProcessScene(bool swscene, int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D) override;
 
 	bool HWGammaActive = false;			// Are we using hardware or software gamma?

--- a/src/common/rendering/gl/gl_postprocess.cpp
+++ b/src/common/rendering/gl/gl_postprocess.cpp
@@ -68,8 +68,18 @@ void FGLRenderer::PostProcessScene(int fixedcm, float flash, const std::function
 	renderstate.TimeGame = static_cast<float>(primaryLevel->LocalWorldTimer / (double)GameTicRate);
 
 	hw_postprocess.Pass1(&renderstate, fixedcm, sceneWidth, sceneHeight);
-	mBuffers->BindCurrentFB();
-	if (afterBloomDrawEndScene2D) afterBloomDrawEndScene2D();
+	if (hw_postprocess.customShaders.HasWeaponShaders())
+	{
+		auto *weaponTex = hw_postprocess.customShaders.GetWeaponLayerTexture(mBuffers->GetWidth(), mBuffers->GetHeight());
+		renderstate.BindWeaponLayerFB(weaponTex);
+		if (afterBloomDrawEndScene2D) afterBloomDrawEndScene2D();
+		hw_postprocess.customShaders.RunWeapon(&renderstate);
+	}
+	else
+	{
+		mBuffers->BindCurrentFB();
+		if (afterBloomDrawEndScene2D) afterBloomDrawEndScene2D();
+	}
 	hw_postprocess.Pass2(&renderstate, fixedcm, flash, sceneWidth, sceneHeight);
 }
 

--- a/src/common/rendering/gl/gl_postprocess.cpp
+++ b/src/common/rendering/gl/gl_postprocess.cpp
@@ -68,7 +68,7 @@ void FGLRenderer::PostProcessScene(int fixedcm, float flash, const std::function
 	renderstate.TimeGame = static_cast<float>(primaryLevel->LocalWorldTimer / (double)GameTicRate);
 
 	hw_postprocess.Pass1(&renderstate, fixedcm, sceneWidth, sceneHeight);
-	if (hw_postprocess.customShaders.HasWeaponShaders())
+	if (hw_postprocess.customShaders.HasWeaponShaders() || hw_postprocess.customShaders.HasUIShaders())
 	{
 		auto *weaponTex = hw_postprocess.customShaders.GetWeaponLayerTexture(mBuffers->GetWidth(), mBuffers->GetHeight());
 		renderstate.BindWeaponLayerFB(weaponTex);
@@ -81,6 +81,29 @@ void FGLRenderer::PostProcessScene(int fixedcm, float flash, const std::function
 		if (afterBloomDrawEndScene2D) afterBloomDrawEndScene2D();
 	}
 	hw_postprocess.Pass2(&renderstate, fixedcm, flash, sceneWidth, sceneHeight);
+	mSceneRenderedThisFrame = true;
+}
+
+void FGLRenderer::RunUILayerPostProcess(const std::function<void()> &draw2D)
+{
+	if (!mSceneRenderedThisFrame)
+	{
+		mBuffers->BindCurrentFB();
+		draw2D();
+		return;
+	}
+	mSceneRenderedThisFrame = false;
+
+	GLPPRenderState renderstate(mBuffers);
+
+	renderstate.TimeDelta = static_cast<float>(GetDeltaTime());
+	renderstate.Time = static_cast<float>(screen->FrameTime / 1000.0);
+	renderstate.TimeGame = static_cast<float>(primaryLevel->LocalWorldTimer / (double)GameTicRate);
+
+	auto *uiTex = hw_postprocess.customShaders.GetUILayerTexture(mBuffers->GetWidth(), mBuffers->GetHeight());
+	renderstate.BindUILayerFB(uiTex);
+	draw2D();
+	hw_postprocess.customShaders.RunUI(&renderstate);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/common/rendering/gl/gl_renderbuffers.cpp
+++ b/src/common/rendering/gl/gl_renderbuffers.cpp
@@ -1000,6 +1000,17 @@ void GLPPRenderState::CopyToTexture(PPTexture* dst)
 	glBindTexture(GL_TEXTURE_2D, 0);
 }
 
+void GLPPRenderState::BindWeaponLayerFB(PPTexture *weapon)
+{
+	PPGLTextureBackend *backend = GetGLTexture(weapon);
+	if (!backend->FB)
+		backend->FB = buffers->CreateFrameBuffer("WeaponLayerFB", backend->Tex);
+	backend->FB.Bind();
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	glViewport(screen->mScreenViewport.left, screen->mScreenViewport.top, screen->mScreenViewport.width, screen->mScreenViewport.height);
+}
+
 void GLPPRenderState::PushGroup(const FString &name)
 {
 	FGLDebug::PushGroup(name.GetChars());

--- a/src/common/rendering/gl/gl_renderbuffers.cpp
+++ b/src/common/rendering/gl/gl_renderbuffers.cpp
@@ -1011,6 +1011,17 @@ void GLPPRenderState::BindWeaponLayerFB(PPTexture *weapon)
 	glViewport(screen->mScreenViewport.left, screen->mScreenViewport.top, screen->mScreenViewport.width, screen->mScreenViewport.height);
 }
 
+void GLPPRenderState::BindUILayerFB(PPTexture *ui)
+{
+	PPGLTextureBackend *backend = GetGLTexture(ui);
+	if (!backend->FB)
+		backend->FB = buffers->CreateFrameBuffer("UILayerFB", backend->Tex);
+	backend->FB.Bind();
+	glClearColor(0.0f, 0.0f, 0.0f, 0.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+	glViewport(screen->mScreenViewport.left, screen->mScreenViewport.top, screen->mScreenViewport.width, screen->mScreenViewport.height);
+}
+
 void GLPPRenderState::PushGroup(const FString &name)
 {
 	FGLDebug::PushGroup(name.GetChars());

--- a/src/common/rendering/gl/gl_renderbuffers.h
+++ b/src/common/rendering/gl/gl_renderbuffers.h
@@ -116,6 +116,7 @@ public:
 	void Draw() override;
 	void CopyToTexture(PPTexture* dst) override;
 	void BindWeaponLayerFB(PPTexture *weapon);
+	void BindUILayerFB(PPTexture *ui);
 
 private:
 	PPGLTextureBackend *GetGLTexture(PPTexture *texture);

--- a/src/common/rendering/gl/gl_renderbuffers.h
+++ b/src/common/rendering/gl/gl_renderbuffers.h
@@ -115,6 +115,7 @@ public:
 	void PopGroup() override;
 	void Draw() override;
 	void CopyToTexture(PPTexture* dst) override;
+	void BindWeaponLayerFB(PPTexture *weapon);
 
 private:
 	PPGLTextureBackend *GetGLTexture(PPTexture *texture);

--- a/src/common/rendering/gl/gl_renderer.h
+++ b/src/common/rendering/gl/gl_renderer.h
@@ -86,6 +86,8 @@ public:
 
 	int mLightMapID = 0;
 
+	bool mSceneRenderedThisFrame = false;
+
 	//FRotator mAngles;
 
 	FGLRenderer(OpenGLFrameBuffer *fb);
@@ -98,6 +100,7 @@ public:
 	void PresentStereo();
 	void RenderScreenQuad();
 	void PostProcessScene(int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D);
+	void RunUILayerPostProcess(const std::function<void()> &draw2D);
 	void AmbientOccludeScene(float m5);
 	void ClearTonemapPalette();
 	void BlurScene(float gameinfobluramount);

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
@@ -945,6 +945,75 @@ void PPCustomShaders::UpdateLastInputTexture(PPRenderState *renderstate)
 	mLastInputTexture->Swap();
 }
 
+bool PPCustomShaders::HasUIShaders() const
+{
+	if (!gl_custompost)
+		return false;
+	for (unsigned int i = 0; i < PostProcessShaders.Size(); i++)
+		if (PostProcessShaders[i].Target == FString("ui") && PostProcessShaders[i].Enabled)
+			return true;
+	return false;
+}
+
+PPTexture *PPCustomShaders::GetUILayerTexture(int width, int height)
+{
+	UpdateUITextures(width, height);
+	return &mUIHistory[mUIHistoryIndex];
+}
+
+void PPCustomShaders::UpdateUITextures(int width, int height)
+{
+	if (mUITexWidth != width || mUITexHeight != height)
+	{
+		mUITextures[0] = PPTexture(width, height, PixelFormat::Rgba16f);
+		mUITextures[1] = PPTexture(width, height, PixelFormat::Rgba16f);
+		mUIHistory[0]  = PPTexture(width, height, PixelFormat::Rgba16f);
+		mUIHistory[1]  = PPTexture(width, height, PixelFormat::Rgba16f);
+		mUITexWidth = width;
+		mUITexHeight = height;
+	}
+}
+
+void PPCustomShaders::RunUI(PPRenderState *renderstate)
+{
+	if (!gl_custompost)
+		return;
+
+	CreateShaders();
+
+	mUIInputPtr = &mUIHistory[mUIHistoryIndex];
+	mUILastPtr  = &mUIHistory[1 - mUIHistoryIndex];
+
+	PPTexture *current = mUIInputPtr;
+	int pingpong = 0;
+
+	for (auto &shader : mShaders)
+	{
+		if (shader->Desc->Target == FString("ui") && shader->Desc->Enabled)
+		{
+			shader->RunWithUITextures(renderstate, current, &mUITextures[pingpong]);
+			current = &mUITextures[pingpong];
+			pingpong = 1 - pingpong;
+		}
+	}
+
+	if (current != &mUIHistory[mUIHistoryIndex])
+		std::swap(mUIHistory[mUIHistoryIndex].Backend, current->Backend);
+
+	mUIInputPtr = &mUIHistory[mUIHistoryIndex];
+
+	renderstate->Clear();
+	renderstate->Shader = &mUICompositeShader;
+	renderstate->Viewport = screen->mScreenViewport;
+	renderstate->SetInputCurrent(0, PPFilterMode::Linear);
+	renderstate->SetInputTexture(1, mUIInputPtr, PPFilterMode::Linear);
+	renderstate->SetOutputNext();
+	renderstate->SetNoBlend();
+	renderstate->Draw();
+
+	mUIHistoryIndex = 1 - mUIHistoryIndex;
+}
+
 bool PPCustomShaders::HasWeaponShaders() const
 {
 	if (!gl_custompost)
@@ -997,8 +1066,6 @@ void PPCustomShaders::RunWeapon(PPRenderState *renderstate)
 		}
 	}
 
-	// Swap the processed result into the history slot so WeaponLastTexture
-	// next frame holds the shader output rather than the raw weapon render.
 	if (current != &mWeaponHistory[mWeaponHistoryIndex])
 		std::swap(mWeaponHistory[mWeaponHistoryIndex].Backend, current->Backend);
 
@@ -1025,14 +1092,14 @@ void PPCustomShaders::CreateShaders()
 
 	for (unsigned int i = 0; i < PostProcessShaders.Size(); i++)
 	{
-		mShaders.push_back(std::make_unique<PPCustomShaderInstance>(&PostProcessShaders[i], &mLastInputTexture, &mWeaponInputPtr, &mWeaponLastPtr));
+		mShaders.push_back(std::make_unique<PPCustomShaderInstance>(&PostProcessShaders[i], &mLastInputTexture, &mWeaponInputPtr, &mWeaponLastPtr, &mUIInputPtr, &mUILastPtr));
 	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture)
-	: Desc(desc), LastInputTexture(lastInputTexture), WeaponInputTexture(weaponInputTexture), WeaponLastTexture(weaponLastTexture)
+PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture, PPTexture **uiInputTexture, PPTexture **uiLastTexture)
+	: Desc(desc), LastInputTexture(lastInputTexture), WeaponInputTexture(weaponInputTexture), WeaponLastTexture(weaponLastTexture), UIInputTexture(uiInputTexture), UILastTexture(uiLastTexture)
 {
 	// Build an uniform block to be used as input
 	TMap<FString, PostProcessUniformValue>::Iterator it(Desc->Uniforms);
@@ -1086,6 +1153,10 @@ PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::uni
 	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D WeaponTexture;\n", WeaponInputTextureBinding);
 	WeaponLastTextureBinding = binding++;
 	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D WeaponLastTexture;\n", WeaponLastTextureBinding);
+	UIInputTextureBinding = binding++;
+	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D UITexture;\n", UIInputTextureBinding);
+	UILastTextureBinding = binding++;
+	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D UILastTexture;\n", UILastTextureBinding);
 
 	FString prolog;
 	prolog += uniformTextures;
@@ -1125,10 +1196,28 @@ void PPCustomShaderInstance::RunWithTextures(PPRenderState *renderstate, PPTextu
 	renderstate->SetOutputTexture(out);
 
 	SetTextures(renderstate);
-	// Override WeaponTexture with the ping-pong input so each chained shader
-	// processes the previous shader's output rather than the original render.
 	if (WeaponInputTextureBinding >= 0)
 		renderstate->SetInputTexture(WeaponInputTextureBinding, in, PPFilterMode::Linear);
+	SetUniforms(renderstate);
+
+	renderstate->Draw();
+
+	renderstate->PopGroup();
+}
+
+void PPCustomShaderInstance::RunWithUITextures(PPRenderState *renderstate, PPTexture *in, PPTexture *out)
+{
+	renderstate->PushGroup(Desc->Name);
+
+	renderstate->Clear();
+	renderstate->Shader = &Shader;
+	renderstate->Viewport = screen->mScreenViewport;
+	renderstate->SetNoBlend();
+	renderstate->SetOutputTexture(out);
+
+	SetTextures(renderstate);
+	if (UIInputTextureBinding >= 0)
+		renderstate->SetInputTexture(UIInputTextureBinding, in, PPFilterMode::Linear);
 	SetUniforms(renderstate);
 
 	renderstate->Draw();
@@ -1193,6 +1282,12 @@ void PPCustomShaderInstance::SetTextures(PPRenderState *renderstate)
 
 	if (WeaponLastTexture && *WeaponLastTexture && WeaponLastTextureBinding >= 0 && (*WeaponLastTexture)->Backend)
 		renderstate->SetInputTexture(WeaponLastTextureBinding, *WeaponLastTexture, PPFilterMode::Linear, PPWrapMode::Clamp);
+
+	if (UIInputTexture && *UIInputTexture && UIInputTextureBinding >= 0 && (*UIInputTexture)->Backend)
+		renderstate->SetInputTexture(UIInputTextureBinding, *UIInputTexture, PPFilterMode::Linear, PPWrapMode::Clamp);
+
+	if (UILastTexture && *UILastTexture && UILastTextureBinding >= 0 && (*UILastTexture)->Backend)
+		renderstate->SetInputTexture(UILastTextureBinding, *UILastTexture, PPFilterMode::Linear, PPWrapMode::Clamp);
 }
 
 void PPCustomShaderInstance::SetUniforms(PPRenderState *renderstate)

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.cpp
@@ -945,6 +945,77 @@ void PPCustomShaders::UpdateLastInputTexture(PPRenderState *renderstate)
 	mLastInputTexture->Swap();
 }
 
+bool PPCustomShaders::HasWeaponShaders() const
+{
+	if (!gl_custompost)
+		return false;
+	for (unsigned int i = 0; i < PostProcessShaders.Size(); i++)
+		if (PostProcessShaders[i].Target == FString("weapon") && PostProcessShaders[i].Enabled)
+			return true;
+	return false;
+}
+
+PPTexture *PPCustomShaders::GetWeaponLayerTexture(int width, int height)
+{
+	UpdateWeaponTextures(width, height);
+	return &mWeaponHistory[mWeaponHistoryIndex];
+}
+
+void PPCustomShaders::UpdateWeaponTextures(int width, int height)
+{
+	if (mWeaponTexWidth != width || mWeaponTexHeight != height)
+	{
+		mWeaponTextures[0] = PPTexture(width, height, PixelFormat::Rgba16f);
+		mWeaponTextures[1] = PPTexture(width, height, PixelFormat::Rgba16f);
+		mWeaponHistory[0]  = PPTexture(width, height, PixelFormat::Rgba16f);
+		mWeaponHistory[1]  = PPTexture(width, height, PixelFormat::Rgba16f);
+		mWeaponTexWidth = width;
+		mWeaponTexHeight = height;
+	}
+}
+
+void PPCustomShaders::RunWeapon(PPRenderState *renderstate)
+{
+	if (!gl_custompost)
+		return;
+
+	CreateShaders();
+
+	mWeaponInputPtr = &mWeaponHistory[mWeaponHistoryIndex];
+	mWeaponLastPtr  = &mWeaponHistory[1 - mWeaponHistoryIndex];
+
+	PPTexture *current = mWeaponInputPtr;
+	int pingpong = 0;
+
+	for (auto &shader : mShaders)
+	{
+		if (shader->Desc->Target == FString("weapon") && shader->Desc->Enabled)
+		{
+			shader->RunWithTextures(renderstate, current, &mWeaponTextures[pingpong]);
+			current = &mWeaponTextures[pingpong];
+			pingpong = 1 - pingpong;
+		}
+	}
+
+	// Swap the processed result into the history slot so WeaponLastTexture
+	// next frame holds the shader output rather than the raw weapon render.
+	if (current != &mWeaponHistory[mWeaponHistoryIndex])
+		std::swap(mWeaponHistory[mWeaponHistoryIndex].Backend, current->Backend);
+
+	mWeaponInputPtr = &mWeaponHistory[mWeaponHistoryIndex];
+
+	renderstate->Clear();
+	renderstate->Shader = &mWeaponCompositeShader;
+	renderstate->Viewport = screen->mScreenViewport;
+	renderstate->SetInputCurrent(0, PPFilterMode::Linear);
+	renderstate->SetInputTexture(1, mWeaponInputPtr, PPFilterMode::Linear);
+	renderstate->SetOutputNext();
+	renderstate->SetNoBlend();
+	renderstate->Draw();
+
+	mWeaponHistoryIndex = 1 - mWeaponHistoryIndex;
+}
+
 void PPCustomShaders::CreateShaders()
 {
 	if (mShaders.size() == PostProcessShaders.Size())
@@ -954,13 +1025,14 @@ void PPCustomShaders::CreateShaders()
 
 	for (unsigned int i = 0; i < PostProcessShaders.Size(); i++)
 	{
-		mShaders.push_back(std::make_unique<PPCustomShaderInstance>(&PostProcessShaders[i], &mLastInputTexture));
+		mShaders.push_back(std::make_unique<PPCustomShaderInstance>(&PostProcessShaders[i], &mLastInputTexture, &mWeaponInputPtr, &mWeaponLastPtr));
 	}
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
-PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture) : Desc(desc), LastInputTexture(lastInputTexture)
+PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture)
+	: Desc(desc), LastInputTexture(lastInputTexture), WeaponInputTexture(weaponInputTexture), WeaponLastTexture(weaponLastTexture)
 {
 	// Build an uniform block to be used as input
 	TMap<FString, PostProcessUniformValue>::Iterator it(Desc->Uniforms);
@@ -1008,8 +1080,12 @@ PPCustomShaderInstance::PPCustomShaderInstance(PostProcessShader *desc, std::uni
 		pipelineInOut += "out vec4 FragColor;\n";
 	}
 
-	LastInputTextureBinding = binding;
+	LastInputTextureBinding = binding++;
 	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D LastInputTexture;\n", LastInputTextureBinding);
+	WeaponInputTextureBinding = binding++;
+	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D WeaponTexture;\n", WeaponInputTextureBinding);
+	WeaponLastTextureBinding = binding++;
+	uniformTextures.AppendFormat("layout(binding=%d) uniform sampler2D WeaponLastTexture;\n", WeaponLastTextureBinding);
 
 	FString prolog;
 	prolog += uniformTextures;
@@ -1031,6 +1107,28 @@ void PPCustomShaderInstance::Run(PPRenderState *renderstate)
 	//renderstate->SetDebugName(Desc->ShaderLumpName.GetChars());
 
 	SetTextures(renderstate);
+	SetUniforms(renderstate);
+
+	renderstate->Draw();
+
+	renderstate->PopGroup();
+}
+
+void PPCustomShaderInstance::RunWithTextures(PPRenderState *renderstate, PPTexture *in, PPTexture *out)
+{
+	renderstate->PushGroup(Desc->Name);
+
+	renderstate->Clear();
+	renderstate->Shader = &Shader;
+	renderstate->Viewport = screen->mScreenViewport;
+	renderstate->SetNoBlend();
+	renderstate->SetOutputTexture(out);
+
+	SetTextures(renderstate);
+	// Override WeaponTexture with the ping-pong input so each chained shader
+	// processes the previous shader's output rather than the original render.
+	if (WeaponInputTextureBinding >= 0)
+		renderstate->SetInputTexture(WeaponInputTextureBinding, in, PPFilterMode::Linear);
 	SetUniforms(renderstate);
 
 	renderstate->Draw();
@@ -1087,10 +1185,14 @@ void PPCustomShaderInstance::SetTextures(PPRenderState *renderstate)
 	{
 		auto texture = (*LastInputTexture)->GetRead();
 		if (texture->Backend)
-		{
 			renderstate->SetInputTexture(LastInputTextureBinding, texture, PPFilterMode::Linear, PPWrapMode::Clamp);
-		}
 	}
+
+	if (WeaponInputTexture && *WeaponInputTexture && WeaponInputTextureBinding >= 0 && (*WeaponInputTexture)->Backend)
+		renderstate->SetInputTexture(WeaponInputTextureBinding, *WeaponInputTexture, PPFilterMode::Linear, PPWrapMode::Clamp);
+
+	if (WeaponLastTexture && *WeaponLastTexture && WeaponLastTextureBinding >= 0 && (*WeaponLastTexture)->Backend)
+		renderstate->SetInputTexture(WeaponLastTextureBinding, *WeaponLastTexture, PPFilterMode::Linear, PPWrapMode::Clamp);
 }
 
 void PPCustomShaderInstance::SetUniforms(PPRenderState *renderstate)

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
@@ -830,10 +830,11 @@ private:
 class PPCustomShaderInstance
 {
 public:
-	PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture);
+	PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture, PPTexture **uiInputTexture, PPTexture **uiLastTexture);
 
 	void Run(PPRenderState *renderstate);
 	void RunWithTextures(PPRenderState *renderstate, PPTexture *in, PPTexture *out);
+	void RunWithUITextures(PPRenderState *renderstate, PPTexture *in, PPTexture *out);
 
 	PostProcessShader *Desc = nullptr;
 
@@ -856,6 +857,11 @@ private:
 	int WeaponInputTextureBinding = -1;
 	PPTexture **WeaponLastTexture;
 	int WeaponLastTextureBinding = -1;
+
+	PPTexture **UIInputTexture;
+	int UIInputTextureBinding = -1;
+	PPTexture **UILastTexture;
+	int UILastTextureBinding = -1;
 };
 
 class PPCustomShaders
@@ -868,9 +874,14 @@ public:
 	PPTexture *GetWeaponLayerTexture(int width, int height);
 	void RunWeapon(PPRenderState *renderstate);
 
+	bool HasUIShaders() const;
+	PPTexture *GetUILayerTexture(int width, int height);
+	void RunUI(PPRenderState *renderstate);
+
 private:
 	void CreateShaders();
 	void UpdateWeaponTextures(int width, int height);
+	void UpdateUITextures(int width, int height);
 
 	std::vector<std::unique_ptr<PPCustomShaderInstance>> mShaders;
 	std::unique_ptr<PPPersistentBuffer> mLastInputTexture;
@@ -885,6 +896,15 @@ private:
 	int mWeaponTexWidth = 0;
 	int mWeaponTexHeight = 0;
 	PPShader mWeaponCompositeShader = { "shaders/pp/weaponlayer.fp", "", {} };
+
+	PPTexture mUITextures[2];
+	PPTexture mUIHistory[2];
+	int mUIHistoryIndex = 0;
+	PPTexture *mUIInputPtr = nullptr;
+	PPTexture *mUILastPtr = nullptr;
+	int mUITexWidth = 0;
+	int mUITexHeight = 0;
+	PPShader mUICompositeShader = { "shaders/pp/uilayer.fp", "", {} };
 };
 
 class PPShadowMap

--- a/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
+++ b/src/common/rendering/hwrenderer/postprocessing/hw_postprocess.h
@@ -830,9 +830,10 @@ private:
 class PPCustomShaderInstance
 {
 public:
-	PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture);
+	PPCustomShaderInstance(PostProcessShader *desc, std::unique_ptr<PPPersistentBuffer> *lastInputTexture, PPTexture **weaponInputTexture, PPTexture **weaponLastTexture);
 
 	void Run(PPRenderState *renderstate);
+	void RunWithTextures(PPRenderState *renderstate, PPTexture *in, PPTexture *out);
 
 	PostProcessShader *Desc = nullptr;
 
@@ -850,6 +851,11 @@ private:
 
 	std::unique_ptr<PPPersistentBuffer> *LastInputTexture;
 	int LastInputTextureBinding = -1;
+
+	PPTexture **WeaponInputTexture;
+	int WeaponInputTextureBinding = -1;
+	PPTexture **WeaponLastTexture;
+	int WeaponLastTextureBinding = -1;
 };
 
 class PPCustomShaders
@@ -858,13 +864,27 @@ public:
 	void Run(PPRenderState *renderstate, FString target);
 	void UpdateLastInputTexture(PPRenderState *renderstate);
 
+	bool HasWeaponShaders() const;
+	PPTexture *GetWeaponLayerTexture(int width, int height);
+	void RunWeapon(PPRenderState *renderstate);
+
 private:
 	void CreateShaders();
+	void UpdateWeaponTextures(int width, int height);
 
 	std::vector<std::unique_ptr<PPCustomShaderInstance>> mShaders;
 	std::unique_ptr<PPPersistentBuffer> mLastInputTexture;
 	int mLastWidth = 0;
 	int mLastHeight = 0;
+
+	PPTexture mWeaponTextures[2];
+	PPTexture mWeaponHistory[2];
+	int mWeaponHistoryIndex = 0;
+	PPTexture *mWeaponInputPtr = nullptr;
+	PPTexture *mWeaponLastPtr = nullptr;
+	int mWeaponTexWidth = 0;
+	int mWeaponTexHeight = 0;
+	PPShader mWeaponCompositeShader = { "shaders/pp/weaponlayer.fp", "", {} };
 };
 
 class PPShadowMap

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -277,6 +277,8 @@ public:
 
 	virtual void Draw2D() {}
 
+	virtual void FlushGameUI() {}
+
 	virtual void SetViewportRects(IntRect *bounds);
 	int ScreenToWindowX(int x);
 	int ScreenToWindowY(int y);

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
@@ -102,7 +102,7 @@ void VkPostprocess::PostProcessScene(int fixedcm, float flash, const std::functi
 	AutomaticUniformsBuffer->Unmap();
 
 	hw_postprocess.Pass1(&renderstate, fixedcm, sceneWidth, sceneHeight);
-	if (hw_postprocess.customShaders.HasWeaponShaders())
+	if (hw_postprocess.customShaders.HasWeaponShaders() || hw_postprocess.customShaders.HasUIShaders())
 	{
 		auto buffers = fb->GetBuffers();
 		int bufferWidth = buffers->GetWidth();
@@ -144,6 +144,49 @@ void VkPostprocess::PostProcessScene(int fixedcm, float flash, const std::functi
 		afterBloomDrawEndScene2D();
 	}
 	hw_postprocess.Pass2(&renderstate, fixedcm, flash, sceneWidth, sceneHeight);
+	mSceneRenderedThisFrame = true;
+}
+
+void VkPostprocess::RunUIPostProcess(const std::function<void()> &draw2D)
+{
+	mSceneRenderedThisFrame = false;
+	auto buffers = fb->GetBuffers();
+	int bufferWidth = buffers->GetWidth();
+	int bufferHeight = buffers->GetHeight();
+	auto *uiTex = hw_postprocess.customShaders.GetUILayerTexture(bufferWidth, bufferHeight);
+
+	if (!uiTex->Backend)
+		uiTex->Backend = std::make_unique<VkPPTexture>(fb, uiTex);
+	auto *uiBackend = static_cast<VkPPTexture*>(uiTex->Backend.get());
+
+	auto cmdbuffer = fb->GetCommands()->GetDrawCommands();
+	bool undefinedLayout = (uiBackend->TexImage.Layout == VK_IMAGE_LAYOUT_UNDEFINED);
+	VkImageTransition()
+		.AddImage(&uiBackend->TexImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, undefinedLayout)
+		.Execute(cmdbuffer);
+
+	VkClearColorValue clearColor = {};
+	VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+	cmdbuffer->clearColorImage(uiBackend->TexImage.Image->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &range);
+
+	VkImageTransition()
+		.AddImage(&uiBackend->TexImage, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, false)
+		.Execute(cmdbuffer);
+
+	fb->GetRenderState()->SetRenderTarget(&uiBackend->TexImage, nullptr, bufferWidth, bufferHeight, VK_FORMAT_R16G16B16A16_SFLOAT, VK_SAMPLE_COUNT_1_BIT);
+	draw2D();
+
+	fb->GetRenderState()->EndRenderPass();
+	VkImageTransition()
+		.AddImage(&uiBackend->TexImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, false)
+		.Execute(fb->GetCommands()->GetDrawCommands());
+
+	VkPPRenderState renderstate(fb);
+	renderstate.TimeDelta = static_cast<float>(GetDeltaTime());
+	renderstate.Time = static_cast<float>(fb->FrameTime / 1000.0);
+	renderstate.TimeGame = static_cast<float>(primaryLevel->LocalWorldTimer / (double)GameTicRate);
+
+	hw_postprocess.customShaders.RunUI(&renderstate);
 }
 
 void VkPostprocess::BlitSceneToPostprocess()

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
@@ -102,8 +102,47 @@ void VkPostprocess::PostProcessScene(int fixedcm, float flash, const std::functi
 	AutomaticUniformsBuffer->Unmap();
 
 	hw_postprocess.Pass1(&renderstate, fixedcm, sceneWidth, sceneHeight);
-	SetActiveRenderTarget();
-	afterBloomDrawEndScene2D();
+	if (hw_postprocess.customShaders.HasWeaponShaders())
+	{
+		auto buffers = fb->GetBuffers();
+		int bufferWidth = buffers->GetWidth();
+		int bufferHeight = buffers->GetHeight();
+		auto *weaponTex = hw_postprocess.customShaders.GetWeaponLayerTexture(bufferWidth, bufferHeight);
+
+		if (!weaponTex->Backend)
+			weaponTex->Backend = std::make_unique<VkPPTexture>(fb, weaponTex);
+		auto *weaponBackend = static_cast<VkPPTexture*>(weaponTex->Backend.get());
+
+		auto cmdbuffer = fb->GetCommands()->GetDrawCommands();
+		bool undefinedLayout = (weaponBackend->TexImage.Layout == VK_IMAGE_LAYOUT_UNDEFINED);
+		VkImageTransition()
+			.AddImage(&weaponBackend->TexImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, undefinedLayout)
+			.Execute(cmdbuffer);
+
+		VkClearColorValue clearColor = {};
+		VkImageSubresourceRange range = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+		cmdbuffer->clearColorImage(weaponBackend->TexImage.Image->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearColor, 1, &range);
+
+		VkImageTransition()
+			.AddImage(&weaponBackend->TexImage, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, false)
+			.AddImage(&buffers->PipelineDepthStencil, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, false)
+			.Execute(cmdbuffer);
+
+		fb->GetRenderState()->SetRenderTarget(&weaponBackend->TexImage, buffers->PipelineDepthStencil.View.get(), bufferWidth, bufferHeight, VK_FORMAT_R16G16B16A16_SFLOAT, VK_SAMPLE_COUNT_1_BIT);
+		afterBloomDrawEndScene2D();
+
+		fb->GetRenderState()->EndRenderPass();
+		VkImageTransition()
+			.AddImage(&weaponBackend->TexImage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, false)
+			.Execute(fb->GetCommands()->GetDrawCommands());
+
+		hw_postprocess.customShaders.RunWeapon(&renderstate);
+	}
+	else
+	{
+		SetActiveRenderTarget();
+		afterBloomDrawEndScene2D();
+	}
 	hw_postprocess.Pass2(&renderstate, fixedcm, flash, sceneWidth, sceneHeight);
 }
 

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.h
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.h
@@ -46,6 +46,7 @@ public:
 
 	void SetActiveRenderTarget();
 	void PostProcessScene(int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D);
+	void RunUIPostProcess(const std::function<void()> &draw2D);
 
 	void AmbientOccludeScene(float m5);
 	void BlurScene(float gameinfobluramount);
@@ -63,6 +64,8 @@ public:
 	int GetCurrentPipelineImage() const { return mCurrentPipelineImage; }
 
 	VulkanBuffer* GetAutomaticUniformsBuffer() { return AutomaticUniformsBuffer.get(); }
+
+	bool mSceneRenderedThisFrame = false;
 
 private:
 	void NextEye(int eyeCount);

--- a/src/common/rendering/vulkan/system/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/system/vk_renderdevice.cpp
@@ -210,6 +210,17 @@ void VulkanRenderDevice::InitializeState()
 #endif
 }
 
+void VulkanRenderDevice::FlushGameUI()
+{
+	if (!hw_postprocess.customShaders.HasUIShaders()) return;
+	if (!GetPostprocess()->mSceneRenderedThisFrame) return;
+
+	GetPostprocess()->RunUIPostProcess([this]() { ::Draw2D(twod, *mRenderState); twod->Clear(); });
+	mRenderState->EndRenderPass();
+	twod->OnFrameDone();
+	twod->Begin(GetWidth(), GetHeight());
+}
+
 void VulkanRenderDevice::Update()
 {
 	twoD.Reset();
@@ -217,10 +228,16 @@ void VulkanRenderDevice::Update()
 
 	Flush3D.Clock();
 
-	GetPostprocess()->SetActiveRenderTarget();
-
-	Draw2D();
-	twod->Clear();
+	if (hw_postprocess.customShaders.HasUIShaders() && GetPostprocess()->mSceneRenderedThisFrame)
+	{
+		GetPostprocess()->RunUIPostProcess([this]() { ::Draw2D(twod, *mRenderState); twod->Clear(); });
+	}
+	else
+	{
+		GetPostprocess()->SetActiveRenderTarget();
+		Draw2D();
+		twod->Clear();
+	}
 
 	mRenderState->EndRenderPass();
 	mRenderState->EndFrame();

--- a/src/common/rendering/vulkan/system/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/system/vk_renderdevice.h
@@ -74,6 +74,7 @@ public:
 	bool IsVulkan() override { return true; }
 
 	void Update() override;
+	void FlushGameUI() override;
 
 	void InitializeState() override;
 	bool CompileNextShader() override;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1373,6 +1373,7 @@ void D_Display ()
 	{
 		if (wipestart != nullptr) wipestart->DecRef();
 		wipestart = nullptr;
+		screen->FlushGameUI();
 		DrawOverlays();
 		End2DAndUpdate ();
 	}

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1525,6 +1525,7 @@ class GLDefsParser
 			if (sc.Compare("scene")) validTarget = true;
 			if (sc.Compare("screen")) validTarget = true;
 			if (sc.Compare("weapon")) validTarget = true;
+			if (sc.Compare("ui")) validTarget = true;
 			if (!validTarget)
 				sc.ScriptError("Invalid target '%s' for postprocess shader",sc.String);
 

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1524,6 +1524,7 @@ class GLDefsParser
 			if (sc.Compare("beforebloom")) validTarget = true;
 			if (sc.Compare("scene")) validTarget = true;
 			if (sc.Compare("screen")) validTarget = true;
+			if (sc.Compare("weapon")) validTarget = true;
 			if (!validTarget)
 				sc.ScriptError("Invalid target '%s' for postprocess shader",sc.String);
 

--- a/wadsrc/static/shaders/pp/uilayer.fp
+++ b/wadsrc/static/shaders/pp/uilayer.fp
@@ -1,0 +1,26 @@
+/*
+** uilayer.fp
+**
+** Passthrough shader for compositing the UI layer onto the scene
+**
+**---------------------------------------------------------------------------
+**
+** Copyright 2025-2026 UZDoom Maintainers and Contributors
+**
+** SPDX-License-Identifier: GPL-3.0-or-later
+**
+**---------------------------------------------------------------------------
+*/
+
+layout(location=0) in vec2 TexCoord;
+layout(location=0) out vec4 FragColor;
+
+layout(binding=0) uniform sampler2D SceneTexture;
+layout(binding=1) uniform sampler2D UITexture;
+
+void main()
+{
+	vec4 scene = texture(SceneTexture, TexCoord);
+	vec4 ui = texture(UITexture, TexCoord);
+	FragColor = vec4(mix(scene.rgb, ui.rgb, ui.a), scene.a);
+}

--- a/wadsrc/static/shaders/pp/weaponlayer.fp
+++ b/wadsrc/static/shaders/pp/weaponlayer.fp
@@ -1,0 +1,26 @@
+/*
+** weaponlayer.fp
+**
+** Passthrough shader for compositing the weapon layer onto the scene
+**
+**---------------------------------------------------------------------------
+**
+** Copyright 2025-2026 UZDoom Maintainers and Contributors
+**
+** SPDX-License-Identifier: GPL-3.0-or-later
+**
+**---------------------------------------------------------------------------
+*/
+
+layout(location=0) in vec2 TexCoord;
+layout(location=0) out vec4 FragColor;
+
+layout(binding=0) uniform sampler2D SceneTexture;
+layout(binding=1) uniform sampler2D WeaponTexture;
+
+void main()
+{
+	vec4 scene = texture(SceneTexture, TexCoord);
+	vec4 weapon = texture(WeaponTexture, TexCoord);
+	FragColor = vec4(mix(scene.rgb, weapon.rgb, weapon.a), scene.a);
+}


### PR DESCRIPTION
Adds "weapon" and "ui" postprocess targets to GLDEFS. Weapon sprites render into an isolated Rgba16f texture, run through any enabled weapon shaders, then get alpha-composited onto the scene. The in-game HUD does the same through the ui chain, compositing onto the fully-rendered scene afterward. Effects can bleed past element boundaries and interact across layers.

Menus and the console bypass the ui pipeline entirely.

All GLDEFS shaders now get six auto-declared samplers: InputTexture, LastInputTexture, WeaponTexture, WeaponLastTexture, UITexture, and UILastTexture. WeaponTexture No overhead when neither weapon nor ui target is in use.

Implemented for both GL and Vulkan.

- [✔] I have reviewed [CONTRIBUTING.md] and agree to its terms.