### PR TITLE
Added a self-reference check to P_CheckSight

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -266,3 +266,4 @@ Francisco Ortega
 Adam Pliszka
 Vortex (vortexdesign)
 RageSpark
+Phil "Shadsy" Salvador

--- a/src/playsim/p_sight.cpp
+++ b/src/playsim/p_sight.cpp
@@ -881,6 +881,14 @@ sightcounts[0]++;
 		}
 	}
 
+	// Return true if the actor is calling CheckSight
+	// on themselves and they can see themselves
+	if (t1 == t2)
+	{
+		res = true;
+		goto done;
+	}
+	
 	// killough 4/19/98: make fake floors and ceilings block monster view
 
 	if (!(flags & SF_IGNOREWATERBOUNDARY))


### PR DESCRIPTION
If an actor calls CheckSight on themselves and they can see themselves, return true. Fixes #1147.

This is meant as a fix for a crash that occurs when an actor self-references with CheckSight while moving through a stacked portal. Boondorl suggested in Discord this should be the standard behavior for CheckSight anyway; there are no circumstances where a player is visible to themselves and a self-referenced CheckSight should return false.

~~Untested, but works in theory!~~ [See comment below](https://github.com/UZDoom/UZDoom/pull/1182#issuecomment-4140135490); these commits have been tested and they resolve the crash in #1147 without impacting other uses of CheckSight.

(If this does get added, I'd recommend squashing to one commit, since the first one had an error!)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
