### PR TITLE
Sealing leak in reflective-flats border

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_flats.cpp
+++ b/src/rendering/hwrenderer/scene/hw_flats.cpp
@@ -311,7 +311,6 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 	int rel = getExtraLight();
 
 	state.SetNormal(plane.plane.Normal().X, plane.plane.Normal().Z, plane.plane.Normal().Y);
-	double zshift = (plane.plane.Normal().Z > 0.0 ? 0.1f : -0.1f); // The HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats
 
 	SetColor(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), Colormap, alpha);
 	SetFog(state, di->Level, di->lightmode, lightlevel, rel, di->isFullbrightScene(), &Colormap, false);
@@ -362,11 +361,7 @@ void HWFlat::DrawFlat(HWDrawInfo *di, FRenderState &state, bool translucent)
 			else state.AlphaFunc(Alpha_GEqual, 0.f);
 			state.SetMaterial(texture, UF_Texture, 0, CLAMP_NONE, NO_TRANSLATION, -1);
 			SetPlaneTextureRotation(state, &plane, texture);
-			di->VPUniforms.mViewMatrix.translate(0.0, zshift, 0.0);
-			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
 			DrawSubsectors(di, state);
-			di->VPUniforms.mViewMatrix.translate(0.0, -zshift, 0.0);
-			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
 			state.EnableTextureMatrix(false);
 		}
 		state.SetRenderStyle(DefaultRenderStyle());

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -28,6 +28,7 @@
 #include "hw_lighting.h"
 #include "hw_cvars.h"
 #include "texturemanager.h"
+#include "hw_viewpointbuffer.h"
 
 void SetPlaneTextureRotation(FRenderState& state, HWSectorPlane* plane, FGameTexture* texture);
 
@@ -254,6 +255,12 @@ void HWPortal::SetupStencil(HWDrawInfo *di, FRenderState &state, bool usestencil
 	
 	if (usestencil)
 	{
+		if (GetMirrorSide() != 0) // (strcmp(GetName(), "Planemirror ceiling") == 0) || (strcmp(GetName(), "Planemirror floor") == 0))
+		{
+			di->VPUniforms.mViewMatrix.translate(0.0, -zshift * GetMirrorSide(), 0.0);
+			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
+		}
+
 		// Create stencil
 		state.SetStencil(0, SOP_Increment);	// create stencil, increment stencil of valid pixels
 		state.SetColorMask(false);
@@ -298,6 +305,11 @@ void HWPortal::SetupStencil(HWDrawInfo *di, FRenderState &state, bool usestencil
 		}
 		screen->stencilValue++;
 		
+		if (GetMirrorSide() != 0) // (strcmp(GetName(), "Planemirror ceiling") == 0) || (strcmp(GetName(), "Planemirror floor") == 0))
+		{
+			di->VPUniforms.mViewMatrix.translate(0.0, zshift * GetMirrorSide(), 0.0);
+			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
+		}
 		
 	}
 	else
@@ -332,6 +344,12 @@ void HWPortal::RemoveStencil(HWDrawInfo *di, FRenderState &state, bool usestenci
 	if (usestencil)
 	{
 		
+		if (GetMirrorSide() != 0) // (strcmp(GetName(), "Planemirror ceiling") == 0) || (strcmp(GetName(), "Planemirror floor") == 0))
+		{
+			di->VPUniforms.mViewMatrix.translate(0.0, -zshift * GetMirrorSide(), 0.0);
+			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
+		}
+
 		state.SetColorMask(false);						// no graphics
 		state.SetEffect(EFF_NONE);
 		state.ResetColor();
@@ -364,6 +382,11 @@ void HWPortal::RemoveStencil(HWDrawInfo *di, FRenderState &state, bool usestenci
 		
 		// restore old stencil op.
 		state.SetStencil(0, SOP_Keep);
+		if (GetMirrorSide() != 0) // (strcmp(GetName(), "Planemirror ceiling") == 0) || (strcmp(GetName(), "Planemirror floor") == 0))
+		{
+			di->VPUniforms.mViewMatrix.translate(0.0, zshift * GetMirrorSide(), 0.0);
+			screen->mViewpoints->SetViewpoint(state, &di->VPUniforms);
+		}
 	}
 	else
 	{
@@ -946,6 +969,28 @@ void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 
 			state.SetNormal(flat.plane.plane.Normal().X, flat.plane.plane.Normal().Z, flat.plane.plane.Normal().Y);
 			state.DrawIndexed(DT_Triangles, flat.iboindex + flat.section->vertexindex, flat.section->vertexcount, i == 0);
+		}
+		// Cannot combine these two for loops because of the DrawIndexed() vs Draw() calls interleaving
+		for (unsigned int i = 0; i < lines.Size(); i++)
+		{
+			flat.section = lines[i].sub->section;
+			flat.iboindex = lines[i].sub->sector->iboindex[isceiling ? sector_t::ceiling : sector_t::floor];
+			flat.plane.GetFromSector(lines[i].sub->sector, isceiling ? sector_t::ceiling : sector_t::floor);
+			screen->mVertexData->Map();
+			auto verts = screen->mVertexData->AllocVertices(5);
+			auto ptr = verts.first;
+			ptr[0].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
+					   lines[i].vertexes[0]->p.Y, 0, 0);
+			ptr[1].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p),
+					   lines[i].vertexes[1]->p.Y, 0, 0);
+			ptr[2].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p) + zshift*GetMirrorSide(),
+					   lines[i].vertexes[1]->p.Y, 0, 0);
+			ptr[3].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p) + zshift*GetMirrorSide(),
+					   lines[i].vertexes[0]->p.Y, 0, 0);
+			ptr[4].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
+					   lines[i].vertexes[0]->p.Y, 0, 0);
+			screen->mVertexData->Unmap();
+			state.Draw(DT_TriangleStrip, verts.second, 5, screen->IsVulkan());
 		}
 	}
 	else

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -81,6 +81,7 @@ public:
 	TArray<HWWall> lines;
 	BoundingRect boundingBox;
 	int planesused = 0;
+	float zshift = 0.1; 	// HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats unless zshift >= 0.1
 	HWFlat flat;
 
     HWPortal(FPortalSceneState *s, bool local = false) : mState(s), boundingBox(false)

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -383,15 +383,6 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 		pitch.Normalized180();
 
 		mat.Translate(x, z, y);
-		// Account for zshift in hw_flats.cpp due to flat stencils used to render reflective flats
-		if ((actor->Sector->GetReflect(sector_t::floor) > 0) && (z == actor->floorz))
-		{
-			mat.Translate(0, 0.1f, 0);
-		}
-		else if ((actor->Sector->GetReflect(sector_t::ceiling) > 0) && (z == actor->ceilingz))
-		{
-			mat.Translate(0, -0.1f, 0);
-		}
 		mat.Rotate(0, 1, 0, 270. - Angles.Yaw.Degrees());
 		mat.Rotate(1, 0, 0, pitch.Degrees());
 


### PR DESCRIPTION
Added short, vertical stencil walls to seal the seams of reflective-flats stencil. Insetting stencil plane to slightly below floor or above ceiling instead of moving translucent flat texture inward to prevent z-fighting with stencil.

Closes https://github.com/UZDoom/UZDoom/issues/1221
While still avoiding an older z-fighting rendering bug: https://github.com/ZDoom/gzdoom/issues/3246

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
