### PR TITLE
clean up RNG code including fixing a crash bug when maximal integer bound range was requested

### DIFF
--- a/src/common/engine/m_random.cpp
+++ b/src/common/engine/m_random.cpp
@@ -290,13 +290,14 @@ void FRandom::StaticWriteRNGState (FSerializer &arc)
 	{
 		for (rng = FRandom::RNGList; rng != NULL; rng = rng->Next)
 		{
+			auto s32 = rng->s32();
 			// Only write those RNGs that have names
 			if (rng->NameCRC != 0)
 			{
 				if (arc.BeginObject(nullptr))
 				{
 					arc("crc", rng->NameCRC)
-						.Array("u", rng->s32.data(), rng->s32.size())
+						.Array("u", s32.data(), s32.size())
 						.EndObject();
 				}
 			}
@@ -336,9 +337,10 @@ void FRandom::StaticReadRNGState(FSerializer &arc)
 
 				for (rng = FRandom::RNGList; rng != NULL; rng = rng->Next)
 				{
+					auto s32 = rng->s32();
 					if (rng->NameCRC == crc)
 					{
-						arc.Array("u", rng->s32.data(), rng->s32.size());
+						arc.Array("u", s32.data(), s32.size());
 						break;
 					}
 				}

--- a/src/common/engine/m_random.h
+++ b/src/common/engine/m_random.h
@@ -32,10 +32,6 @@
 
 class FSerializer;
 
-static inline uint64_t rotl(const uint64_t x, int k) {
-	return (x << k) | (x >> (64 - k));
-}
-
 class FRandom
 {
 public:
@@ -45,19 +41,24 @@ public:
 
 	int Seed() const
 	{
+		auto s32 = this->s32();
 		return s32[0] ^ s32[1];
 	}
 
-	union {
-		std::array<uint32_t, 2> s32;
-		uint64_t s;
-	};
+	uint64_t s = 0;
+	std::array<uint32_t, 2> s32() const {
+		return {
+			static_cast<uint32_t>(this->s),
+			static_cast<uint32_t>(this->s >> 32)
+		};
+	}
 
 	uint64_t GenRand64() {
 		return (uint64_t(GenRand32()) << 32) + uint64_t(GenRand32());
 	}
 
 	uint32_t GenRand32() {
+		// this is the PCG-XSH-RR RNG algorithm
 		uint64_t oldstate = s;
 		s = oldstate * 6364136223846793005ULL + 0xda3e39cb94b95bdbULL;
 		uint32_t xorshifted = ((oldstate >> 18u) ^ oldstate) >> 27u;
@@ -71,16 +72,84 @@ public:
 		return GenRand32() & 255;
 	}
 
-	// Returns a random number in the range [0,bound)
-	int operator() (int bound)
+	// Returns a random number in the range [0,bound).
+	//
+	// `bound` must not be `0`.
+	uint32_t GenRand32BoundExclusive(uint32_t bound)
 	{
-		uint32_t threshold = -bound % bound;
+		// this algorithm is designed to produce the required number without
+		// any bias. it does so by rejection sampling, by carving out a range
+		// within the integers where the size of the range is a multiple of
+		// `bound`, and then rejection sampling until a random number falls
+		// into this range, then taking it modulo `bound`.
 
+		// this line looks weird  - but it's effectively a way to calculate
+		// `2^32 % bound` without going into 64-bit arithmetic. in unsigned
+		// 32-bit arithmetic, `-bound == 2^32 - bound`. subtracting `bound`
+		// doesn't change the result modulo `bound` so this is the same number
+		// as `2^32 % bound`.
+		auto threshold = -bound % bound;
+
+		// then sample an integer until it's in the range `[2^32 % bound,
+		// 2^32)`. this range has size `2^32 - (2^32 % bound)`. this number
+		// itself is a multiple of `bound`, because `2^32 % bound` is, by
+		// definition, the remainder of `2^32` after division by `bound` - so
+		// subtracting it from `2^32` gives a number divisible by `bound`.
+		//
+		// worth noting that this for loop is very likely to terminate on the
+		// first iteration for most bounds. if not the first, then probably the
+		// second. the worst possible case is `bound == 2^31 + 1`, at which
+		// point the threshold becomes `2^31 - 1`. this gives the loop a ~1/2
+		// chance of terminating every time, and so some probability maths
+		// shows the worst-case expected value of the number of loops is ~2. in
+		// most actual cases, the loop has a high chance of just succeeding
+		// instantly.
 		for (;;) {
-			uint32_t r = GenRand32();
-			if (r >= threshold)
+			auto r = GenRand32();
+			if (r >= threshold) {
+				// then, take the output modulo bound. there's no longer any
+				// potential bias in the range, so this gets every answer with
+				// equal likelihood
 				return r % bound;
+			}
 		}
+	}
+	uint32_t operator() (uint32_t bound) {
+		return this->GenRand32BoundExclusive(bound);
+	}
+
+	// Returns a random number in the range [min, max].
+	int32_t GenRand32MinMaxInclusive(int32_t min, int32_t max) {
+		if (min == max) {
+			return min;
+		}
+		if (min > max) {
+			std::swap(min, max);
+		}
+		// some 32-bit signed integers are far enough away from each other that
+		// the difference needs the extra space of an unsigned integer. as a
+		// result, this entire function just does everything unsigned and lets
+		// modular arithmetic handle the details
+		auto lo = static_cast<uint32_t>(min);
+		auto hi = static_cast<uint32_t>(max);
+
+		// we're going to generate a number in [lo, hi], so we can instead do
+		// one in [0, hi - lo] and add lo. but the bound generating function
+		// uses an exclusive range, so instead needs to be [0, hi - lo + 1).
+		// note that hi can actually be below lo after casting to unsigned -
+		// but the maths works out fine anyway
+		auto bound = hi - lo + 1;
+		// bound calculation overflow check - can only happen if hi is int max
+		// & lo is int min, so generate on full range if so
+		if (bound == 0) {
+			return static_cast<int32_t>(this->GenRand32());
+		}
+		// if lo was originally a negative number and hi is positive then it's
+		// actually as-designed for this to overflow. this is defined behavior
+		// in C++ whereas signed overflow technically isn't
+		auto result = this->GenRand32BoundExclusive(bound) + lo;
+
+		return static_cast<int32_t>(result);
 	}
 
 	// Returns rand# - rand#

--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -6223,11 +6223,7 @@ FxExpression *FxRandom::Resolve(FCompileContext &ctx)
 
 static int NativeRandom(FRandom *rng, int min, int max)
 {
-	if (max < min)
-	{
-		std::swap(max, min);
-	}
-	return (*rng)(max - min + 1) + min;
+	return rng->GenRand32MinMaxInclusive(min, max);
 }
 
 DEFINE_ACTION_FUNCTION_NATIVE(DObject, BuiltinRandom, NativeRandom)


### PR DESCRIPTION
Resolves https://github.com/UZDoom/UZDoom/issues/1317

On a second look the code is a bit confusing for readers so this includes a quite hefty commenting pass, there's a lot of hidden bits of maths in a couple of lines in these functions.

I've also removed the union for s32 as I noticed I missed some code review from @kcat on the last PR, so in its place is a function that just uses some bit shifting to let the compiler handle endianness concerns in case we ever remotely care

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
