### PR TITLE
Allow of repo specification

### DIFF
--- a/tools/update-subtrees.sh
+++ b/tools/update-subtrees.sh
@@ -20,6 +20,8 @@ pull() {
 
 	[[ -z ${1} ]] || ref=${1}
 	shift
+	[[ -z ${1} ]] || repo=${1}
+	shift
 
 	git -C $GITROOT subtree pull --prefix="${dest}" "${repo}" "${ref}" \
 		--squash --message "Update ${dest} to ${ref}" || exit


### PR DESCRIPTION
Makes testing comtributions to zmusic easier

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
