### PR TITLE
SetMaxDisplayItems from 2 to 4 for LoadList in Launcher

### DIFF
--- a/src/widgets/settingspage.cpp
+++ b/src/widgets/settingspage.cpp
@@ -141,7 +141,7 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 	{
 		LoadLabel = new TextLabel(this);
 		LoadList = new Dropdown(this);
-		LoadList->SetMaxDisplayItems(2);
+		LoadList->SetMaxDisplayItems(4);
 		LoadList->SetDropdownDirection(false);
 		int opts = sizeof(FILELOAD_OPTS)/sizeof(FILELOAD_OPTS[0]), selected = opts-1;
 		for (int i = 0; i < opts; i++)


### PR DESCRIPTION
There are four options in the `LoadList` in the settings page of the Launcher, but the pop-up box only shows two items. We have to scroll to see the other two. I think it's unnecessary to do this in such a small box. Expanding the pop-up box to show all four items would be more intuitive.

Before:
<img width="199" height="155" alt="uzdoom_loadlist0" src="https://github.com/user-attachments/assets/9db3ccf8-f8f9-4c18-8b65-fcc0a6022f5f" />
After:
<img width="197" height="154" alt="uzdoom_loadlist1" src="https://github.com/user-attachments/assets/d56fe520-792f-45ab-9042-3f9c2324ed62" />

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
