### PR TITLE
Add notice warning of undisclosed AI usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,11 +113,11 @@ all contributors must adhere to the following:
 ### AI Generated Code
 
 As LLMs are trained on unknown scraped data, no code generated entirely
-by an LLM may be submitted. AI may be used as a brainstorming or
-debugging aid, but all submitted code must be fundamentally authored
-and understood by the contributor to ensure it meets our quality and
-licensing standards. Code generated through traditional mechanical
-processes is not considered AI generated.
+by an LLM may be submitted. All submitted code must be fundamentally
+authored and understood by the contributor to ensure it meets our quality
+and licensing standards. Code generated through traditional mechanical
+processes is not considered AI generated. Any undisclosed use of AI will
+result in an organization-wide ban.
 
 ### Testing
 


### PR DESCRIPTION
Firmly showing our position, while allowing flexible enforcement, the changes are as follows:
> As LLMs are trained on unknown scraped data, no code generated entirely by an LLM may be submitted. ~~AI may be used as a brainstorming or debugging aid, but all~~ **All** submitted code must be fundamentally authored and understood by the contributor to ensure it meets our quality and licensing standards. Code generated through traditional mechanical processes is not considered AI generated. **Any undisclosed use of AI will result in an organization-wide ban.**

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
