### PR TITLE
Add error when specifying invalid spawn filter

### DIFF
--- a/src/gamedata/g_skill.cpp
+++ b/src/gamedata/g_skill.cpp
@@ -182,6 +182,7 @@ void FMapInfoParser::ParseSkill ()
 				else if (sc.Compare("normal")) skill.SpawnFilter |= 4;
 				else if (sc.Compare("hard")) skill.SpawnFilter |= 8;
 				else if (sc.Compare("nightmare")) skill.SpawnFilter |= 16;
+				else sc.ScriptError("Invalid skill filter name '%s' in skill definition for '%s'\n", sc.String, skill.Name.GetChars());
 			}
 		}
 		else if (sc.Compare ("spawnmulti"))


### PR DESCRIPTION
Add a `ScriptError` call when specifying a bad spawn filter name for a skill definition.

Resolves #1061 by preventing the situation from happening in the first place. (#1348 should have resolved any of the other weirdness with this issue, as well, but I can't test because the mod author deleted the older versions :confused:)

I chose `ScriptError` because I can't think of any mod that would want to do this intentionally. It seems to have happened in the first place because this mod used to have a skill level that wasn't even tested in the first place. Regardless, if there are backwards compatibility concerns, it's easy enough to change into a warning with `ScriptMessage` instead.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
