### PR TITLE
Fix specific fonts selection in launcher since stringtable refactor

### DIFF
--- a/src/common/engine/stringtable.cpp
+++ b/src/common/engine/stringtable.cpp
@@ -167,7 +167,7 @@ inline FName GetFallback(FName name)
 		{"en-*-CA", "en-GB"},
 		{"en-*-SD", "en-GB"}, // TODO: support Subdivision
 		{"zh-*-CN", "zh-Hans-CN"},
-		{"zh-*-HK", "zh-Hans-HK"},
+		{"zh-*-HK", "zh-Hant-HK"},
 		{"zh-*-MO", "zh-Hant-MO"},
 		{"zh-*-SG", "zh-Hans-SG"},
 		{"zh-*-TW", "zh-Hant-TW"},
@@ -527,7 +527,9 @@ bool FStringTable::ParseLanguageCSV(int filenum, const char* buffer, size_t size
 						lang = "en-US";
 						hasDefaultEntry = true;
 					}
-					langrows.Push(std::make_pair(column, GetID(lang).normalized));
+					auto langid = GetID(lang).normalized;
+					langrows.Push(std::make_pair(column, langid));
+					InsertString(filenum, langid, "LANG", lang); // for retrieving language name from langid
 				}
 			}
 		}
@@ -771,7 +773,6 @@ void FStringTable::UpdateLanguage(const char *language)
 	size_t langlen = strlen(language);
 
 	auto LanguageID = ((langlen < 2) ? GetID("default"): GetID(language));
-	langName = LanguageID.name;
 	auto FallbackID = (LanguageID.fallback==NAME_None)? (LangID{NAME_None}): GetID(LanguageID.fallback.GetChars());
 	auto fallback = FallbackID.name;
 
@@ -805,6 +806,7 @@ void FStringTable::UpdateLanguage(const char *language)
 		currentLanguageSet.Push(std::make_pair(lang, list));
 		if (debug_languages) diagnostics.AppendFormat(" %c-%x", id, lang);
 	}
+	langName = CheckString("LANG");
 	if (debug_languages) Printf("Strings %s:%s\n", language, diagnostics.GetChars());
 }
 

--- a/src/widgets/errorwindow.cpp
+++ b/src/widgets/errorwindow.cpp
@@ -47,6 +47,8 @@ bool ErrorWindow::ExecModal(const std::string& text, const std::string& log, std
 
 ErrorWindow::ErrorWindow(std::vector<uint8_t> initminidump) : Widget(nullptr, WidgetType::Window), minidump(std::move(initminidump))
 {
+	GetCanvas()->setLanguage(GStrings.GetLangName().GetChars());
+
 	FStringf caption("%s - " GAMENAME " %s (%s)", GStrings.GetString("ERROR_FATAL"), GetVersionString(), GetGitTime());
 	SetWindowTitle(caption.GetChars());
 

--- a/src/widgets/widgetresourcedata.cpp
+++ b/src/widgets/widgetresourcedata.cpp
@@ -127,8 +127,8 @@ std::vector<SingleFontData> LoadWidgetFontData(const std::string& name, bool roo
 			// fonts with specific languages list here for high priority
 			{ "ui/noto/noto-sans-jp.ttf", "ja" },
 			{ "ui/noto/noto-sans-kr.ttf", "ko" },
-			{ "ui/noto/noto-sans-sc.ttf", "zh-Hans" },
-			// "ui/noto/noto-sans-tc.ttf", "zh-Hant" },
+			{ "ui/noto/noto-sans-sc.ttf", "zh_Hans" },
+			// "ui/noto/noto-sans-tc.ttf", "zh_Hant" },
 
 			// generic fonts
 			{ "ui/noto/noto-sans.ttf", ""},


### PR DESCRIPTION
Include some related bugs fixed:
- `zh-*-HK` (HongKong) uses `zh-Hant` (Tranditional Chinese).
- lang names in the specific font table should be exactly the same as the language.csv header.
- add `GetCanvas()->setLanguage` for error window.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
