### PR TITLE
Fix crash during shutdown

### DIFF
--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -231,6 +231,7 @@ int main (int argc, char **argv)
 		I_TryRestart(argv);
 	}
 
+	SDL_SetRelativeMouseMode(SDL_FALSE);
 	SDL_Quit();
 
 	return result;


### PR DESCRIPTION
Fixes this crash:
```
Thread 1 "uzdoom" received signal SIGSEGV, Segmentation fault.
pointer_dispatch_relative_motion (seat=0x55555747c6d0) at /usr/src/debug/SDL3-3.4.0-3.fc42.x86_64/src/video/wayland/SDL_waylandevents.c:1202
1202        SDL_SendMouseMotion(seat->pointer.pending_frame.timestamp_ns, window->sdlwindow, seat->pointer.sdl_id, true, (float)dx, (float)dy);
```

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
