### PR TITLE
better message for experimental builds

### DIFF
--- a/.github/workflows/release_core.yml
+++ b/.github/workflows/release_core.yml
@@ -38,6 +38,14 @@ jobs:
           sparse-checkout: |
             README.md
 
+      - uses: actions/checkout@v6
+        if: ${{ inputs.is_experimental }}
+        with:
+          ref: trunk
+          fetch-depth: 0
+          sparse-checkout: |
+            README.md
+
       - name: Download Artifacts
         uses: actions/download-artifact@v8
         with:
@@ -80,10 +88,10 @@ jobs:
         name: Find Base Commit
         if: ${{ inputs.is_experimental }}
         run: |
-          echo "base=$(git merge-base trunk experimental)" >> "$GITHUB_OUTPUT"
+          echo "base=$(git merge-base trunk ${{ inputs.branch }})" >> "$GITHUB_OUTPUT"
           {
             echo 'message<<EOF'
-            git log --format=%B -n 1 $(git merge-base trunk experimental)
+            git log --format=%B -n 1 $(git merge-base trunk ${{ inputs.branch }})
             echo 'EOF'
           } >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release_core.yml
+++ b/.github/workflows/release_core.yml
@@ -19,6 +19,9 @@ on:
       message:
         required: true
         type: string
+      is_experimental:
+        required: true
+        type: boolean
 
 jobs:
   upload_release:
@@ -73,7 +76,28 @@ jobs:
           git tag ${{ inputs.tag-name }}
           git push origin ${{ inputs.tag-name }}
 
+      - id: base
+        name: Find Base Commit
+        if: ${{ inputs.is_experimental }}
+        run: |
+          echo "base=$(git merge-base trunk experimental)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'message<<EOF'
+            git log --format=%B -n 1 $(git merge-base trunk experimental)
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
+
+      - id: list_prs
+        name: List Experimental PRs
+        if: ${{ inputs.is_experimental }}
+        uses: buildsville/list-pull-requests@v1.0.1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          labels: '["experimental"]'
+          skip_hour: 0
+
       - name: Upload
+        if: ${{ !inputs.is_experimental }}
         uses: softprops/action-gh-release@v2.5.0 # FIXME: update this
         with:
           name: UZDoom ${{ inputs.title }}
@@ -91,3 +115,27 @@ jobs:
             **Version:** `${{ steps.tag.outputs.describe }}`
             **Message:** ${{ steps.tag.outputs.message }}
             **Workflow:** [Logs](${{ inputs.run-url }}) - [Artifacts](https://nightly.link/?url=${{ inputs.run-url }})
+
+      - name: Upload Experimental
+        if: ${{ inputs.is_experimental }}
+        uses: softprops/action-gh-release@v2.5.0 # FIXME: update this
+        with:
+          name: UZDoom ${{ inputs.title }}
+          tag_name: ${{ inputs.tag-name }}
+          draft: false
+          prerelease: true
+          make_latest: false
+          generate_release_notes: false
+          files: release/**
+          body: |
+            These builds are automatically generated based on the latest commit to `${{ inputs.branch }}`.
+
+            ${{ inputs.message }}
+
+            **Version:** `${{ steps.tag.outputs.describe }}`
+            **Message:** ${{ steps.tag.outputs.message }}
+            **Base Commit:** `${{ steps.base.outputs.base }}`
+            **Base Commit Message:** ${{ steps.base.outputs.message }}
+            **Workflow:** [Logs](${{ inputs.run-url }}) - [Artifacts](https://nightly.link/?url=${{ inputs.run-url }})
+            ### **Pull Requests Currently in Experimental:**
+            ${{ steps.list_prs.outputs.pulls }}

--- a/.github/workflows/upload_nightly.yml
+++ b/.github/workflows/upload_nightly.yml
@@ -20,6 +20,7 @@ jobs:
       branch: ${{ github.event.workflow_run.head_branch }}
       tag-name: x-preview
       message: They are development builds, so they may be unstable and have issues. Please report any problems you find.
+      is_experimental: false
 
   experimental:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'experimental' }}
@@ -34,3 +35,4 @@ jobs:
       branch: ${{ github.event.workflow_run.head_branch }}
       tag-name: x-testing
       message: ⚠️ They are experimental development builds, specifically to test upcoming features. **Use at your own risk**.
+      is_experimental: true


### PR DESCRIPTION
now lists the base commit (so that people can know it was updated if the update was only a sync to trunk) and lists the PRs that are in experimental

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
