### PR TITLE
Don't use haptics while on keyboard

### DIFF
--- a/src/common/console/keydef.h
+++ b/src/common/console/keydef.h
@@ -243,3 +243,11 @@ static const int KeyAxisMapping[NUM_AXIS_CODES] = {
 	KEY_PAD_RTRIGGER,
 };
 
+
+enum EKeyDeviceTypes
+{
+	DEVICE_KBM, // Keyboard / mouse
+	DEVICE_JOY, // DInput Joystick
+	DEVICE_PAD, // XInput Gamepad
+	DEVICE__MAX
+};

--- a/src/common/engine/m_haptics.cpp
+++ b/src/common/engine/m_haptics.cpp
@@ -22,6 +22,7 @@
 #include "c_dispatch.h"
 #include "doomdef.h"
 #include "doomstat.h"
+#include "i_system.h"
 #include "m_haptics.h"
 #include "name.h"
 #include "printf.h"
@@ -441,6 +442,17 @@ void Joy_ReadyRumbleMapping()
 void Joy_RumbleTick()
 {
 	if (!Haptics.enabled) return;
+
+	if (I_GetLastUsedDevice() == DEVICE_KBM)
+	{
+		// no haptics while using keyboard + mouse
+
+		// TODO: probably save the device and only
+		// do this on value change, instead of
+		// blasting every frame
+		I_Rumble(0, 0, 0, 0);
+		return;
+	}
 
 	// pause detection
 	if (AppActive != Haptics.active)

--- a/src/common/platform/posix/i_system.h
+++ b/src/common/platform/posix/i_system.h
@@ -90,4 +90,7 @@ FString I_GetCWD();
 bool I_ChDir(const char* path);
 void I_OpenShellFolder(const char*);
 
+
+int I_GetLastUsedDevice();
+
 #endif

--- a/src/common/platform/posix/sdl/i_input.cpp
+++ b/src/common/platform/posix/sdl/i_input.cpp
@@ -242,6 +242,13 @@ static void I_CheckGUICapture ()
 	}
 }
 
+static int g_LastUsedDeviceType = DEVICE_KBM;
+
+int I_GetLastUsedDevice()
+{
+	return g_LastUsedDeviceType;
+}
+
 void I_SetMouseCapture()
 {
 	// Clear out any mouse movement.
@@ -376,6 +383,12 @@ void MessagePump (const SDL_Event &sev)
 	case SDL_MOUSEBUTTONDOWN:
 	case SDL_MOUSEBUTTONUP:
 		if (joykey_stop_conflict > 0 && sev.type == SDL_MOUSEBUTTONDOWN) break;
+
+		if (sev.type == SDL_MOUSEBUTTONDOWN)
+		{
+			g_LastUsedDeviceType = DEVICE_KBM;
+		}
+
 		if (!GUICapture)
 		{
 			event.type = sev.type == SDL_MOUSEBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
@@ -446,6 +459,9 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_MOUSEMOTION:
 		if (joykey_stop_conflict > 0) break;
+
+		//g_LastUsedDeviceType = DEVICE_KBM;
+
 		if (GUICapture)
 		{
 			event.data1 = sev.motion.x;
@@ -467,6 +483,9 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_MOUSEWHEEL:
 		if (joykey_stop_conflict > 0) break;
+
+		g_LastUsedDeviceType = DEVICE_KBM;
+
 		if (GUICapture)
 		{
 			event.type = EV_GUI_Event;
@@ -501,6 +520,12 @@ void MessagePump (const SDL_Event &sev)
 	case SDL_KEYDOWN:
 	case SDL_KEYUP:
 		if (joykey_stop_conflict > 0 && sev.type == SDL_KEYDOWN) break;
+
+		if (sev.type == SDL_KEYDOWN)
+		{
+			g_LastUsedDeviceType = DEVICE_KBM;
+		}
+
 		if (!GUICapture)
 		{
 			if (sev.key.repeat)
@@ -588,6 +613,9 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_TEXTINPUT:
 		if (joykey_stop_conflict > 0 && sev.type == SDL_TEXTINPUT) break;
+
+		//g_LastUsedDeviceType = DEVICE_KBM;
+
 		if (GUICapture)
 		{
 			int size;
@@ -608,6 +636,12 @@ void MessagePump (const SDL_Event &sev)
 	case SDL_JOYBUTTONUP:
 		if (SDL_GameControllerFromInstanceID(sev.jdevice.which))
 			break; // let SDL_CONTROLLERBUTTON* handle this
+
+		if (sev.type == SDL_JOYBUTTONDOWN)
+		{
+			g_LastUsedDeviceType = DEVICE_JOY;
+		}
+
 		event.type = sev.type == SDL_JOYBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
 		event.data1 = KEY_FIRSTJOYBUTTON + sev.jbutton.button;
 		if(event.data1 != 0)
@@ -616,6 +650,11 @@ void MessagePump (const SDL_Event &sev)
 
 	case SDL_CONTROLLERBUTTONDOWN:
 	case SDL_CONTROLLERBUTTONUP:
+		if (sev.type == SDL_CONTROLLERBUTTONDOWN)
+		{
+			g_LastUsedDeviceType = DEVICE_PAD;
+		}
+
 		event.type = sev.type == SDL_CONTROLLERBUTTONDOWN ? EV_KeyDown : EV_KeyUp;
 		switch (sev.cbutton.button)
 		{


### PR DESCRIPTION
Resolves #548 

WIP, I was struggling with Windows support because it has quite a few different branches for the different gamepad types.

## TODO

- [ ] Finish platform support
  - [ ] Windows (full support)
  - [ ] Mac (stub, it does not support haptics)
- [ ] On the haptics' code's end, measure how long it has been since the non-keyboard input
- [ ] Don't blast a call to `I_Rumble(0, 0, 0, 0)` every frame while using keyboard; only do it when necessary

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
