### PR TITLE
Wad dir button

### DIFF
--- a/libraries/ZWidget/include/zwidget/core/widget.h
+++ b/libraries/ZWidget/include/zwidget/core/widget.h
@@ -13,6 +13,7 @@
 class Canvas;
 class Timer;
 class Dropdown;
+class PushButton;
 
 enum class WidgetType
 {
@@ -166,6 +167,8 @@ public:
 	void* GetNativeHandle();
 	int GetNativePixelWidth();
 	int GetNativePixelHeight();
+	virtual double GetPreferredWidth();
+	virtual double GetPreferredHeight();
 
 	// Vulkan support:
 	std::vector<std::string> GetVulkanInstanceExtensions() { return Window()->DispWindow->GetVulkanInstanceExtensions(); }
@@ -259,4 +262,5 @@ private:
 	friend class OpenFolderDialog;
 	friend class SaveFileDialog;
 	friend class Dropdown;
+	friend class PushButton;
 };

--- a/libraries/ZWidget/include/zwidget/widgets/checkboxlabel/checkboxlabel.h
+++ b/libraries/ZWidget/include/zwidget/widgets/checkboxlabel/checkboxlabel.h
@@ -15,7 +15,7 @@ public:
 	bool GetChecked() const;
 	void Toggle();
 
-	double GetPreferredHeight() const;
+	double GetPreferredHeight() override;
 	std::function<void(bool)> FuncChanged;
 	void SetRadioStyle(bool on) { radiostyle = on; }
 

--- a/libraries/ZWidget/include/zwidget/widgets/dropdown/dropdown.h
+++ b/libraries/ZWidget/include/zwidget/widgets/dropdown/dropdown.h
@@ -33,8 +33,8 @@ public:
 	int GetSelectedItem() const { return selectedItem; }
 	void SetSelectedItem(int index);
 
-	double GetPreferredHeight() const;
-	double GetPreferredWidth() const;
+	double GetPreferredHeight() override;
+	double GetPreferredWidth() override;
 
 	std::function<void(int)> OnChanged;
 

--- a/libraries/ZWidget/include/zwidget/widgets/imagebox/imagebox.h
+++ b/libraries/ZWidget/include/zwidget/widgets/imagebox/imagebox.h
@@ -19,8 +19,8 @@ public:
 	void SetImage(std::shared_ptr<Image> newImage);
 	void SetImageMode(ImageBoxMode mode);
 
-	double GetPreferredWidth() const;
-	double GetPreferredHeight() const;
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 
 protected:
 	void OnPaint(Canvas* canvas) override;

--- a/libraries/ZWidget/include/zwidget/widgets/listview/listview.h
+++ b/libraries/ZWidget/include/zwidget/widgets/listview/listview.h
@@ -23,8 +23,8 @@ public:
 	void SetSelectedItem(int index);
 	void ScrollToItem(int index);
 
-	double GetPreferredWidth();
-	double GetPreferredHeight();
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 	double GetMinimumHeight() const;
 
 	void Activate();

--- a/libraries/ZWidget/include/zwidget/widgets/menubar/menubar.h
+++ b/libraries/ZWidget/include/zwidget/widgets/menubar/menubar.h
@@ -49,7 +49,7 @@ public:
 	void SetOpenCallback(std::function<void(Menu* menu)> callback) { onOpen = std::move(callback); }
 	const std::function<void(Menu* menu)>& GetOpenCallback() const { return onOpen; }
 
-	double GetPreferredWidth() const;
+	double GetPreferredWidth() override;
 
 	bool AlignRight = false;
 
@@ -76,8 +76,8 @@ public:
 	MenuItem* AddItem(std::shared_ptr<Image> icon, std::string text, std::function<void()> onClick = {});
 	MenuItemSeparator* AddSeparator();
 
-	double GetPreferredWidth() const;
-	double GetPreferredHeight() const;
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 
 	void SetSelected(MenuItem* item);
 

--- a/libraries/ZWidget/include/zwidget/widgets/pushbutton/pushbutton.h
+++ b/libraries/ZWidget/include/zwidget/widgets/pushbutton/pushbutton.h
@@ -12,11 +12,12 @@ public:
 	void SetText(const std::string& value);
 	const std::string& GetText() const;
 
-	double GetPreferredHeight() const;
-
 	void Click();
 
 	std::function<void()> OnClick;
+
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 
 protected:
 	void OnPaint(Canvas* canvas) override;

--- a/libraries/ZWidget/include/zwidget/widgets/scrollbar/scrollbar.h
+++ b/libraries/ZWidget/include/zwidget/widgets/scrollbar/scrollbar.h
@@ -32,8 +32,8 @@ public:
 
 	void SetPosition(double pos);
 
-	double GetPreferredWidth() const { return 16.0; }
-	double GetPreferredHeight() const { return 16.0; }
+	double GetPreferredWidth() override { return 16.0; }
+	double GetPreferredHeight() override { return 16.0; }
 
 	std::function<void()> FuncScroll;
 	std::function<void()> FuncScrollMin;

--- a/libraries/ZWidget/include/zwidget/widgets/tabwidget/tabwidget.h
+++ b/libraries/ZWidget/include/zwidget/widgets/tabwidget/tabwidget.h
@@ -62,7 +62,7 @@ public:
 	int GetCurrentIndex() const;
 	void SetCurrentIndex(int pageIndex);
 
-	double GetPreferredHeight() const { return 30.0; }
+	double GetPreferredHeight() override { return 30.0; }
 
 	std::function<void()> OnCurrentChanged;
 
@@ -94,7 +94,7 @@ public:
 	void SetIcon(const std::shared_ptr<Image>& icon);
 	void SetCurrent(bool value);
 
-	double GetPreferredWidth() const;
+	double GetPreferredWidth() override;
 
 	std::function<void()> OnClick;
 

--- a/libraries/ZWidget/include/zwidget/widgets/textlabel/textlabel.h
+++ b/libraries/ZWidget/include/zwidget/widgets/textlabel/textlabel.h
@@ -21,8 +21,8 @@ public:
 	void SetTextAlignment(TextLabelAlignment alignment);
 	TextLabelAlignment GetTextAlignment() const;
 
-	double GetPreferredWidth() const;
-	double GetPreferredHeight() const;
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 
 protected:
 	void OnPaint(Canvas* canvas) override;

--- a/libraries/ZWidget/include/zwidget/widgets/toolbar/toolbarbutton.h
+++ b/libraries/ZWidget/include/zwidget/widgets/toolbar/toolbarbutton.h
@@ -16,8 +16,8 @@ public:
 
 	void Click();
 
-	double GetPreferredWidth();
-	double GetPreferredHeight();
+	double GetPreferredWidth() override;
+	double GetPreferredHeight() override;
 
 	std::function<void()> OnClick;
 

--- a/libraries/ZWidget/src/core/widget.cpp
+++ b/libraries/ZWidget/src/core/widget.cpp
@@ -409,6 +409,16 @@ void Widget::Paint(Canvas* canvas)
 	canvas->popClip();
 }
 
+double Widget::GetPreferredWidth()
+{
+	return GetNoncontentLeft() + GetNoncontentRight();
+}
+
+double Widget::GetPreferredHeight()
+{
+	return GetNoncontentTop() + GetNoncontentBottom();
+}
+
 void Widget::OnPaintFrame(Canvas* canvas)
 {
 	WidgetStyle* style = WidgetTheme::GetTheme()->GetStyle(StyleClass);

--- a/libraries/ZWidget/src/widgets/checkboxlabel/checkboxlabel.cpp
+++ b/libraries/ZWidget/src/widgets/checkboxlabel/checkboxlabel.cpp
@@ -34,7 +34,7 @@ bool CheckboxLabel::GetChecked() const
 	return checked;
 }
 
-double CheckboxLabel::GetPreferredHeight() const
+double CheckboxLabel::GetPreferredHeight()
 {
 	return 20.0;
 }

--- a/libraries/ZWidget/src/widgets/dropdown/dropdown.cpp
+++ b/libraries/ZWidget/src/widgets/dropdown/dropdown.cpp
@@ -139,12 +139,12 @@ void Dropdown::SetSelectedItem(int index)
 	Update();
 }
 
-double Dropdown::GetPreferredHeight() const
+double Dropdown::GetPreferredHeight()
 {
 	return 20.0 + 2*5.0; // Text plus top/bottom padding
 }
 
-double Dropdown::GetPreferredWidth() const
+double Dropdown::GetPreferredWidth()
 {
 	Canvas* canvas = GetCanvas();
 

--- a/libraries/ZWidget/src/widgets/imagebox/imagebox.cpp
+++ b/libraries/ZWidget/src/widgets/imagebox/imagebox.cpp
@@ -5,7 +5,7 @@ ImageBox::ImageBox(Widget* parent) : Widget(parent)
 {
 }
 
-double ImageBox::GetPreferredWidth() const
+double ImageBox::GetPreferredWidth()
 {
 	if (image)
 		return (double)image->GetWidth();
@@ -13,7 +13,7 @@ double ImageBox::GetPreferredWidth() const
 		return 0.0;
 }
 
-double ImageBox::GetPreferredHeight() const
+double ImageBox::GetPreferredHeight()
 {
 	if (image)
 		return (double)image->GetHeight();

--- a/libraries/ZWidget/src/widgets/menubar/menubar.cpp
+++ b/libraries/ZWidget/src/widgets/menubar/menubar.cpp
@@ -244,7 +244,7 @@ void MenubarItem::OnMouseLeave()
 	SetStyleState("");
 }
 
-double MenubarItem::GetPreferredWidth() const
+double MenubarItem::GetPreferredWidth()
 {
 	Canvas* canvas = GetCanvas();
 	return canvas->measureText(text).width;
@@ -288,12 +288,12 @@ MenuItemSeparator* Menu::AddSeparator()
 	return sep;
 }
 
-double Menu::GetPreferredWidth() const
+double Menu::GetPreferredWidth()
 {
 	return GridFitSize(200.0);
 }
 
-double Menu::GetPreferredHeight() const
+double Menu::GetPreferredHeight()
 {
 	double h = 0.0;
 	for (Widget* item = FirstChild(); item != nullptr; item = item->NextSibling())

--- a/libraries/ZWidget/src/widgets/pushbutton/pushbutton.cpp
+++ b/libraries/ZWidget/src/widgets/pushbutton/pushbutton.cpp
@@ -20,9 +20,17 @@ const std::string& PushButton::GetText() const
 	return text;
 }
 
-double PushButton::GetPreferredHeight() const
+double PushButton::GetPreferredWidth()
 {
-	return 30.0;
+	Widget* w = Window();
+	if (!w->DispCanvas) return Widget::GetPreferredWidth();
+	Rect box = w->DispCanvas->measureText(text);
+	return box.width + Widget::GetPreferredWidth();
+}
+
+double PushButton::GetPreferredHeight()
+{
+	return 20 + Widget::GetPreferredHeight();
 }
 
 void PushButton::OnPaint(Canvas* canvas)

--- a/libraries/ZWidget/src/widgets/tabwidget/tabwidget.cpp
+++ b/libraries/ZWidget/src/widgets/tabwidget/tabwidget.cpp
@@ -266,7 +266,7 @@ void TabBarTab::SetCurrent(bool value)
 	}
 }
 
-double TabBarTab::GetPreferredWidth() const
+double TabBarTab::GetPreferredWidth()
 {
 	double x = Icon ? 32.0 + 5.0 : 0.0;
 	if (Label) x += Label->GetPreferredWidth();

--- a/libraries/ZWidget/src/widgets/textlabel/textlabel.cpp
+++ b/libraries/ZWidget/src/widgets/textlabel/textlabel.cpp
@@ -33,13 +33,13 @@ TextLabelAlignment TextLabel::GetTextAlignment() const
 	return textAlignment;
 }
 
-double TextLabel::GetPreferredWidth() const
+double TextLabel::GetPreferredWidth()
 {
 	Canvas* canvas = GetCanvas();
 	return canvas->measureText(text).width;
 }
 
-double TextLabel::GetPreferredHeight() const
+double TextLabel::GetPreferredHeight()
 {
 	return 20.0;
 }

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -360,7 +360,7 @@ int FIWadManager::ScanIWAD (const char *iwad)
 
 	mLumpsFound.Resize(mIWadInfos.Size());
 
-	auto CheckFileName = [=](const char *name)
+	auto CheckFileName = [=,this](const char *name)
 	{
 		for (unsigned i = 0; i< mIWadInfos.Size(); i++)
 		{
@@ -795,7 +795,7 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 		gamedir = "~/Library/Application Support/" GAMENAMELOWERCASE "/";
 		cfgfile = "~/Library/Preferences/" GAMENAMELOWERCASE ".ini";
 #else
-		auto gd = FStringf("%s/games/" GAMENAMELOWERCASE, GetDataPath());
+		auto gd = M_GetAppDataPath(true);
 		auto cd = FStringf("%s/" GAMENAMELOWERCASE ".ini", GetConfigPath());
 		gd.Substitute("$HOME/", "~/");
 		cd.Substitute("$HOME/", "~/");

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -2291,7 +2291,7 @@ static void AddAutoloadFiles(const char *autoname, std::vector<FileSys::Resource
 		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig, true);
 
 #ifdef __unix__
-		FString skinDir = FStringf("%s/games/" GAMENAMELOWERCASE "/skins", GetDataPath());
+		FString skinDir = FStringf("%s/skins", M_GetAppDataPath(true).GetChars());
 		file = NicePath(skinDir.GetChars());
 		D_AddDirectory (allwads, file.GetChars(), "*.wad", GameConfig, true);
 #endif

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -17,6 +17,8 @@
 **
 */
 
+// HEADER FILES ------------------------------------------------------------
+
 #include <memory>
 #include <stdio.h>
 #include <string.h>
@@ -80,32 +82,123 @@
 #include "vm.h"
 #include "wi_stuff.h"
 
-static FRandom pr_dmspawn ("DMSpawn");
-static FRandom pr_pspawn ("PlayerSpawn");
+// MACROS ------------------------------------------------------------------
 
-extern int startpos, laststartpos;
+#define MAXPLMOVE        (forwardmove[1])
+#define TURBOTHRESHOLD   12800
+#define SLOWTURNTICS     6
+#define ANALOG_LOOK_BASE 1280
+
+// TYPES -------------------------------------------------------------------
+
+enum {
+	SPY_CANCEL = 0,
+	SPY_NEXT,
+	SPY_PREV,
+};
+
+// EXTERNAL FUNCTION PROTOTYPES --------------------------------------------
 
 bool WriteZip(const char* filename, const FileSys::FCompressedBuffer* content, size_t contentcount);
-bool	G_CheckDemoStatus (void);
-void	G_ReadDemoTiccmd (usercmd_t *cmd, int player);
-void	G_WriteDemoTiccmd (usercmd_t *cmd, int player, int buf);
-void	G_PlayerReborn (int player);
 
-void	G_DoNewGame (void);
-void	G_DoLoadGame (void);
-void	G_DoPlayDemo (void);
-void	G_DoCompleted (void);
-void	G_DoVictory (void);
-void	G_DoWorldDone (void);
-void	G_DoMapWarp();
-void	G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description);
-void	G_DoAutoSave ();
-void	G_DoQuickSave ();
+void G_DoCompleted (void);
+void G_DoMapWarp();
+void G_DoNewGame (void);
+void G_DoQuickSave ();
+void G_DoWorldDone (void);
 
 void STAT_Serialize(FSerializer &file);
 
-CVARD_NAMED(Int, gameskill, skill, 2, CVAR_SERVERINFO|CVAR_LATCH, "sets the skill for the next newly started game")
-CVAR(Bool, save_formatted, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)	// use formatted JSON for saves (more readable but a larger files and a bit slower.
+// PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
+
+// PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
+
+void G_ReadDemoTiccmd (usercmd_t *cmd, int player);
+void G_WriteDemoTiccmd (usercmd_t *cmd, int player, int buf);
+void G_PlayerReborn (int player);
+
+void G_DoAutoSave ();
+void G_DoPlayDemo (void);
+void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description);
+void G_DoVictory (void);
+
+void SetupLoadingCVars();
+void FinishLoadingCVars();
+bool CheckGZDoomSaveCompat(FString &engine, FString &software);
+
+// EXTERNAL DATA DECLARATIONS ----------------------------------------------
+
+extern int     startpos;
+extern int     laststartpos;
+extern bool    playedtitlemusic;
+extern uint8_t globalfreeze;
+extern uint8_t *streamPos;
+
+EXTERN_CVAR (Float, con_midtime);
+EXTERN_CVAR (Int, net_disablepause);
+EXTERN_CVAR (Bool, net_limitsaves);
+
+EXTERN_CVAR (Int, turnspeedwalkfast);
+EXTERN_CVAR (Int, turnspeedsprintfast);
+EXTERN_CVAR (Int, turnspeedwalkslow);
+EXTERN_CVAR (Int, turnspeedsprintslow);
+
+EXTERN_CVAR (Bool, invertmouse);
+EXTERN_CVAR (Bool, invertmousex);
+
+EXTERN_CVAR (Int, team);
+EXTERN_CVAR (Bool, sv_singleplayerrespawn);
+
+gameaction_t    gameaction;
+
+bool            sendpause;   // send a pause event next tic
+bool            sendsave;    // send a save event next tic
+bool            sendturn180; // [RH] send a 180 degree turn next tic
+bool            usergame;    // ok to save / end game
+bool            insave;      // Game is saving - used to block exit commands
+
+
+// PUBLIC DATA DEFINITIONS -------------------------------------------------
+
+bool            timingdemo;  // if true, exit with report on completion
+bool            nodrawers;   // for comparative timing purposes
+bool            noblit;      // for comparative timing purposes
+
+bool            viewactive;
+
+bool            multiplayernext = false; // [SP] Map coop/dm implementation
+player_t        players[MAXPLAYERS];
+bool            playeringame[MAXPLAYERS];
+
+int             gametic;
+
+FString         newdemoname;
+FString         newdemomap;
+FString         demoname;
+bool            demorecording;
+bool            demoplayback;
+bool            demonew; // [RH] Only used around G_InitNew for demos
+int             demover;
+TArray<uint8_t> demobuffer;
+TArrayView<uint8_t> demo_p;
+
+bool            singledemo;      // quit after playing a demo from cmdline
+bool            precache = true; // if true, load all graphics at start
+
+bool            SendLand;
+const AActor    *SendItemUse;
+const AActor    *SendItemDrop;
+int             SendItemDropAmount;
+
+float           mousex; // mouse values are used once
+float           mousey;
+
+FString         savegamefile;
+FString         savedescription;
+FString         BackupSaveName;
+
+CVARD_NAMED (Int, gameskill, skill, 2, CVAR_SERVERINFO|CVAR_LATCH, "sets the skill for the next newly started game")
+CVAR (Bool, save_formatted, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // use formatted JSON for saves (more readable but a larger files and a bit slower.
 CVAR (Int, deathmatch, 0, CVAR_SERVERINFO|CVAR_LATCH);
 CVAR (Bool, chasedemo, false, 0);
 CVAR (Bool, storesavepic, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
@@ -113,10 +206,6 @@ CVAR (Bool, longsavemessages, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
 CVAR (Bool, cl_waitforsave, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR (Bool, enablescriptscreenshot, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 CVAR (Bool, cl_restartondeath, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
-
-EXTERN_CVAR (Float, con_midtime);
-EXTERN_CVAR(Int, net_disablepause);
-EXTERN_CVAR(Bool, net_limitsaves);
 
 FARG(nodraw, "Debug", "Stops the game from drawing anything.", "",
 	"Causes ZDoom not to draw anything at all. Only useful with -timedemo.");
@@ -140,115 +229,31 @@ CUSTOM_CVAR (Int, displaynametags, 0, CVAR_ARCHIVE)
 	}
 }
 
-CVAR(Int, nametagcolor, CR_GOLD, CVAR_ARCHIVE)
+CVAR (Int,  nametagcolor,  CR_GOLD, CVAR_ARCHIVE);
+CVAR (Bool, demo_compress, true,    CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
 
-extern bool playedtitlemusic;
-
-gameaction_t	gameaction;
-
-bool 			sendpause;				// send a pause event next tic 
-bool			sendsave;				// send a save event next tic 
-bool			sendturn180;			// [RH] send a 180 degree turn next tic
-bool 			usergame;				// ok to save / end game
-bool			insave;					// Game is saving - used to block exit commands
-
-bool			timingdemo; 			// if true, exit with report on completion 
-bool 			nodrawers;				// for comparative timing purposes 
-bool 			noblit; 				// for comparative timing purposes 
-
-bool	 		viewactive;
-
-bool			multiplayernext = false;		// [SP] Map coop/dm implementation
-player_t		players[MAXPLAYERS];
-bool			playeringame[MAXPLAYERS];
-
-int 			gametic;
-
-CVAR(Bool, demo_compress, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
-FString			newdemoname;
-FString			newdemomap;
-FString			demoname;
-bool 			demorecording;
-bool 			demoplayback;
-bool			demonew;				// [RH] Only used around G_InitNew for demos
-int				demover;
-TArray<uint8_t>	demobuffer;
-TArrayView<uint8_t>	demo_p;
-uint8_t*			democompspot;
-uint8_t*			demobodyspot;
-size_t			maxdemosize;
-uint8_t*			zdemformend;			// end of FORM ZDEM chunk
-uint8_t*			zdembodyend;			// end of ZDEM BODY chunk
-bool 			singledemo; 			// quit after playing a demo from cmdline 
- 
-bool 			precache = true;		// if true, load all graphics at start 
- 
- 
-#define MAXPLMOVE				(forwardmove[1]) 
- 
-#define TURBOTHRESHOLD	12800
-
-EXTERN_CVAR (Int, turnspeedwalkfast)
-EXTERN_CVAR (Int, turnspeedsprintfast)
-EXTERN_CVAR (Int, turnspeedwalkslow)
-EXTERN_CVAR (Int, turnspeedsprintslow)
-
-int				forwardmove[2], sidemove[2];
-FIntCVarRef		*angleturn[4] = {&turnspeedwalkfast, &turnspeedsprintfast, &turnspeedwalkslow, &turnspeedsprintslow};
-int				flyspeed[2] = {1*256, 3*256};
-int				lookspeed[2] = {450, 512};
-
-#define SLOWTURNTICS	6 
-
-CVAR (Bool,		cl_run,			false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always run?
-CVAR (Bool,		freelook,		true,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always mlook?
-CVAR (Bool,		lookstrafe,		false,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)		// Always strafe with mouse?
-CVAR (Float,	m_forward,		1.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-CVAR (Float,	m_side,			2.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-
-#define ANALOG_LOOK_BASE	1280
+CVAR (Bool,  cl_run,     false, CVAR_GLOBALCONFIG|CVAR_ARCHIVE); // Always run?
+CVAR (Bool,  freelook,   true,  CVAR_GLOBALCONFIG|CVAR_ARCHIVE); // Always mlook?
+CVAR (Bool,  lookstrafe, false, CVAR_GLOBALCONFIG|CVAR_ARCHIVE); // Always strafe with mouse?
+CVAR (Float, m_forward,  1.f,   CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
+CVAR (Float, m_side,     2.f,   CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
 
 // You can change cl_analog_sensitivity_pitch's default to 1.6f if the old historical
 // behavior is preferred, but IMO that is so fast that it's practically unplayable...
-CVAR (Float, cl_analog_sensitivity_yaw,		1.f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-CVAR (Float, cl_analog_sensitivity_pitch,	0.6f,	CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-
-CVAR (Bool, cl_analog_run, true, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-CVAR (Bool, cl_analog_straferun, false, CVAR_GLOBALCONFIG|CVAR_ARCHIVE)
-
-int 			turnheld;								// for accelerative turning 
-
-EXTERN_CVAR (Bool, invertmouse)
-EXTERN_CVAR (Bool, invertmousex)
-
-// mouse values are used once 
-float 			mousex;
-float 			mousey; 		
-
-FString			savegamefile;
-FString			savedescription;
-
-// [RH] Name of screenshot file to generate (usually NULL)
-FString			shotfile;
-
-FString savename;
-FString BackupSaveName;
-
-bool SendLand;
-const AActor *SendItemUse, *SendItemDrop;
-int SendItemDropAmount;
-
-extern uint8_t globalfreeze;
-
-EXTERN_CVAR (Int, team)
+CVAR (Float, cl_analog_sensitivity_yaw,   1.f,   CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
+CVAR (Float, cl_analog_sensitivity_pitch, 0.6f,  CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
+CVAR (Bool,  cl_analog_run,               true,  CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
+CVAR (Bool,  cl_analog_straferun,         false, CVAR_GLOBALCONFIG|CVAR_ARCHIVE);
 
 CVAR (Bool, teamplay, false, CVAR_SERVERINFO)
 
-// Workaround for x64 code generation bug in MSVC 2015 
+// Workaround for x64 code generation bug in MSVC 2015
 // Optimized targets contain illegal instructions in the function below
 #if defined _M_X64 && _MSC_VER < 1910
 #pragma optimize("", off)
 #endif // _M_X64 && _MSC_VER < 1910
+
+int forwardmove[2], sidemove[2];
 
 // [RH] Allow turbo setting anytime during game
 CUSTOM_CVAR (Float, turbo, 100.f, CVAR_NOINITCALL | CVAR_CHEAT)
@@ -275,6 +280,71 @@ CUSTOM_CVAR (Float, turbo, 100.f, CVAR_NOINITCALL | CVAR_CHEAT)
 #if defined _M_X64 && _MSC_VER < 1910
 #pragma optimize("", on)
 #endif // _M_X64 && _MSC_VER < 1910
+
+CVAR (Bool, bot_allowspy, false, 0);
+
+CVAR (Int, autosavenum, 0, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+CVAR (Int, disableautosave, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+CVAR (Bool, saveloadconfirmation, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG); // [mxd]
+
+CUSTOM_CVAR (Int, autosavecount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+{
+	if (self < 0)
+		self = 0;
+}
+
+CVAR (Int, quicksavenum, -1, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+CVAR (Bool, quicksaverotation, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG);
+
+CUSTOM_CVAR (Int, quicksaverotationcount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
+{
+	if (self < 1)
+		self = 1;
+}
+
+// PRIVATE DATA DEFINITIONS ------------------------------------------------
+
+constexpr char  True[] = "true";
+
+static FRandom pr_dmspawn ("DMSpawn");
+static FRandom pr_pspawn ("PlayerSpawn");
+
+uint8_t         *democompspot;
+uint8_t         *demobodyspot;
+size_t          maxdemosize;
+uint8_t         *zdemformend; // end of FORM ZDEM chunk
+uint8_t         *zdembodyend; // end of ZDEM BODY chunk
+
+FIntCVarRef     *angleturn[4] = {&turnspeedwalkfast, &turnspeedsprintfast, &turnspeedwalkslow, &turnspeedsprintslow};
+int             flyspeed[2] = {1*256, 3*256};
+int             lookspeed[2] = {450, 512};
+
+int             turnheld; // for accelerative turning
+
+FString         shotfile; // [RH] Name of screenshot file to generate (usually NULL)
+
+FString         savename;
+
+bool            stoprecording;
+
+static int      nextautosave = -1;
+static int      lastquicksave = -1;
+
+static usercmd_t emptycmd;
+
+static float    axis_yaw = 0; // used for debug printouts
+static float    axis_pitch = 0;
+static float    axis_forward = 0;
+static float    axis_side = 0;
+static float    axis_up = 0;
+static int      strafe = 0;
+static int      speed = 0;
+static int      forward = 0;
+static int      side = 0;
+static int      fly = 0;
+static uint32_t buttons = 0;
+
+// CODE --------------------------------------------------------------------
 
 CCMD (turnspeeds)
 {
@@ -445,8 +515,6 @@ CCMD(invquery)
 	}
 }
 
-constexpr char True[] = "true";
-
 CCMD (use)
 {
 	if (argv.argc() > 1 && players[consoleplayer].mo != NULL)
@@ -542,14 +610,11 @@ FBaseCVar* G_GetUserCVar(int playernum, const char* cvarname)
 	return cvar;
 }
 
-static usercmd_t emptycmd;
-
 usercmd_t* G_BaseTiccmd()
 {
 	return &emptycmd;
 }
 
-static float axis_yaw = 0, axis_pitch = 0, axis_forward = 0, axis_side = 0, axis_up = 0;
 ADD_STAT (analogue)
 {
 	return FStringf(
@@ -558,8 +623,6 @@ ADD_STAT (analogue)
 	);
 }
 
-static int strafe = 0, speed = 0, forward = 0, side = 0, fly = 0;
-static uint32_t buttons = 0;
 ADD_STAT (digital)
 {
 	return FStringf(
@@ -912,15 +975,6 @@ void G_AddViewAngle (int yaw, bool mouse)
 	}
 }
 
-CVAR (Bool, bot_allowspy, false, 0)
-
-
-enum {
-	SPY_CANCEL = 0,
-	SPY_NEXT,
-	SPY_PREV,
-};
-
 // [RH] Spy mode has been separated into two console commands.
 //		One goes forward; the other goes backward.
 static void ChangeSpy (int changespy)
@@ -950,7 +1004,7 @@ static void ChangeSpy (int changespy)
 	// Otherwise, cycle to the next player.
 	bool checkTeam = !demoplayback && deathmatch;
 	int pnum = consoleplayer;
-	if (changespy != SPY_CANCEL) 
+	if (changespy != SPY_CANCEL)
 	{
 		player_t *player = players[consoleplayer].camera->player;
 		// only use the camera as starting index if it's a valid player.
@@ -1007,15 +1061,15 @@ bool G_Responder (event_t *ev)
 	// check events
 	if (ev->type != EV_Mouse && primaryLevel->localEventManager->Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
 		return true;
-	
+
 	if (gamestate == GS_INTRO || gamestate == GS_CUTSCENE)
 	{
 		return ScreenJobResponder(ev);
 	}
-	
+
 	// any other key pops up menu if in demos
 	// [RH] But only if the key isn't bound to a "special" command
-	if (gameaction == ga_nothing && 
+	if (gameaction == ga_nothing &&
 		(demoplayback || gamestate == GS_DEMOSCREEN || gamestate == GS_TITLELEVEL))
 	{
 		if (chatmodeon) chatmodeon = 0;
@@ -1054,14 +1108,14 @@ bool G_Responder (event_t *ev)
 	}
 
 	if (CT_Responder (ev))
-		return true;			// chat ate the event
+		return true; // chat ate the event
 
 	if (gamestate == GS_LEVEL)
 	{
 		if (ST_Responder (ev))
-			return true;		// status window ate it
+			return true; // status window ate it
 		if (!viewactive && primaryLevel->automap && primaryLevel->automap->Responder (ev, false))
-			return true;		// automap ate it
+			return true; // automap ate it
 	}
 
 	switch (ev->type)
@@ -1077,22 +1131,22 @@ bool G_Responder (event_t *ev)
 
 	// [RH] mouse buttons are sent as key up/down events
 	case EV_Mouse:
-        if(invertmousex)
-        {
+		if(invertmousex)
+		{
 		   mousex = -ev->x;
-        }
-        else
-        {
-            mousex = ev->x;
-        }
-        if(invertmouse)
-        {
-            mousey = -ev->y;
-        }
-        else
-        {
-            mousey = ev->y;
-        }
+		}
+		else
+		{
+			mousex = ev->x;
+		}
+		if(invertmouse)
+		{
+			mousey = -ev->y;
+		}
+		else
+		{
+			mousey = ev->y;
+		}
 		break;
 	}
 
@@ -1166,7 +1220,7 @@ static void D_CheckCutsceneAdvance()
 //
 void G_Ticker ()
 {
-	gamestate_t	oldgamestate;
+	gamestate_t oldgamestate;
 
 	// do player reborns if needed
 	// TODO: These should really be moved to queues.
@@ -1197,7 +1251,7 @@ void G_Ticker ()
 			G_RecordDemo(newdemoname.GetChars());
 			G_BeginRecording(newdemomap.GetChars());
 			[[fallthrough]];
-		case ga_newgame2:	// Silence GCC (see above)
+		case ga_newgame2: // Silence GCC (see above)
 		case ga_newgame:
 			G_DoNewGame ();
 			break;
@@ -1356,19 +1410,19 @@ void G_PlayerFinishLevel (int player, EFinishLevelType mode, int flags)
 //
 void FLevelLocals::PlayerReborn (int player)
 {
-	player_t*	p;
-	int 		frags[MAXPLAYERS];
-	int			fragcount;	// [RH] Cumulative frags
-	int 		killcount;
-	int 		itemcount;
-	int 		secretcount;
-	int			chasecam;
-	int			currclass;
-	userinfo_t  userinfo;	// [RH] Save userinfo
-	AActor *actor;
+	player_t*   p;
+	int         frags[MAXPLAYERS];
+	int         fragcount; // [RH] Cumulative frags
+	int         killcount;
+	int         itemcount;
+	int         secretcount;
+	int         chasecam;
+	int         currclass;
+	userinfo_t  userinfo; // [RH] Save userinfo
+	AActor      *actor;
 	PClassActor *cls;
-	FString		log;
-	DBot		*Bot;		//Added by MC:
+	FString     log;
+	DBot        *Bot; //Added by MC:
 
 	p = &players[player];
 
@@ -1383,7 +1437,7 @@ void FLevelLocals::PlayerReborn (int player)
 	cls = p->cls;
 	log = p->LogText;
 	chasecam = p->cheats & CF_CHASECAM;
-	Bot = p->Bot;			//Added by MC:
+	Bot = p->Bot; //Added by MC:
 	const bool settings_controller = p->settings_controller;
 
 	// Reset player structure to its defaults
@@ -1402,11 +1456,11 @@ void FLevelLocals::PlayerReborn (int player)
 	p->cls = cls;
 	p->LogText = log;
 	p->cheats |= chasecam;
-	p->Bot = Bot;			//Added by MC:
+	p->Bot = Bot; //Added by MC:
 	p->settings_controller = settings_controller;
 	p->LastSafePos.Update(*p->mo, true);
 
-	p->oldbuttons = ~0, p->attackdown = true; p->usedown = true;	// don't do anything immediately
+	p->oldbuttons = ~0, p->attackdown = true; p->usedown = true; // don't do anything immediately
 	p->original_oldbuttons = ~0;
 	p->playerstate = PST_LIVE;
 	NetworkEntityManager::SetClientNetworkEntity(p->mo, p - players);
@@ -1433,10 +1487,10 @@ void FLevelLocals::PlayerReborn (int player)
 }
 
 //
-// G_CheckSpot	
+// G_CheckSpot
 // Returns false if the player cannot be respawned
-// at the given mapthing spot  
-// because something is occupying it 
+// at the given mapthing spot
+// because something is occupying it
 //
 
 bool FLevelLocals::CheckSpot (int playernum, FPlayerStart *mthing)
@@ -1463,8 +1517,8 @@ bool FLevelLocals::CheckSpot (int playernum, FPlayerStart *mthing)
 		return true;
 	}
 
-	oldz = players[playernum].mo->Z();	// [RH] Need to save corpse's z-height
-	players[playernum].mo->SetZ(spot.Z);		// [RH] Checks are now full 3-D
+	oldz = players[playernum].mo->Z();   // [RH] Need to save corpse's z-height
+	players[playernum].mo->SetZ(spot.Z); // [RH] Checks are now full 3-D
 
 	// killough 4/2/98: fix bug where P_CheckPosition() uses a non-solid
 	// corpse to detect collisions with other players in DM starts
@@ -1476,7 +1530,7 @@ bool FLevelLocals::CheckSpot (int playernum, FPlayerStart *mthing)
 	players[playernum].mo->flags |=  MF_SOLID;
 	i = P_CheckPosition(players[playernum].mo, spot.XY());
 	players[playernum].mo->flags &= ~MF_SOLID;
-	players[playernum].mo->SetZ(oldz);	// [RH] Restore corpse's height
+	players[playernum].mo->SetZ(oldz); // [RH] Restore corpse's height
 	if (!i)
 		return false;
 
@@ -1485,9 +1539,9 @@ bool FLevelLocals::CheckSpot (int playernum, FPlayerStart *mthing)
 
 
 //
-// G_DeathMatchSpawnPlayer 
-// Spawns a player at one of the random death match spots 
-// called at level load and each death 
+// G_DeathMatchSpawnPlayer
+// Spawns a player at one of the random death match spots
+// called at level load and each death
 //
 
 // [RH] Returns the distance of the closest player to the given mapthing
@@ -1730,7 +1784,6 @@ void FLevelLocals::QueueBody (AActor *body)
 //
 // G_DoReborn
 //
-EXTERN_CVAR(Bool, sv_singleplayerrespawn)
 void FLevelLocals::DoReborn (int playernum, bool force)
 {
 	if (!multiplayer && !(flags2 & LEVEL2_ALLOWRESPAWN) && !sv_singleplayerrespawn &&
@@ -1867,8 +1920,6 @@ void G_ScreenShot (const char *filename)
 	}
 }
 
-
-
 //
 // G_InitFromSavegame
 // Can be called by the startup code or the menu task.
@@ -1950,7 +2001,7 @@ void C_SerializeCVars(FSerializer& arc, const char* label, uint32_t filter)
 			while (it.NextPair(pair))
 			{
 				auto cvar = pair->Value;
-				
+
 				if ((cvar->Flags & filter) && !(cvar->Flags & (CVAR_NOSAVE | CVAR_IGNORE | CVAR_CONFIG_ONLY)))
 				{
 					UCVarValue val = cvar->GetGenericRep(CVAR_String);
@@ -1983,11 +2034,6 @@ void C_SerializeCVars(FSerializer& arc, const char* label, uint32_t filter)
 		arc.EndObject();
 	}
 }
-
-
-void SetupLoadingCVars();
-void FinishLoadingCVars();
-bool CheckGZDoomSaveCompat(FString &engine, FString &software);
 
 void G_DoLoadGame ()
 {
@@ -2124,7 +2170,7 @@ void G_DoLoadGame ()
 
 	primaryLevel->BotInfo.RemoveAllBots(primaryLevel, true);
 
-	savegamerestore = true;		// Use the player actors in the savegame
+	savegamerestore = true; // Use the player actors in the savegame
 
 	FString cvar;
 	arc("importantcvars", cvar);
@@ -2149,7 +2195,7 @@ void G_DoLoadGame ()
 	level.time = Scale(time[1], TICRATE, time[0]);
 
 	G_ReadSnapshots(resfile.get());
-	resfile.reset(nullptr);	// we no longer need the resource file below this point
+	resfile.reset(nullptr); // we no longer need the resource file below this point
 	G_ReadVisited(arc);
 
 	// load a base level
@@ -2191,18 +2237,18 @@ void G_SaveGame (const char *filename, const char *description, bool quick)
 	{
 		Printf ("%s\n", GStrings.GetString("TXT_SAVEPENDING"));
 	}
-    else if (!usergame)
+	else if (!usergame)
 	{
 		Printf ("%s\n", GStrings.GetString("TXT_NOTSAVEABLE"));
-    }
-    else if (gamestate != GS_LEVEL)
+	}
+	else if (gamestate != GS_LEVEL)
 	{
 		Printf ("%s\n", GStrings.GetString("TXT_NOTINLEVEL"));
-    }
-    else if (players[consoleplayer].health <= 0 && !multiplayer)
-    {
+	}
+	else if (players[consoleplayer].health <= 0 && !multiplayer)
+	{
 		Printf ("%s\n", GStrings.GetString("TXT_SPPLAYERDEAD"));
-    }
+	}
 	else if (netgame && net_limitsaves && !players[consoleplayer].settings_controller)
 	{
 		Printf("Only settings controllers can save the game\n");
@@ -2232,24 +2278,6 @@ CCMD(opensaves)
 	I_OpenShellFolder(name.GetChars());
 }
 
-CVAR (Int, autosavenum, 0, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-static int nextautosave = -1;
-CVAR (Int, disableautosave, 0, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-CVAR (Bool, saveloadconfirmation, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG) // [mxd]
-CUSTOM_CVAR (Int, autosavecount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-{
-	if (self < 0)
-		self = 0;
-}
-CVAR (Int, quicksavenum, -1, CVAR_NOSET|CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-static int lastquicksave = -1;
-CVAR (Bool, quicksaverotation, false, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-CUSTOM_CVAR (Int, quicksaverotationcount, 4, CVAR_ARCHIVE|CVAR_GLOBALCONFIG)
-{
-	if (self < 1)
-		self = 1;
-}
-
 void G_DoAutoSave ()
 {
 	// Never autosave in netgames since you can't load this properly anyway.
@@ -2262,8 +2290,8 @@ void G_DoAutoSave ()
 	UCVarValue num;
 	const char *readableTime;
 	int count = autosavecount != 0 ? autosavecount : 1;
-	
-	if (nextautosave == -1) 
+
+	if (nextautosave == -1)
 	{
 		nextautosave = (autosavenum + 1) % count;
 	}
@@ -2301,8 +2329,8 @@ void G_DoQuickSave ()
 	UCVarValue num;
 	const char *readableTime;
 	int count = quicksaverotationcount != 0 ? quicksaverotationcount : 1;
-	
-	if (quicksavenum < 0) 
+
+	if (quicksavenum < 0)
 	{
 		lastquicksave = 0;
 	}
@@ -2418,8 +2446,8 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 	}
 
 	BufferWriter savepic;
-	FSerializer savegameinfo;		// this is for displayable info about the savegame
-	FSerializer savegameglobals;	// and this for non-level related info that must be saved.
+	FSerializer savegameinfo;    // this is for displayable info about the savegame
+	FSerializer savegameglobals; // and this for non-level related info that must be saved.
 
 	savegameinfo.OpenWriter(true);
 	savegameglobals.OpenWriter(save_formatted);
@@ -2493,7 +2521,7 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 	savegame_content.Push(savegameglobals.GetCompressedOutput());
 	savegame_filenames.Push("globals.json");
 	G_WriteSnapshots (savegame_filenames, savegame_content);
-	
+
 	for (unsigned i = 0; i < savegame_content.Size(); i++)
 		savegame_content[i].filename = savegame_filenames[i].GetChars();
 
@@ -2531,15 +2559,12 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 
 	// We don't need the snapshot any longer.
 	level.info->Snapshot.Clean();
-		
+
 	insave = false;
 
 	if (cl_waitforsave)
 		I_FreezeTime(false);
 }
-
-
-
 
 //
 // DEMO RECORDING
@@ -2590,16 +2615,12 @@ void G_ReadDemoTiccmd (usercmd_t *cmd, int player)
 			break;
 		}
 	}
-} 
-
-bool stoprecording;
+}
 
 CCMD (stop)
 {
 	stoprecording = true;
 }
-
-extern uint8_t *streamPos;
 
 void G_WriteDemoTiccmd (usercmd_t *cmd, int player, int buf)
 {
@@ -2653,13 +2674,13 @@ void G_RecordDemo (const char* name)
 	DefaultExtension (demoname, ".lmp");
 	maxdemosize = 0x20000;
 	demobuffer.Resize(maxdemosize);
-	demorecording = true; 
+	demorecording = true;
 }
 
 
 // [RH] Demos are now saved as IFF FORMs. I've also removed support
-//		for earlier ZDEMs since I didn't want to bother supporting
-//		something that probably wasn't used much (if at all).
+//      for earlier ZDEMs since I didn't want to bother supporting
+//      something that probably wasn't used much (if at all).
 
 void G_BeginRecording (const char *startmap)
 {
@@ -2671,18 +2692,18 @@ void G_BeginRecording (const char *startmap)
 	}
 	demo_p = TArrayView(demobuffer.Data(), demobuffer.Size());
 
-	WriteInt32 (FORM_ID, demo_p);			// Write FORM ID
-	AdvanceStream(demo_p, 4);				// Leave space for len
-	WriteInt32 (ZDEM_ID, demo_p);			// Write ZDEM ID
+	WriteInt32 (FORM_ID, demo_p); // Write FORM ID
+	AdvanceStream(demo_p, 4);     // Leave space for len
+	WriteInt32 (ZDEM_ID, demo_p); // Write ZDEM ID
 
 	// Write header chunk
 	StartChunk (ZDHD_ID, demo_p);
-	WriteInt16 (DEMOGAMEVERSION, demo_p);	// Write ZDoom version
-	WriteInt8(2, demo_p);					// Write minimum version needed to use this demo.
-	WriteInt8(3, demo_p);					// (Useful?)
+	WriteInt16 (DEMOGAMEVERSION, demo_p); // Write ZDoom version
+	WriteInt8(2, demo_p);                 // Write minimum version needed to use this demo.
+	WriteInt8(3, demo_p);                 // (Useful?)
 
-	WriteString(startmap, demo_p);			// Write name of map demo was recorded on.
-	WriteInt32(rngseed, demo_p);			// Write RNG seed
+	WriteString(startmap, demo_p);        // Write name of map demo was recorded on.
+	WriteInt32(rngseed, demo_p);          // Write RNG seed
 	WriteInt8(consoleplayer, demo_p);
 	FinishChunk (demo_p);
 
@@ -2771,7 +2792,7 @@ UNSAFE_CCMD (timedemo)
 }
 
 // [RH] Process all the information in a FORM ZDEM
-//		until a BODY chunk is entered.
+//      until a BODY chunk is entered.
 bool G_ProcessIFFDemo (FString &mapname)
 {
 	bool headerHit = false;
@@ -2818,13 +2839,13 @@ bool G_ProcessIFFDemo (FString &mapname)
 		case ZDHD_ID:
 			headerHit = true;
 
-			demover = ReadInt16 (demo_p);	// ZDoom version demo was created with
+			demover = ReadInt16 (demo_p); // ZDoom version demo was created with
 			if (demover < MINDEMOVERSION)
 			{
 				Printf ("Demo requires an older version of " GAMENAME "!\n");
 				//return true;
 			}
-			if (ReadInt16 (demo_p) > DEMOGAMEVERSION)	// Minimum ZDoom version
+			if (ReadInt16 (demo_p) > DEMOGAMEVERSION) // Minimum ZDoom version
 			{
 				Printf ("Demo requires a newer version of " GAMENAME "!\n");
 				return true;
@@ -2948,7 +2969,7 @@ void G_DoPlayDemo (void)
 		}
 		size_t demolen = fr.GetLength();
 		demobuffer.Resize(demolen);
-		if (fr.Read(demobuffer.Data(), demolen) != demolen)
+		if (static_cast<size_t>(fr.Read(demobuffer.Data(), demolen)) != demolen)
 		{
 			I_Error("Unable to read demo '%s'", defdemoname.GetChars());
 		}
@@ -2957,7 +2978,7 @@ void G_DoPlayDemo (void)
 
 	if (singledemo) Printf ("Playing demo %s\n", defdemoname.GetChars());
 
-	C_BackupCVars ();		// [RH] Save cvars that might be affected by demo
+	C_BackupCVars (); // [RH] Save cvars that might be affected by demo
 
 	if (ReadInt32 (demo_p) != FORM_ID)
 	{
@@ -2984,7 +3005,7 @@ void G_DoPlayDemo (void)
 	}
 	else
 	{
-		// don't spend a lot of time in loadlevel 
+		// don't spend a lot of time in loadlevel
 		precache = false;
 		demonew = true;
 		if (mapname.Len() != 0)
@@ -3044,7 +3065,7 @@ bool G_CheckDemoStatus (void)
 		if (timingdemo)
 			endtime = I_GetTime () - starttime;
 
-		C_RestoreCVars ();		// [RH] Restore cvars demo might have changed
+		C_RestoreCVars (); // [RH] Restore cvars demo might have changed
 		demobuffer.Reset();
 
 		P_SetupWeapons_ntohton();
@@ -3080,10 +3101,10 @@ bool G_CheckDemoStatus (void)
 		}
 		else
 		{
-			D_AdvanceDemo (); 
+			D_AdvanceDemo ();
 		}
 
-		return true; 
+		return true;
 	}
 
 	if (demorecording)
@@ -3125,7 +3146,7 @@ bool G_CheckDemoStatus (void)
 		stoprecording = false;
 		if (saved)
 		{
-			Printf ("Demo %s recorded\n", demoname.GetChars()); 
+			Printf ("Demo %s recorded\n", demoname.GetChars());
 		}
 		else
 		{
@@ -3133,7 +3154,7 @@ bool G_CheckDemoStatus (void)
 		}
 	}
 
-	return false; 
+	return false;
 }
 
 void G_StartSlideshow(FLevelLocals *Level, FName whichone, int state)

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -114,7 +114,7 @@ static void CollectDefaultSearchPaths()
 #   endif
 
 	bool shareDirChanged = 0 != strcmp(SHARE_DIR, DEFAULT_SHARE_DIR);
-	FString dataDir = GetDataPath();
+	FString dataDir = M_GetAppDataPath(true);
 
 #endif
 

--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -307,10 +307,15 @@ UNSAFE_CCMD (writeini)
 	}
 }
 
-CCMD(openconfig)
+void M_OpenConfigDir()
 {
 	M_SaveDefaults(nullptr);
 	I_OpenShellFolder(ExtractFilePath(GameConfig->GetPathName()).GetChars());
+}
+
+CCMD(openconfig)
+{
+	M_OpenConfigDir();
 }
 
 //
@@ -697,3 +702,24 @@ DEFINE_ACTION_FUNCTION_NATIVE(_CVar, SaveConfig, SaveConfig)
 	ACTION_RETURN_INT(M_SaveDefaults(nullptr));
 }
 
+void M_OpenWadDir()
+{
+	size_t dirlen;
+	FString autoname = M_GetAppDataPath(true);
+	dirlen = autoname.Len();
+	if (dirlen > 0)
+	{
+		if (autoname[dirlen-1] != '/' && autoname[dirlen-1] != '\\')
+		{
+			autoname += '/';
+		}
+	}
+	autoname = NicePath(autoname.GetChars());
+	CreatePath(autoname.GetChars());
+	I_OpenShellFolder(autoname.GetChars());
+}
+
+CCMD(openwads)
+{
+	M_OpenWadDir();
+}

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -40,6 +40,8 @@ void M_LoadDefaults ();
 bool M_SaveDefaults (const char *filename);
 void M_SaveCustomKeys (FConfigFile *config, char *section, char *subsection, size_t sublen);
 
+void M_OpenConfigDir();
+void M_OpenWadDir();
 
 #include "i_specialpaths.h"
 #endif

--- a/src/widgets/aboutpage.cpp
+++ b/src/widgets/aboutpage.cpp
@@ -103,12 +103,14 @@ void AboutPage::OnGeometryChanged()
 	double y = 0.0;
 	double w = GetWidth();
 	double h = GetHeight();
+	double tw, th;
 
-	Text->SetFrameGeometry(0.0, y, w, h - Notes->GetPreferredHeight() - 8.0);
-	y += h - Notes->GetPreferredHeight();
+	th = Notes->GetPreferredHeight();
+	tw = Notes->GetPreferredWidth();
+	Text->SetFrameGeometry(0.0, y, w, h - th - 8.0);
+	y += h - th;
 
-	// [Marcus] TODO: add PushButton.GetPreferredWidth()
-	Notes->SetFrameGeometry(round(w/2) - 100.0, y, 200.0, Notes->GetPreferredHeight());
+	Notes->SetFrameGeometry(round((w-tw)/2), y, tw, th);
 	y += h;
 
 	Launcher->UpdatePlayButton();

--- a/src/widgets/errorwindow.cpp
+++ b/src/widgets/errorwindow.cpp
@@ -23,6 +23,7 @@
 
 #include "errorwindow.h"
 #include "gstrings.h"
+#include "m_misc.h"
 #include "printf.h"
 #include "utf8.h"
 #include "v_font.h"
@@ -53,6 +54,13 @@ ErrorWindow::ErrorWindow(std::vector<uint8_t> initminidump) : Widget(nullptr, Wi
 	ClipboardButton = new PushButton(this);
 	ClipboardButton->OnClick = [=,this]() { OnClipboardButtonClicked(); };
 	ClipboardButton->SetText(GStrings.GetString("ACTION_COPYTOCLIPBOARD"));
+
+	WadDirButton = new PushButton(this);
+	WadDirButton->OnClick = [=]() { M_OpenWadDir(); };
+	WadDirButton->SetText(GStrings.GetString("ACTION_OPENWADDIR"));
+	ConfigDirButton = new PushButton(this);
+	ConfigDirButton->OnClick = [=]() { M_OpenConfigDir(); };
+	ConfigDirButton->SetText(GStrings.GetString("ACTION_OPENCONFIGDIR"));
 
 	if (minidump.empty())
 	{
@@ -158,11 +166,13 @@ void ErrorWindow::OnGeometryChanged()
 	{
 		if (!button) return;
 		auto w = button->GetPreferredWidth();
-		x -= 20.0 + w;
-		button->SetFrameGeometry(x, y, w, button->GetPreferredHeight());
+		x -= 10.0 + w;
+		button->SetFrameGeometry(x - 10, y, w, button->GetPreferredHeight());
 	};
 	rButton(RestartButton);
 	rButton(SaveReportButton);
+	rButton(ConfigDirButton);
+	rButton(WadDirButton);
 	y -= 20.0;
 
 	LogView->SetFrameGeometry(Rect::xywh(0.0, 0.0, w, y));

--- a/src/widgets/errorwindow.cpp
+++ b/src/widgets/errorwindow.cpp
@@ -51,19 +51,19 @@ ErrorWindow::ErrorWindow(std::vector<uint8_t> initminidump) : Widget(nullptr, Wi
 
 	LogView = new LogViewer(this);
 	ClipboardButton = new PushButton(this);
-	ClipboardButton->OnClick = [=]() { OnClipboardButtonClicked(); };
+	ClipboardButton->OnClick = [=,this]() { OnClipboardButtonClicked(); };
 	ClipboardButton->SetText(GStrings.GetString("ACTION_COPYTOCLIPBOARD"));
 
 	if (minidump.empty())
 	{
 		RestartButton = new PushButton(this);
-		RestartButton->OnClick = [=]() { OnRestartButtonClicked(); };
+		RestartButton->OnClick = [=,this]() { OnRestartButtonClicked(); };
 		RestartButton->SetText(GStrings.GetString("ACTION_RESTART"));
 	}
 	else
 	{
 		SaveReportButton = new PushButton(this);
-		SaveReportButton->OnClick = [=]() { OnSaveReportButtonClicked(); };
+		SaveReportButton->OnClick = [=,this]() { OnSaveReportButtonClicked(); };
 		SaveReportButton->SetText(GStrings.GetString("ERRORMNU_SAVE"));
 	}
 
@@ -150,12 +150,19 @@ void ErrorWindow::OnGeometryChanged()
 	double w = GetWidth();
 	double h = GetHeight();
 
-	double y = GetHeight() - 15.0 - ClipboardButton->GetPreferredHeight();
-	ClipboardButton->SetFrameGeometry(20.0, y, 170.0, ClipboardButton->GetPreferredHeight());
-	if (RestartButton)
-		RestartButton->SetFrameGeometry(GetWidth() - 20.0 - 100.0, y, 100.0, RestartButton->GetPreferredHeight());
-	else if (SaveReportButton)
-		SaveReportButton->SetFrameGeometry(GetWidth() - 20.0 - 100.0, y, 100.0, SaveReportButton->GetPreferredHeight());
+	double x = w;
+	double y = h - 15.0 - ClipboardButton->GetPreferredHeight();
+
+	ClipboardButton->SetFrameGeometry(20.0, y, ClipboardButton->GetPreferredWidth(), ClipboardButton->GetPreferredHeight());
+	auto rButton = [&x, y](PushButton *button)
+	{
+		if (!button) return;
+		auto w = button->GetPreferredWidth();
+		x -= 20.0 + w;
+		button->SetFrameGeometry(x, y, w, button->GetPreferredHeight());
+	};
+	rButton(RestartButton);
+	rButton(SaveReportButton);
 	y -= 20.0;
 
 	LogView->SetFrameGeometry(Rect::xywh(0.0, 0.0, w, y));
@@ -168,7 +175,7 @@ LogViewer::LogViewer(Widget* parent) : Widget(parent)
 	SetNoncontentSizes(8.0, 8.0, 3.0, 8.0);
 
 	scrollbar = new Scrollbar(this);
-	scrollbar->FuncScroll = [=]() { OnScrollbarScroll(); };
+	scrollbar->FuncScroll = [=,this]() { OnScrollbarScroll(); };
 }
 
 void LogViewer::SetText(const std::string& text, const std::string& log)

--- a/src/widgets/errorwindow.h
+++ b/src/widgets/errorwindow.h
@@ -48,6 +48,8 @@ private:
 	PushButton* ClipboardButton = nullptr;
 	PushButton* RestartButton = nullptr;
 	PushButton* SaveReportButton = nullptr;
+	PushButton* ConfigDirButton = nullptr;
+	PushButton* WadDirButton = nullptr;
 
 	std::vector<uint8_t> minidump;
 	std::string clipboardtext;

--- a/src/widgets/launcherbanner.cpp
+++ b/src/widgets/launcherbanner.cpp
@@ -30,7 +30,7 @@ LauncherBanner::LauncherBanner(Widget* parent) : Widget(parent)
 	this->SetStyleColor("background-color", Theme::getHeader(COLOR_BACKGROUND));
 }
 
-double LauncherBanner::GetPreferredHeight() const
+double LauncherBanner::GetPreferredHeight()
 {
 	return Logo->GetPreferredHeight();
 }

--- a/src/widgets/launcherbanner.h
+++ b/src/widgets/launcherbanner.h
@@ -27,7 +27,7 @@ class LauncherBanner : public Widget
 public:
 	LauncherBanner(Widget* parent);
 
-	double GetPreferredHeight() const;
+	double GetPreferredHeight() override;
 
 private:
 	void OnGeometryChanged() override;

--- a/src/widgets/launcherbuttonbar.cpp
+++ b/src/widgets/launcherbuttonbar.cpp
@@ -42,15 +42,18 @@ void LauncherButtonbar::UpdateLanguage()
 	ExitButton->SetText(GStrings.GetString("PICKER_EXIT"));
 }
 
-double LauncherButtonbar::GetPreferredHeight() const
+double LauncherButtonbar::GetPreferredHeight()
 {
 	return 20.0 + std::max(PlayButton->GetPreferredHeight(), ExitButton->GetPreferredHeight());
 }
 
 void LauncherButtonbar::OnGeometryChanged()
 {
-	PlayButton->SetFrameGeometry(20.0, 10.0, 120.0, PlayButton->GetPreferredHeight());
-	ExitButton->SetFrameGeometry(GetWidth() - 20.0 - 120.0, 10.0, 120.0, PlayButton->GetPreferredHeight());
+	double w, h;
+	h = std::max(PlayButton->GetPreferredHeight(), ExitButton->GetPreferredHeight());
+	w = 10 + std::max(PlayButton->GetPreferredWidth(), ExitButton->GetPreferredWidth());
+	PlayButton->SetFrameGeometry(20.0, 10.0, w, h);
+	ExitButton->SetFrameGeometry(GetWidth() - 20.0 - w, 10.0, w, h);
 }
 
 void LauncherButtonbar::OnPlayButtonClicked()

--- a/src/widgets/launcherbuttonbar.h
+++ b/src/widgets/launcherbuttonbar.h
@@ -28,7 +28,7 @@ public:
 	LauncherButtonbar(LauncherWindow* parent);
 	void UpdateLanguage();
 
-	double GetPreferredHeight() const;
+	double GetPreferredHeight() override;
 
 private:
 	void OnGeometryChanged() override;

--- a/src/widgets/netstartwindow.cpp
+++ b/src/widgets/netstartwindow.cpp
@@ -287,10 +287,23 @@ void NetStartWindow::OnGeometryChanged()
 	y = GetHeight() - 15.0 - AbortButton->GetPreferredHeight();
 	if (hosting)
 	{
-		AbortButton->SetFrameGeometry((w + 215.0) * 0.5, y, 100.0, AbortButton->GetPreferredHeight());
-		BanButton->SetFrameGeometry((w + 5.0) * 0.5, y, 100.0, BanButton->GetPreferredHeight());
-		KickButton->SetFrameGeometry((w - 205.0) * 0.5, y, 100.0, KickButton->GetPreferredHeight());
-		ForceStartButton->SetFrameGeometry((w - 415.0) * 0.5, y, 100.0, ForceStartButton->GetPreferredHeight());
+		Widget *bs[] = {AbortButton, BanButton, KickButton, ForceStartButton};
+		const size_t n = sizeof(bs)/sizeof(bs[0]);
+		double ws[n];
+		double hs[n];
+		double pos = 0, padding = 10.0;
+		for (size_t i = 0; i < n; i++)
+		{
+			ws[i] = bs[i]->GetPreferredWidth();
+			hs[i] = bs[i]->GetPreferredHeight();
+			pos += ws[i] + padding;
+		}
+		pos = (w - pos + padding) / 2;
+		for (size_t i = 0; i < n; i++)
+		{
+			bs[i]->SetFrameGeometry(pos, y, ws[i], hs[i]);
+			pos += ws[i] + padding;
+		}
 	}
 	else
 	{

--- a/src/widgets/networkpage.cpp
+++ b/src/widgets/networkpage.cpp
@@ -15,22 +15,20 @@
 **
 */
 
-
-#include "networkpage.h"
-#include "launcherwindow.h"
-#include "gstrings.h"
-#include "c_cvars.h"
-#include "i_net.h"
-#include "i_interface.h"
-#include "widgets/themedata.h"
 #include <zwidget/core/resourcedata.h>
-#include <zwidget/widgets/listview/listview.h>
-#include <zwidget/widgets/textlabel/textlabel.h>
 #include <zwidget/widgets/checkboxlabel/checkboxlabel.h>
-#include <zwidget/widgets/lineedit/lineedit.h>
-#include <zwidget/widgets/pushbutton/pushbutton.h>
-#include <zwidget/widgets/tabwidget/tabwidget.h>
 #include <zwidget/widgets/dropdown/dropdown.h>
+#include <zwidget/widgets/lineedit/lineedit.h>
+#include <zwidget/widgets/listview/listview.h>
+#include <zwidget/widgets/tabwidget/tabwidget.h>
+#include <zwidget/widgets/textlabel/textlabel.h>
+
+#include "gstrings.h"
+#include "i_interface.h"
+#include "i_net.h"
+#include "launcherwindow.h"
+#include "networkpage.h"
+#include "widgets/themedata.h"
 
 constexpr double EditHeight = 24.0;
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -383,6 +383,7 @@ OptionMenu "OptionsMenu" protected
 	
 	Command "$OPTMNU_CONSOLE",			"menuconsole"
 	Command "$OPTMNU_OPENCONFIG",		"openconfig"
+	Command "$OPTMNU_OPENWADS",			"openwads"
 	Command "$OPTMNU_OPENSCREENSHOTS",	"openscreenshots"
 	Command "$OPTMNU_OPENSAVES",		"opensaves"
 }


### PR DESCRIPTION
Adds a "Open wad dir" and "Open config dir" button to the error screen.

When the game cannot find any iwads, it gives a nice error explaining to either put wads in the right place, or to edit the config file to look elsewhere. I've noticed that people often have no idea how to get to the correct folder. This adds a button for that.

It also adds the same button to the options screen (next to the open screenshots) button. It also updates zwidget to be better. I'll upstream that when/if this gets merged.

<img width="1284" height="819" alt="Screenshot_20260323_231714" src="https://github.com/user-attachments/assets/2a20d583-28f3-4b80-b611-b94d4c8f2a4e" />

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
