### PR TITLE
Fix menu issue

### DIFF
--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -1188,7 +1188,7 @@ DMenuItemBase * CreateOptionMenuItemJoyConfigMenu(const char *label, IJoystickCo
 DMenuItemBase * CreateOptionMenuItemSubmenu(
 	const char *label,
 	FName cmd,
-	int center,
+	int param,
 	FIntCVar *greycheck,
 	int greycheckVal,
 	FName greycheckMode
@@ -1197,7 +1197,7 @@ DMenuItemBase * CreateOptionMenuItemSubmenu(
 	auto c = PClass::FindClass("OptionMenuItemSubmenu");
 	auto p = c->CreateNew();
 	FString namestr = label;
-	VMValue params[] = { p, &namestr, cmd.GetIndex(), 0, center, greycheck, greycheckVal, greycheckMode.GetIndex() };
+	VMValue params[] = { p, &namestr, cmd.GetIndex(), param, false, greycheck, greycheckVal, greycheckMode.GetIndex() };
 	auto f = dyn_cast<PFunction>(c->FindSymbol("Init", false));
 	VMCall(f->Variants[0].Implementation, params, countof(params), nullptr, 0);
 	return (DMenuItemBase*)p;

--- a/src/common/menu/menu.h
+++ b/src/common/menu/menu.h
@@ -356,7 +356,7 @@ bool M_IsAnimated();
 
 struct IJoystickConfig;
 DMenuItemBase * CreateOptionMenuItemStaticText(const char *name, int v = -1, FIntCVar *greycheck = nullptr, int greycheckVal = 0, FName greycheckMode = NAME_Hide);
-DMenuItemBase * CreateOptionMenuItemSubmenu(const char *label, FName cmd, int center, FIntCVar *greycheck = nullptr, int greycheckVal = 0, FName greycheckMode = NAME_Hide);
+DMenuItemBase * CreateOptionMenuItemSubmenu(const char *label, FName cmd, int param, FIntCVar *greycheck = nullptr, int greycheckVal = 0, FName greycheckMode = NAME_Hide);
 DMenuItemBase * CreateOptionMenuItemControl(const char *label, FName cmd, FKeyBindings *bindings);
 DMenuItemBase * CreateOptionMenuItemJoyConfigMenu(const char *label, IJoystickConfig *joy);
 DMenuItemBase * CreateListMenuItemPatch(double x, double y, int height, int hotkey, FTextureID tex, FName command, int param);


### PR DESCRIPTION
So this was caused by an arg being miss-labeled as `center`, when it was actually the `param` arg. I think the correct thing to do is just change the name of the arg? I don't see it in the docs anywhere, so it should be fine.

Fixes #1237

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
