### PR TITLE
Fix missing geometry update of LauncherWindow when language changed

### DIFF
--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -134,6 +134,8 @@ void LauncherWindow::UpdateLanguage()
 		Release->UpdateLanguage();
 	}
 	Buttonbar->UpdateLanguage();
+
+	OnGeometryChanged();
 }
 
 void LauncherWindow::OnClose()


### PR DESCRIPTION
The size of the `Play Game` button in launcher window is not updated when switching languages.

**Replication**
Set the current language to `Polish` in `uzdoom.ini`:
```
language=pl
```
Then start the launcher, and change the language to `English`, you will see:
<img width="193" height="185" alt="uzdoom_play" src="https://github.com/user-attachments/assets/4f8585d5-0553-483e-b431-c3deeba9cdbd" />

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
