### PR TITLE
Add optional pride colors to launcher

### DIFF
--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -70,6 +70,8 @@ CVAR(Int, defaultnethostteam, 255, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Int, defaultnetjointeam, 255, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(Bool, defaultnetextratic, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 CVAR(String, defaultnetsavefile, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(String, ui_colors, "", CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
+CVAR(Float, ui_color_mix, .35, CVAR_ARCHIVE | CVAR_GLOBALCONFIG);
 
 EXTERN_CVAR(Bool, ui_generic)
 EXTERN_CVAR(Int, vid_preferbackend)
@@ -81,6 +83,9 @@ CUSTOM_CVAR(String, language, "auto", CVAR_ARCHIVE | CVAR_NOINITCALL | CVAR_GLOB
 	UpdateGenericUI(ui_generic);
 	if (sysCallbacks.LanguageChanged) sysCallbacks.LanguageChanged(self);
 }
+
+FARG(pride, "Launcher", "Show pride colors", "",
+	 "Show pride colors in launcher.");
 
 // Some of this info has to be passed and managed from the front end since it's game-engine specific.
 FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs& args, int startFlags) : Wads(&wads), Args(&args), DefaultStartFlags(startFlags)
@@ -132,6 +137,9 @@ FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs
 	DefaultNetAddress = defaultnetaddress;
 	DefaultNetJoinPort = defaultnetjoinport;
 	DefaultNetJoinTeam = defaultnetjointeam;
+
+	prideColors = Args->CheckParm(FArg_pride)? "list": ui_colors;
+	prideMix = ui_color_mix;
 }
 
 // Return whatever IWAD the user selected.

--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -98,6 +98,8 @@ struct FStartupSelectionInfo
 	bool DefaultFullscreen = true;
 	int DefaultFileLoadBehaviour = 0;
 	bool notifyNewRelease = true;
+	FName prideColors = {};
+	float prideMix = 0;
 
 	// Net game info
 	int DefaultNetIWAD = 0;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -278,7 +278,7 @@ FARG(nointro, "Loading", "Skips intro video", "",
 FARG(episode, "Loading", "Starts the game on the first map of an episode", "1",
 	"Like -warp, bu starts the game on the first map of the specified episode");
 
-FARG(showlauncher, "Loading", "Forces the startup launcher to show, even if disabled through other means.", "",
+FARG(showlauncher, "Launcher", "Forces the startup launcher to show, even if disabled through other means.", "",
 	"Forces the startup launcher to show, even if disabled through other means.");
 
 FARG(version, "Other", "Print version", "",

--- a/src/utility/colorspace.cpp
+++ b/src/utility/colorspace.cpp
@@ -34,6 +34,23 @@ Color rgb(ColorP r, ColorP g, ColorP b)
 	return { SRGB, r, g, b };
 }
 
+Color rgb(uint32_t rgb24)
+{
+	ColorP r = ((rgb24>>16)&0xff)/255.0;
+	ColorP g = ((rgb24>>8 )&0xff)/255.0;
+	ColorP b = ((rgb24    )&0xff)/255.0;
+	return rgb(r, g, b);
+}
+
+uint32_t rgb24(const Color& c)
+{
+	Color C {c};
+	memcpy(&C, &c, sizeof(c));
+	_2rgb(C);
+	uint8_t r = C.rgb.r*255, g = C.rgb.g*255, b = C.rgb.b*255;
+	return r<<16 | g<<8 | b;
+};
+
 Color rgb(const Color& c)
 {
 	Color C {c};

--- a/src/utility/colorspace.h
+++ b/src/utility/colorspace.h
@@ -77,4 +77,7 @@ void oklab2oklch(Color& lab);
 
 Color mix(const Color& a, const Color& b, ColorP mix);
 
+Color rgb(uint32_t c);
+uint32_t rgb24(const Color& c);
+
 }

--- a/src/widgets/launcherbanner.cpp
+++ b/src/widgets/launcherbanner.cpp
@@ -15,19 +15,123 @@
 **
 */
 
+#include <chrono>
+
 #include <zwidget/core/image.h>
 #include <zwidget/widgets/imagebox/imagebox.h>
 #include <zwidget/widgets/textlabel/textlabel.h>
 
+#include "basics.h"
 #include "launcherbanner.h"
+#include "name.h"
+#include "printf.h"
 #include "themedata.h"
+#include "colorspace.h"
+#include "zstring.h"
 
-LauncherBanner::LauncherBanner(Widget* parent) : Widget(parent)
+std::vector<Color::Color> getColors(FName id)
 {
+	using namespace std::chrono;
+	struct Flag {
+		FName flagid;
+		uint32_t data[19]; // alternate {space, color}. if space is 0, that is the end of the flag.
+	};
+	struct Flag tints[] = { // sorted alphabetically
+		{ "agender",      { 1, 0x000000, 1, 0xBCC4C7, 1, 0xFFFFFF, 1, 0xB7F684, 1, 0xFFFFFF, 1, 0xBCC4C7, 1, 0x000000, 0 }},
+		{ "aroace",       { 1, 0xE28C00, 1, 0xECCD00, 1, 0xFFFFFF, 1, 0x62AEDC, 1, 0x203856, 0 }},
+		{ "aroflux",      {1, 0xe7516a, 1, 0xd86d65, 1, 0xb7a55d, 1, 0xa3c95a, 1, 0x92e454, 0 }},
+		{ "aromantic",    { 1, 0x3DA542, 1, 0xA7D379, 1, 0xFFFFFF, 1, 0xA9A9A9, 1, 0x000000, 0 }},
+		{ "asexual",      { 1, 0x000000, 1, 0xA3A3A3, 1, 0xFFFFFF, 1, 0x800080, 0 }},
+		{ "bear",         { 1, 0x613704, 1, 0xD46300, 1, 0xFDDC62, 1, 0xFDE5B7, 1, 0xFFFFFF, 1, 0x545454, 1, 0x000000, 0 }},
+		{ "bisexual",     { 2, 0xD60270, 1, 0x9B4F96, 2, 0x0038A8, 0 }},
+		{ "demisexual",   { 5, 0xFFFFFF, 1, 0x6E0070, 1, 0x000000, 1, 0x6E0070, 5, 0xD2D2D2, 0 }},
+		{ "gay",          { 1, 0x078D70, 1, 0x26CEAA, 1, 0x98E8C1, 1, 0xFFFFFF, 1, 0x7BADE2, 1, 0x5049CC, 1, 0x3D1A78, 0 }},
+		{ "genderfluid",  { 1, 0xFF76A4, 1, 0xFFFFFF, 1, 0xC011D7, 1, 0x000000, 1, 0x2F3CBE, 0 }},
+		{ "genderqueer",  { 1, 0xB57EDC, 1, 0xFFFFFF, 1, 0x4A8123, 0 }},
+		{ "intersex",     { 5, 0xFFD800, 1, 0x7902AA, 5, 0xFFD800, 0 }},
+		{ "lesbian",      { 1, 0xD52D00, 1, 0xEF7627, 1, 0xFF9A56, 1, 0xFFFFFF, 1, 0xD162A4, 1, 0xB55690, 1, 0xA30262, 0 }},
+		{ "nonbinary",    { 1, 0xFCF434, 1, 0xFFFFFF, 1, 0x9C59D1, 1, 0x2C2C2C, 0 }},
+		{ "omnisexual",   { 1, 0xFE9ACE, 1, 0xFF53BF, 1, 0x200044, 1, 0x6760FE, 1, 0x8EA6FF, 0 }},
+		{ "pansexual",    { 1, 0xFF218C, 1, 0xFFD800, 1, 0x21B1FF, 0 }},
+		{ "philadelphia", { 1, 0x000000, 1, 0x784F17, 1, 0xD12229, 1, 0xF68A1E, 1, 0xFDE01A, 1, 0x007940, 1, 0x24408E, 1, 0x732982, 0 }},
+		{ "polysexual",   { 1, 0xF714BA, 1, 0x01D66A, 1, 0x1594F6, 0 }},
+		{ "queer",        { 1, 0x000000, 1, 0x99D9EA, 1, 0x00A2E8, 1, 0xB5E61D, 1, 0xFFFFFF, 1, 0xFFC90E, 1, 0xFD6666, 1, 0xFFAEC9, 1, 0x000000, 0 }},
+		{ "rainbow",      { 1, 0xE40303, 1, 0xFF8C00, 1, 0xFFED00, 1, 0x008026, 1, 0x004CFF, 1, 0x732982, 0 }},
+		{ "transgender",  { 1, 0x5BCEFA, 1, 0xF5A9B8, 1, 0xFFFFFF, 1, 0xF5A9B8, 1, 0x5BCEFA, 0 }},
+	};
+	std::vector<Color::Color> colors;
+
+	size_t flag;
+	if (id == "random" || id == "list")
+	{
+		auto now = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+		flag = now % std::size(tints);
+
+		if (id == "list")
+		{
+			FString avail = "Available flag colors: random";
+			for (auto &f: tints)
+			{
+				FString n = f.flagid.GetChars();
+				n.ToLower();
+				avail.AppendFormat(", %s", n.GetChars());
+			}
+			FString n = tints[flag].flagid.GetChars();
+			n.ToLower();
+			avail.AppendFormat("\nSelecting: %s", n.GetChars());
+			Printf("%s\nOpen an issue on our github if your flag is missing\n", avail.GetChars());
+		}
+	}
+	else
+	{
+		for (flag = 0; flag < std::size(tints); flag++)
+		{
+			if (tints[flag].flagid == id) break;
+		}
+	}
+
+	if (flag < std::size(tints))
+	{
+		for (unsigned i = 0; tints[flag].data[i] != 0; i+=2)
+		{
+			for (int j = tints[flag].data[i]; j >= 0; j--)
+			{
+				colors.push_back(Color::rgb(tints[flag].data[i+1]));
+			}
+		}
+	}
+
+	return colors;
+}
+
+LauncherBanner::LauncherBanner(Widget* parent, FName colors, float mix) : Widget(parent)
+{
+	bool useColors = colors != "";
+	auto bg = Theme::getHeader(COLOR_BACKGROUND);
+	if (useColors)
+	{
+		auto base = Color::rgb(0xFFFFFF);
+		if (mix <= 0)
+		{
+			useColors = false;
+			base = Color::rgb(bg.r, bg.g, bg.b);
+			mix = -mix;
+		}
+		mix = clamp<float>(mix, 0, 1);
+		for (auto &c: getColors(colors))
+		{
+			auto a = std::make_unique<Widget>(this);
+			auto b = std::make_unique<Widget>(this);
+			a->SetStyleColor("background-color", Colorf::fromRgb(Color::rgb24(c)));
+			b->SetStyleColor("background-color", Colorf::fromRgb(Color::rgb24(Color::mix(base, c, mix))));
+			stripes.push_back({std::move(a), std::move(b)});
+		}
+	}
+
 	Logo = new ImageBox(this);
-	auto imgsrc = Theme::getMode() == LIGHT ? "ui/banner-light.png": "ui/banner-dark.png";
+	auto imgsrc = (useColors || Theme::getMode() == LIGHT) ? "ui/banner-light.png": "ui/banner-dark.png";
 	Logo->SetImage(Image::LoadResource(imgsrc));
-	this->SetStyleColor("background-color", Theme::getHeader(COLOR_BACKGROUND));
+	this->SetStyleColor("background-color", bg);
 }
 
 double LauncherBanner::GetPreferredHeight()
@@ -37,5 +141,13 @@ double LauncherBanner::GetPreferredHeight()
 
 void LauncherBanner::OnGeometryChanged()
 {
-	Logo->SetFrameGeometry(0.0, 0.0, GetWidth(), Logo->GetPreferredHeight());
+	auto W = GetWidth(), H = Logo->GetPreferredHeight();
+	auto w = Logo->GetPreferredWidth();
+	auto h = H/stripes.size();
+	for (unsigned i = 0; i < stripes.size(); i++)
+	{
+		std::get<0>(stripes[i]).get()->SetFrameGeometry(0, floor(h*i), W, ceil(h));
+		std::get<1>(stripes[i]).get()->SetFrameGeometry((W-w)/2, floor(h*i), w, ceil(h));
+	}
+	Logo->SetFrameGeometry(0, 0, W, H);
 }

--- a/src/widgets/launcherbanner.h
+++ b/src/widgets/launcherbanner.h
@@ -19,18 +19,25 @@
 
 #include <zwidget/core/widget.h>
 
+#include <memory>
+#include <vector>
+
+#include "name.h"
+
 class ImageBox;
 class TextLabel;
 
 class LauncherBanner : public Widget
 {
 public:
-	LauncherBanner(Widget* parent);
+	LauncherBanner(Widget* parent, FName colors, float mix);
 
 	double GetPreferredHeight() override;
 
 private:
 	void OnGeometryChanged() override;
+
+	std::vector<std::tuple<std::unique_ptr<Widget>,std::unique_ptr<Widget>>> stripes;
 
 	ImageBox* Logo = nullptr;
 };

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -50,7 +50,7 @@ LauncherWindow::LauncherWindow(FStartupSelectionInfo& info) : Widget(nullptr, Wi
 {
 	SetWindowTitle(GAMENAME);
 
-	Banner = new LauncherBanner(this);
+	Banner = new LauncherBanner(this, info.prideColors, info.prideMix);
 	Pages = new TabWidget(this);
 	Buttonbar = new LauncherButtonbar(this);
 


### PR DESCRIPTION
Adds a `-pride` flag (pun intended), which adds pride colours to the launcher banner. Currently there are 21 flags, but more can easily be added. Which flag is displayed is chosen randomly at boot. It can also be configured to be a static flag, or be a random one without needing to add the commandline flag. Also you can ask it to respect the theme (but color mixing can be weird looking, so that's off by default).

<img width="1398" height="1638" alt="pride" src="https://github.com/user-attachments/assets/eb6ed6cf-f5eb-412f-86fd-a5d04ef3a73b" />

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
