### PR TITLE
fix: guard against null wiper and out-of-range wipetype

### DIFF
--- a/src/common/2d/wipe.cpp
+++ b/src/common/2d/wipe.cpp
@@ -517,6 +517,12 @@ void PerformWipe(FTexture* startimg, FTexture* endimg, int wipe_type, bool stops
 	auto starttex = MakeGameTexture(startimg, nullptr, ETextureType::SWCanvas);
 	auto endtex = MakeGameTexture(endimg, nullptr, ETextureType::SWCanvas);
 	auto wiper = Wiper::Create(wipe_type);
+	if (!wiper)
+	{
+		I_FreezeTime(false);
+		GSnd->SetSfxPaused(false, 1);
+		return;
+	}
 	wiper->SetTextures(starttex, endtex);
 
 	wipestart = I_msTime();

--- a/src/common/2d/wipe.cpp
+++ b/src/common/2d/wipe.cpp
@@ -510,19 +510,15 @@ void PerformWipe(FTexture* startimg, FTexture* endimg, int wipe_type, bool stops
 	double diff_frac;
 	bool done;
 
-	GSnd->SetSfxPaused(true, 1);
-	I_FreezeTime(true);
 	twod->End();
 	assert(startimg != nullptr && endimg != nullptr);
 	auto starttex = MakeGameTexture(startimg, nullptr, ETextureType::SWCanvas);
 	auto endtex = MakeGameTexture(endimg, nullptr, ETextureType::SWCanvas);
 	auto wiper = Wiper::Create(wipe_type);
 	if (!wiper)
-	{
-		I_FreezeTime(false);
-		GSnd->SetSfxPaused(false, 1);
 		return;
-	}
+	GSnd->SetSfxPaused(true, 1);
+	I_FreezeTime(true);
 	wiper->SetTextures(starttex, endtex);
 
 	wipestart = I_msTime();

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -466,7 +466,10 @@ CUSTOM_CVAR (Int, fraglimit, 0, CVAR_SERVERINFO)
 }
 
 CVAR (Float, timelimit, 0.f, CVAR_SERVERINFO);
-CVAR (Int, wipetype, 1, CVAR_ARCHIVE);
+CUSTOM_CVAR (Int, wipetype, 1, CVAR_ARCHIVE)
+{
+	if (self < wipe_None || self >= wipe_NUMWIPES) self = wipe_Melt;
+}
 CVAR (Int, snd_drawoutput, 0, 0);
 CUSTOM_CVAR (String, vid_cursor, "None", CVAR_ARCHIVE | CVAR_NOINITCALL)
 {


### PR DESCRIPTION
PerformWipe would crash with a null deref if Wiper::Create returned null
(e.g. an unrecognised wipe type). Add an early return that cleans up and
bails instead.

wipetype was a plain CVAR with no bounds check, so a stale value of 4
(wipe_NUMWIPES) persisted from old configs and triggered the above crash
on the first level transition. Changed to CUSTOM_CVAR with a validator
that resets any out-of-range value to wipe_Melt on load.

- [✔] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
