### PR TITLE
Launcher Drag+Drop support

### DIFF
--- a/libraries/ZWidget/include/zwidget/core/widget.h
+++ b/libraries/ZWidget/include/zwidget/core/widget.h
@@ -217,6 +217,7 @@ private:
 	void OnWindowActivated() override;
 	void OnWindowDeactivated() override;
 	void OnWindowDpiScaleChanged() override;
+	bool OnFileDrop(std::string path) override;
 
 	void NotifySubscribers(const WidgetEvent type);
 

--- a/libraries/ZWidget/include/zwidget/window/window.h
+++ b/libraries/ZWidget/include/zwidget/window/window.h
@@ -145,6 +145,7 @@ public:
 	virtual void OnWindowActivated() = 0;
 	virtual void OnWindowDeactivated() = 0;
 	virtual void OnWindowDpiScaleChanged() = 0;
+	virtual bool OnFileDrop(std::string path) = 0;
 };
 
 class DisplayWindow

--- a/libraries/ZWidget/src/core/widget.cpp
+++ b/libraries/ZWidget/src/core/widget.cpp
@@ -916,6 +916,11 @@ void Widget::OnWindowDpiScaleChanged()
 {
 }
 
+bool Widget::OnFileDrop(std::string path)
+{
+	return (FocusWidget && FocusWidget->OnFileDrop(path)) || (ParentObj && ParentObj->OnFileDrop(path));
+}
+
 double Widget::GetDpiScale() const
 {
 	Widget* w = Window();

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_window.cpp
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_window.cpp
@@ -1,4 +1,5 @@
 #include "sdl2_display_window.h"
+#include <SDL2/SDL_events.h>
 #include <stdexcept>
 #include <SDL2/SDL_vulkan.h>
 
@@ -435,6 +436,7 @@ SDL2DisplayWindow* SDL2DisplayWindow::FindEventWindow(const SDL_Event& event)
 	case SDL_MOUSEBUTTONDOWN:      windowID = event.button.windowID; break;
 	case SDL_MOUSEWHEEL:           windowID = event.wheel.windowID;  break;
 	case SDL_MOUSEMOTION:          windowID = event.motion.windowID; break;
+	case SDL_DROPFILE:             windowID = event.drop.windowID;   break;
 	case SDL_CONTROLLERBUTTONUP:   break; // use last event
 	case SDL_CONTROLLERBUTTONDOWN: break; // use last event
 	default:
@@ -481,6 +483,7 @@ void SDL2DisplayWindow::DispatchEvent(const SDL_Event& event)
 	case SDL_MOUSEBUTTONDOWN:      window->OnMouseButtonDown(event.button);  break;
 	case SDL_MOUSEWHEEL:           window->OnMouseWheel     (event.wheel);   break;
 	case SDL_MOUSEMOTION:          window->OnMouseMotion    (event.motion);  break;
+	case SDL_DROPFILE:             window->OnFileDrop       (event.drop);    break;
 	case SDL_CONTROLLERBUTTONUP:   window->OnJoyButtonUp    (event.cbutton); break;
 	case SDL_CONTROLLERBUTTONDOWN: window->OnJoyButtonDown  (event.cbutton); break;
 	default:
@@ -551,6 +554,14 @@ void SDL2DisplayWindow::OnKeyUp(const SDL_KeyboardEvent& event)
 void SDL2DisplayWindow::OnKeyDown(const SDL_KeyboardEvent& event)
 {
 	WindowHost->OnWindowKeyDown(ScancodeToInputKey(event.keysym.scancode));
+}
+
+void SDL2DisplayWindow::OnFileDrop(const SDL_DropEvent& event)
+{
+	if (event.file == nullptr) return;
+	std::string file{event.file};
+	WindowHost->OnFileDrop(file);
+	SDL_free(event.file);
 }
 
 InputKey SDL2DisplayWindow::GetMouseButtonKey(const SDL_MouseButtonEvent& event)

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_window.h
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_window.h
@@ -69,6 +69,7 @@ public:
 	void OnMouseMotion(const SDL_MouseMotionEvent& event);
 	void OnJoyButtonUp(const SDL_ControllerButtonEvent& event);
 	void OnJoyButtonDown(const SDL_ControllerButtonEvent& event);
+	void OnFileDrop(const SDL_DropEvent& event);
 	void OnPaintEvent();
 	static void OnTimerEvent(const SDL_UserEvent& event);
 

--- a/src/widgets/playgamepage.cpp
+++ b/src/widgets/playgamepage.cpp
@@ -96,6 +96,17 @@ void PlayGamePage::OnSetFocus()
 	GamesList->SetFocus();
 }
 
+bool PlayGamePage::OnFileDrop(std::string path)
+{
+	auto text = ParametersEdit->GetText();
+	if (!text.empty()) text += " ";
+	text += "-file '";
+	text += path;
+	text += "'";
+	ParametersEdit->SetText(text);
+	return true;
+}
+
 void PlayGamePage::OnGeometryChanged()
 {
 	double y = 10.0;

--- a/src/widgets/playgamepage.h
+++ b/src/widgets/playgamepage.h
@@ -38,6 +38,7 @@ private:
 	void OnGeometryChanged() override;
 	void OnSetFocus() override;
 	void OnGamesListActivated();
+	bool OnFileDrop(std::string) override;
 
 	LauncherWindow* Launcher = nullptr;
 


### PR DESCRIPTION
Tosses the path to the file into the args bar upon drag+drop. The implementation is the bare minimum, but it's good enough to help a new user. A more correct implementation should be done during the upcoming launcher re-work.

Fixes #1297

Needs someone with @UZDoom/windows knowledge to implement the same thing on that side of things.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
