### PR TITLE
Fixed missing params in FillSelectMenu

### DIFF
--- a/src/common/audio/sound/s_reverbedit.cpp
+++ b/src/common/audio/sound/s_reverbedit.cpp
@@ -365,8 +365,8 @@ DEFINE_ACTION_FUNCTION(DReverbEdit, FillSelectMenu)
 			if (func != nullptr)
 			{
 				DMenuItemBase *item = (DMenuItemBase*)cls->CreateNew();
-				VMValue params[] = { item, &text, FName(cmd).GetIndex(), false, true };
-				VMCall(func->Variants[0].Implementation, params, 5, nullptr, 0);
+				VMValue params[] = { item, &text, FName(cmd).GetIndex(), false, true, (FIntCVar*)nullptr, 0, FName("Hide").GetIndex() };
+				VMCall(func->Variants[0].Implementation, params, 8, nullptr, 0);
 				desc->mItems.Push((DMenuItemBase*)item);
 			}
 		}


### PR DESCRIPTION
Caused a VM Abort when opening the menu where you select the reverb environments

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
