### PR TITLE
Fix scrolling to the selected item for GamesList and LangList (#1083)

### DIFF
--- a/src/widgets/playgamepage.cpp
+++ b/src/widgets/playgamepage.cpp
@@ -60,7 +60,6 @@ PlayGamePage::PlayGamePage(LauncherWindow* launcher, const FStartupSelectionInfo
 	if (info.DefaultIWAD >= 0 && info.DefaultIWAD < info.Wads->SSize())
 	{
 		GamesList->SetSelectedItem(info.DefaultIWAD);
-		GamesList->ScrollToItem(info.DefaultIWAD);
 	}
 
 	GamesList->OnActivated = [=]() { OnGamesListActivated(); };
@@ -126,4 +125,6 @@ void PlayGamePage::OnGeometryChanged()
 	GamesList->SetFrameGeometry(0.0, listViewTop, GetWidth(), std::max(y - listViewTop, 0.0));
 
 	Launcher->UpdatePlayButton();
+
+	GamesList->ScrollToItem(GamesList->GetSelectedItem());
 }

--- a/src/widgets/settingspage.cpp
+++ b/src/widgets/settingspage.cpp
@@ -308,4 +308,6 @@ void SettingsPage::OnGeometryChanged()
 	y += LoadList->GetHeight();
 
 	Launcher->UpdatePlayButton();
+
+	LangList->ScrollToItem(LangList->GetSelectedItem());
 }


### PR DESCRIPTION
I've decided to release a PR to solve the issue (#1083) I raised so many days before.
Calling `ScrollToItem` in `OnGeometryChanged` seems to be a decent and simple solution. The only side effect is that when switching tabs or changing the window size, it will also scroll to the selected item, but I don't think it's bad.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
