### PR TITLE
Fixed underflow in P_RadiusAttack

### DIFF
--- a/src/playsim/p_map.cpp
+++ b/src/playsim/p_map.cpp
@@ -6293,7 +6293,7 @@ int P_RadiusAttack(AActor *bombspot, AActor *bombsource, int bombdamage, double 
 			!(flags & RADF_OLDRADIUSDAMAGE) && !(thing->Level->i_compatflags2 & COMPATF2_EXPLODE2)))
 		{
 			double points = GetRadiusDamage(false, bombspot, thing, bombdamage, bombdistance, fulldamagedistance, bombsource == thing,!!(flags & RADF_CIRCULAR));
-			double check = int(points) * bombdamage;
+			double check = double(int(points)) * bombdamage;
 			// points and bombdamage should be the same sign (the double cast of 'points' is needed to prevent overflows and incorrect values slipping through.)
 			if ((check > 0 || (check == 0 && bombspot->flags7 & MF7_FORCEZERORADIUSDMG)) && P_CheckSight(thing, bombspot, SF_IGNOREVISIBILITY | SF_IGNOREWATERBOUNDARY))
 			{ // OK to damage; target is in direct path


### PR DESCRIPTION
This fixes #1081. The underflow occurred when converting `points` to an integer, then multiplying that by a potentially large number.

Initially, I thought the solution to this issue would be to clamp this calculation around INT_MIN and INT_MAX. However, the more I thought about it... why was `points` being converted to an integer at all? Was that really necessary? I decided to dig deep into the code's history, and I actually found some good answers. Believe it or not, this bug was identified 10 years ago (!), fixed, and then accidentally broken again.

Wrapping `points` in an `int()` function was a hacky solution introduced in 2016 to prevent fractional damage values between 0.0–1.0 from being applied. (https://github.com/UZDoom/UZDoom/commit/1011e26eb98393a8b5e582df4e1d58d70012e5ee) Just a few weeks later, this was identified as a potential source of underflows/overflows, and the `int()` function was itself wrapped in a `double()` function. (https://github.com/UZDoom/UZDoom/commit/ba7260c1761c2f6846235bbc96650ab4eb728baa) Around a year later, the "is damage > 0" calculation was split out into its own variable called `check`. However, the new implementation did not wrap `int(points)` in a `double()` function. As a result, the over/underflow bug was accidentally reintroduced during calculation. (https://github.com/UZDoom/UZDoom/commit/26144340b804521c1d069aece5aa30f95eddf1ce)

In the interest of keeping backwards compatibility and maintaining the original intent of this code, the easiest solution is simply to wrap `int(points)` in a `double()` function again. This returns the code to its functional state in April 2016 when the bug was first identified and addressed. There are probably better ways to prevent fractional damage between 0.0–1.0 from being applied, but that's outside the scope of just getting this back to where it originally was.

This has been tested in Windows builds. The test example in #1081 now behaves correctly.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
