### PR TITLE
fix dsdhacked not checking if the dsdhacked class had already been made, which is causing a crash

### DIFF
--- a/src/gamedata/d_dehacked.cpp
+++ b/src/gamedata/d_dehacked.cpp
@@ -124,7 +124,7 @@ static PClassActor* FindInfoName(int index, bool mustexist = false)
 	{
 		FStringf name("~Dsdhacked~%d", index);
 		auto cls = PClass::FindActor(name);
-		if (!mustexist)
+		if (!cls && !mustexist)
 		{
 			cls = static_cast<PClassActor*>(RUNTIME_CLASS(AActor)->CreateDerivedClass(name.GetChars(), (unsigned)sizeof(AActor)));
 			NewClassType(cls, -1);	// This needs a VM type to work as intended.


### PR DESCRIPTION
Reported on Discord - would have made into an Issue but the fix ended up being really trivial

Example .deh that caused a crash before:
```
Patch File for DeHackEd v3.0
# Created with DECOHack v0.47.2 by Matt Tropiano
# Note: Use the pound sign ('#') to start comment lines.

Doom version = 2021
Patch format = 6


Thing 3 (Shotgunner - drop shotgun)
Dropped item = 666

Thing 666 (Shotgun Dropped)
Hit points = 1000
Width = 1310720
Height = 1048576
Reaction time = 8
Bits = 1
Mass = 100
Initial frame = 1100

Frame 1100
Sprite number = 92
Next frame = 0
```

The use of 666 twice causes it to call `FindInfoName` twice. On the second call, it tries to make the class again, and `CreateDerivedClass` guards against that by returning `nullptr`. So it's all UB from that point onwards. I guess that the previous FName implementation didn't trigger any problems whereas the new one does.

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
