### PR TITLE
prevent divide by 0 on some systems

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_bonebuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_bonebuffer.cpp
@@ -39,7 +39,7 @@ BoneBuffer::BoneBuffer(int pipelineNbr) : mPipelineNbr(pipelineNbr)
 	{
 		mBufferType = false;
 		mBlockSize = screen->maxuniformblock / BONE_SIZE;
-		mBlockAlign = screen->uniformblockalignment < 64 ? 1 : screen->uniformblockalignment / BONE_SIZE;
+		mBlockAlign = screen->uniformblockalignment < BONE_SIZE ? 1 : screen->uniformblockalignment / BONE_SIZE;
 		mMaxUploadSize = (mBlockSize - mBlockAlign);
 	}
 

--- a/src/common/rendering/hwrenderer/data/hw_lightbuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_lightbuffer.cpp
@@ -42,7 +42,7 @@ FLightBuffer::FLightBuffer(int pipelineNbr):
 	{
 		mBufferType = false;
 		mBlockSize = screen->maxuniformblock / ELEMENT_SIZE;
-		mBlockAlign = screen->uniformblockalignment / ELEMENT_SIZE;
+		mBlockAlign = screen->uniformblockalignment < ELEMENT_SIZE ? 1 : screen->uniformblockalignment / ELEMENT_SIZE;
 		mMaxUploadSize = (mBlockSize - mBlockAlign);
 
 		//mByteSize += screen->maxuniformblock;	// to avoid mapping beyond the end of the buffer. REMOVED this...This can try to allocate 100's of MB..


### PR DESCRIPTION
hopefully fixes the opengl crash on #1159, but doesn't close the issue as it doesn't fix the vulkan crash

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
