### PR TITLE
CVar Serialization Fix

### DIFF
--- a/src/common/console/c_cvars.cpp
+++ b/src/common/console/c_cvars.cpp
@@ -162,6 +162,7 @@ FBaseCVar::FBaseCVar (const char *var_name, uint32_t flags, void *callback, cons
 	m_Callback = callback;
 	Flags = 0;
 	VarName = "";
+	VarFName = "";
 	Description = descr;
 
 	FBaseCVar* var = nullptr;
@@ -170,6 +171,7 @@ FBaseCVar::FBaseCVar (const char *var_name, uint32_t flags, void *callback, cons
 		var = FindCVar(var_name, NULL);
 		C_AddTabCommand (var_name);
 		VarName = var_name;
+		VarFName = var_name;
 		cvarMap.Insert(var_name, this);
 	}
 

--- a/src/common/console/c_cvars.h
+++ b/src/common/console/c_cvars.h
@@ -149,6 +149,8 @@ public:
 	virtual ~FBaseCVar ();
 
 	inline const char *GetName () const { return VarName.GetChars(); }
+	inline size_t GetNameLen () const { return VarName.Len(); }
+	inline FName GetFName () const { return VarFName; }
 	inline uint32_t GetFlags () const { return Flags; }
 
 	void CmdSet (const char *newval);
@@ -237,6 +239,7 @@ protected:
 	static UCVarValue FromString (const char *value, ECVarType type);
 
 	FString VarName;
+	FName VarFName;
 	FString SafeValue;
 	FString Description;
 	FString ToggleMessages[2];

--- a/src/d_netinfo.cpp
+++ b/src/d_netinfo.cpp
@@ -402,7 +402,7 @@ void D_SetupUserInfo ()
 		if ((cvar->GetFlags() & (CVAR_USERINFO|CVAR_IGNORE)) == CVAR_USERINFO)
 		{
 			FBaseCVar **newcvar;
-			FName cvarname(cvar->GetName());
+			FName cvarname = cvar->GetFName();
 
 			switch (cvarname.GetIndex())
 			{
@@ -443,7 +443,7 @@ void userinfo_t::Reset(int pnum)
 		if ((cvar->GetFlags() & (CVAR_USERINFO|CVAR_IGNORE)) == CVAR_USERINFO)
 		{
 			ECVarType type;
-			FName cvarname(cvar->GetName());
+			FName cvarname = cvar->GetFName();
 			FBaseCVar *newcvar;
 
 			// Some cvars have different types for their shadow copies.
@@ -562,7 +562,7 @@ void D_UserInfoChanged (FBaseCVar *cvar)
 
 	val = cvar->GetGenericRep (CVAR_String);
 	escaped_val = D_EscapeUserInfo(val.String);
-	if (4 + strlen(cvar->GetName()) + escaped_val.Len() > 256)
+	if (4 + cvar->GetNameLen() + escaped_val.Len() > 256)
 		I_Error ("User info descriptor too big");
 
 	mysnprintf (foo, countof(foo), "\\%s\\%s", cvar->GetName(), escaped_val.GetChars());
@@ -659,7 +659,7 @@ bool D_SendServerInfoChange (FBaseCVar *cvar, UCVarValue value, ECVarType type)
 		}
 		size_t namelen;
 
-		namelen = strlen(cvar->GetName());
+		namelen = cvar->GetNameLen();
 
 		Net_WriteInt8(DEM_SINFCHANGED);
 		Net_WriteInt8((uint8_t)(namelen | (type << 6)));
@@ -690,7 +690,7 @@ bool D_SendServerFlagChange (FBaseCVar *cvar, int bitnum, bool set, bool silent)
 			return true;
 		}
 
-		int namelen = (int)strlen(cvar->GetName());
+		int namelen = (int)cvar->GetNameLen();
 
 		Net_WriteInt8(DEM_SINFCHANGEDXOR);
 		Net_WriteInt8((uint8_t)namelen);

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -660,7 +660,7 @@ void InitImports();
 struct UserInfoCVarNamePlayer
 {
 	FBaseCVar** addr;
-	FString name;
+	FName name;
 	int pnum;
 };
 
@@ -871,7 +871,7 @@ void InitThingdef()
 				}
 				else
 				{
-					FString name = self->GetName();
+					FName name = self->GetFName();
 					arc("name", name);
 				}
 
@@ -882,7 +882,7 @@ void InitThingdef()
 		{
 			FBaseCVar ** self = (FBaseCVar**)addr;
 
-			FString name;
+			FName name;
 			arc.BeginObject(key);
 
 			arc("name", name);


### PR DESCRIPTION
fix cvar serialization that broke from name optimization
(also remove a few strlen calls from network/serialization code and cache string -> name conversions for cvar names)

should hopefully fix #1080

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
