### PR TITLE
Added WEAPONSPAWN flag to Mace spawner

### DIFF
--- a/wadsrc/static/zscript/actors/heretic/weaponmace.zs
+++ b/wadsrc/static/zscript/actors/heretic/weaponmace.zs
@@ -489,6 +489,7 @@ class MaceSpawner : SpecialSpot
 	{
 		+NOSECTOR
 		+NOBLOCKMAP
+		+WEAPONSPAWN
 	}
 
 	States


### PR DESCRIPTION
Since Heretic relies on a random spot to spawn the Mace, the spawner itself needs to have this flag to prevent it.

Fixes #1115 

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
