### PR TITLE
Fix the vertical centering issue of the noto family fonts drawn in lineedit

### DIFF
--- a/src/widgets/widgetresourcedata.cpp
+++ b/src/widgets/widgetresourcedata.cpp
@@ -73,6 +73,8 @@ void InitWidgetResources(const char* filename)
 		Theme::getClick (COLOR_BACKGROUND), Theme::getClick (COLOR_TEXT),
 		Theme::getBorder(COLOR_LIGHT),      Theme::getBorder(COLOR_HEAVY),
 	}}));
+
+	WidgetTheme::GetTheme()->GetStyle("lineedit")->SetDouble("noncontent-top", 6.0); // applicable to noto family fonts
 }
 
 void CloseWidgetResources()


### PR DESCRIPTION
This pr fixed the issue #1282

Preview:
<img width="196" height="74" alt="uzdoom_lineedit" src="https://github.com/user-attachments/assets/f0114ba5-8526-4e9e-9002-c18a6cb0ad39" />


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
