### PR TITLE
Pixel-perfect crosshairs

### DIFF
--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -24,32 +24,28 @@
 
 #include <assert.h>
 
-
 #include "base_sbar.h"
-#include "printf.h"
-#include "v_draw.h"
-#include "cmdlib.h"
-#include "texturemanager.h"
 #include "c_cvars.h"
-#include "v_font.h"
-#include "utf8.h"
-#include "v_text.h"
-#include "vm.h"
+#include "cmdlib.h"
 #include "i_interface.h"
 #include "r_videoscale.h"
+#include "texturemanager.h"
+#include "utf8.h"
+#include "v_draw.h"
+#include "v_font.h"
+#include "v_text.h"
+#include "vm.h"
 
 FGameTexture* CrosshairImage;
 static int CrosshairNum;
 
-
 IMPLEMENT_CLASS(DStatusBarCore, false, false)
 IMPLEMENT_CLASS(DHUDFont, false, false);
 
-
 CVAR(Color, crosshaircolor, 0xff0000, CVAR_ARCHIVE);
-CVAR(Int, crosshairhealth, 2, CVAR_ARCHIVE);
-CVARD(Float, crosshairscale, 0.2, CVAR_ARCHIVE, "changes the size of the crosshair");
-CVAR(Bool, crosshairgrow, false, CVAR_ARCHIVE);
+CVARD(Int, crosshairhealth, 2, CVAR_ARCHIVE, "0: basic, 1: red-green, 2: blue-green-yellow-red");
+CVARD(Float, crosshairscale, 1.0, CVAR_ARCHIVE, "changes the size of the crosshair");
+CVARD(Bool, crosshairgrow, false, CVAR_ARCHIVE, "grow crosshair upon pickup");
 
 CUSTOM_CVARD(Float, hud_scalefactor, 1.f, CVAR_ARCHIVE, "changes the hud scale")
 {
@@ -62,7 +58,6 @@ CUSTOM_CVARD(Bool, hud_aspectscale, true, CVAR_ARCHIVE, "enables aspect ratio co
 {
 	if (sysCallbacks.HudScaleChanged) sysCallbacks.HudScaleChanged();
 }
-
 
 void ST_LoadCrosshair(int num, bool alwaysload)
 {
@@ -107,7 +102,6 @@ void ST_UnloadCrosshair()
 	CrosshairNum = 0;
 }
 
-
 //---------------------------------------------------------------------------
 //
 // DrawCrosshair
@@ -126,22 +120,14 @@ void ST_DrawCrosshair(int phealth, double xpos, double ypos, double scale, DAngl
 		return;
 	}
 
-	if (crosshairscale > 0.0f)
-	{
-		size = twod->GetHeight() * crosshairscale * 0.005;
-	}
-	else
-	{
-		size = 1.;
-	}
+	int mult = max(twod->Height/720, 1); // 1080p: 1, 1440p: 2, 4K: 3
 
-	if (crosshairgrow)
-	{
-		size *= scale;
-	}
+	size = ((crosshairscale > 0.0f)? crosshairscale: 1.0) * mult;
 
-	w = int(CrosshairImage->GetDisplayWidth() * size);
-	h = int(CrosshairImage->GetDisplayHeight() * size);
+	if (crosshairgrow) size *= scale;
+
+	w = round(CrosshairImage->GetDisplayWidth() * size);
+	h = round(CrosshairImage->GetDisplayHeight() * size);
 
 	if (crosshairhealth == 1)
 	{

--- a/src/common/statusbar/base_sbar.cpp
+++ b/src/common/statusbar/base_sbar.cpp
@@ -48,7 +48,7 @@ IMPLEMENT_CLASS(DHUDFont, false, false);
 
 CVAR(Color, crosshaircolor, 0xff0000, CVAR_ARCHIVE);
 CVAR(Int, crosshairhealth, 2, CVAR_ARCHIVE);
-CVARD(Float, crosshairscale, 0.5, CVAR_ARCHIVE, "changes the size of the crosshair");
+CVARD(Float, crosshairscale, 0.2, CVAR_ARCHIVE, "changes the size of the crosshair");
 CVAR(Bool, crosshairgrow, false, CVAR_ARCHIVE);
 
 CUSTOM_CVARD(Float, hud_scalefactor, 1.f, CVAR_ARCHIVE, "changes the hud scale")

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -112,7 +112,7 @@ EXTERN_CVAR(Float, hud_scalefactor)
 EXTERN_CVAR(Bool, hud_aspectscale)
 
 CVAR (Bool, crosshairon, true, CVAR_ARCHIVE);
-CVAR (Int, crosshair, 0, CVAR_ARCHIVE)
+CVAR (Int, crosshair, 1, CVAR_ARCHIVE)
 CVAR (Bool, crosshairforce, false, CVAR_ARCHIVE)
 CUSTOM_CVAR(Int, am_showmaplabel, 2, CVAR_ARCHIVE)
 {

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1546,7 +1546,7 @@ OptionMenu "HUDOptions" protected
 	Option "$HUDMNU_GROWCROSSHAIR",			"crosshairgrow", "OnOff"
 	ColorPicker "$HUDMNU_CROSSHAIRCOLOR", 	"crosshaircolor"
 	Option "$HUDMNU_CROSSHAIRHEALTH",		"crosshairhealth", "CrosshairHealthTypes"
-	Slider "$HUDMNU_CROSSHAIRSCALE",		"crosshairscale", 0.0, 2.0, 0.05, 2
+	Slider "$HUDMNU_CROSSHAIRSCALE",		"crosshairscale", 0.1, 10.0, 0.1, 1
 	StaticText " "
 	Option "$HUDMNU_NAMETAGS",				"displaynametags", "DisplayTagsTypes"
 	Option "$HUDMNU_NAMETAGCOLOR",			"nametagcolor", "TextColors", "displaynametags"


### PR DESCRIPTION
Continuation of #527

Still enables a default crosshair with a more sensible scale size for modern displays, but now is pixel-perfect.

<img width="2004" height="1199" alt="Screenshot_20260330_001328" src="https://github.com/user-attachments/assets/6654e392-e0e5-41bb-a910-abf87d4c4d0f" />

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
