### PR TITLE
fix compilation on vs19 and newer versions of python

### DIFF
--- a/libraries/Translation/scripts/compile.py
+++ b/libraries/Translation/scripts/compile.py
@@ -157,7 +157,7 @@ def main(args):
 
 	if po_files is None:
 		print(__doc__)
-		print(f"Available recipes: { " ".join(RECIPES.keys()) }")
+		print("Available recipes: " + (" ".join(RECIPES.keys())))
 		exit(1)
 
 	languages = po_files["languages"]

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -896,10 +896,19 @@ void InitThingdef()
 			{
 				if(int pnum; arc.ReadOptionalInt("player", pnum))
 				{
-					*self = nullptr;
-					LoadGameUserInfoCVars.Push({self, name, pnum}); // this needs to be done later, since userinfo isn't loaded yet
-					arc.EndObject();
-					return true;
+					if(arc.IsRollback())
+					{
+						*self = GetCVar(pnum, name.GetChars());
+						arc.EndObject();
+						return true;
+					}
+					else
+					{
+						*self = nullptr;
+						LoadGameUserInfoCVars.Push({self, name, pnum}); // this needs to be done later, since userinfo isn't loaded yet
+						arc.EndObject();
+						return true;
+					}
 				}
 			}
 			

--- a/src/utility/m_crc32.h
+++ b/src/utility/m_crc32.h
@@ -43,7 +43,8 @@ inline constexpr std::array<uint32_t, 256> generate_crc32_table(uint32_t polynom
 	return table;
 }
 
-inline constexpr auto crc32_table = generate_crc32_table(0xEDB88320);
+/*
+// VS19 doesn't like this
 template <auto Transformer = nullptr>
 inline constexpr uint32_t CalcCRC32(std::string_view data)
 {
@@ -57,6 +58,32 @@ inline constexpr uint32_t CalcCRC32(std::string_view data)
 	}
 	return crc ^ 0xFFFFFFFF;
 }
+*/
+
+inline constexpr auto crc32_table = generate_crc32_table(0xEDB88320);
+inline constexpr uint32_t CalcCRC32(std::string_view data)
+{
+	uint32_t crc = 0xFFFFFFFF;
+	for (uint8_t c : data)
+	{
+		uint8_t v = c;
+		crc = (crc >> 8) ^ crc32_table[(crc ^ v) & 0xFF];
+	}
+	return crc ^ 0xFFFFFFFF;
+}
+
+template<typename F>
+inline constexpr uint32_t CalcCRC32(std::string_view data, F && Transformer)
+{
+	uint32_t crc = 0xFFFFFFFF;
+	for (uint8_t c : data)
+	{
+		uint8_t v = Transformer(c);
+		crc = (crc >> 8) ^ crc32_table[(crc ^ v) & 0xFF];
+	}
+	return crc ^ 0xFFFFFFFF;
+}
+
 inline uint32_t CalcCRC32 (const uint8_t *buf, unsigned int len)
 {
 	return crc32 (0, buf, len);

--- a/src/utility/name.cpp
+++ b/src/utility/name.cpp
@@ -42,8 +42,8 @@ static constexpr size_t FindDuplicates()
 
 	size_t i = 0;
 	std::vector<std::pair<uint32_t, size_t>> hashes = {
-		#define xx(n) { CalcCRC32<tolower>(#n), i++ },
-		#define xy(n, s) { CalcCRC32<tolower>(s), i++ },
+		#define xx(n) { CalcCRC32(#n, tolower), i++ },
+		#define xy(n, s) { CalcCRC32(s, tolower), i++ },
 		#define xa(a, n)
 		#include "namedef.h"
 		#undef xx


### PR DESCRIPTION
VS19 doesn't like the auto template parameter being a lambda

and newer python treats `f"Available recipes: { " ".join(RECIPES.keys()) }"` as `f"Available recipes: { "` `<SPACE>` `".join(RECIPES.keys()) }"`

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
