### PR TITLE
Expose SceneColor as a bindable input for material HardwareShaders with per-draw on-demand grab

### DIFF
--- a/src/common/rendering/gl/gl_framebuffer.cpp
+++ b/src/common/rendering/gl/gl_framebuffer.cpp
@@ -405,6 +405,15 @@ void OpenGLFrameBuffer::AmbientOccludeScene(float m5)
 	gl_RenderState.Apply();
 }
 
+// Blit current scene color to the sampleable background texture and bind to unit 18.
+void OpenGLFrameBuffer::GrabSceneColor()
+{
+	if (!GLRenderer || !GLRenderer->mBuffers)
+		return;
+	GLRenderer->mBuffers->GrabSceneColor();
+	GLRenderer->mBuffers->BindSceneColorBackgroundTexture(18);
+}
+
 void OpenGLFrameBuffer::FirstEye()
 {
 	GLRenderer->mBuffers->CurrentEye() = 0;  // always begin at zero, in case eye count changed

--- a/src/common/rendering/gl/gl_framebuffer.h
+++ b/src/common/rendering/gl/gl_framebuffer.h
@@ -51,6 +51,7 @@ public:
 	void Update() override;
 
 	void AmbientOccludeScene(float m5) override;
+	void GrabSceneColor() override;
 	void FirstEye() override;
 	void NextEye(int eyecount) override;
 	void SetSceneRenderTarget(bool useSSAO) override;

--- a/src/common/rendering/gl/gl_renderbuffers.cpp
+++ b/src/common/rendering/gl/gl_renderbuffers.cpp
@@ -70,6 +70,8 @@ void FGLRenderBuffers::ClearScene()
 {
 	DeleteFrameBuffer(mSceneFB);
 	DeleteFrameBuffer(mSceneDataFB);
+	DeleteFrameBuffer(mSceneColorBackgroundFB);
+	DeleteTexture(mSceneColorBackgroundTex);
 	if (mSceneUsesTextures)
 	{
 		DeleteTexture(mSceneMultisampleTex);
@@ -228,6 +230,10 @@ void FGLRenderBuffers::CreateScene(int width, int height, int samples, bool need
 			mSceneDataFB = CreateFrameBuffer("SceneGBufferFB", mPipelineTexture[0], mSceneDepthStencilBuf);
 		}
 	}
+
+	// SceneColor grab-pass background, RGBA16F single-sample.
+	mSceneColorBackgroundTex = Create2DTexture("SceneColorBackground", GL_RGBA16F, width, height);
+	mSceneColorBackgroundFB = CreateFrameBuffer("SceneColorBackgroundFB", mSceneColorBackgroundTex);
 }
 
 //==========================================================================
@@ -523,6 +529,34 @@ void FGLRenderBuffers::BlitSceneToTexture()
 
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
 	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+}
+
+//==========================================================================
+//
+// Grab pass: blit scene color to the sampleable background texture (bindings restored to mSceneFB).
+//
+//==========================================================================
+
+void FGLRenderBuffers::GrabSceneColor()
+{
+	if (!mSceneColorBackgroundFB || !mSceneFB)
+		return;
+
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, mSceneFB.handle);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mSceneColorBackgroundFB.handle);
+	glBlitFramebuffer(0, 0, mWidth, mHeight, 0, 0, mWidth, mHeight, GL_COLOR_BUFFER_BIT, mSamples > 1 ? GL_LINEAR : GL_NEAREST);
+
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, mSceneFB.handle);
+	glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mSceneFB.handle);
+}
+
+void FGLRenderBuffers::BindSceneColorBackgroundTexture(int index)
+{
+	if (!mSceneColorBackgroundTex)
+		return;
+	glActiveTexture(GL_TEXTURE0 + index);
+	glBindTexture(GL_TEXTURE_2D, mSceneColorBackgroundTex.handle);
+	glActiveTexture(GL_TEXTURE0);
 }
 
 //==========================================================================

--- a/src/common/rendering/gl/gl_renderbuffers.h
+++ b/src/common/rendering/gl/gl_renderbuffers.h
@@ -138,6 +138,10 @@ public:
 	void BindSceneDepthTexture(int index);
 	void BlitSceneToTexture();
 
+	// Grab pass: copy scene color into a sampleable texture before translucent.
+	void GrabSceneColor();
+	void BindSceneColorBackgroundTexture(int index);
+
 	void BindCurrentTexture(int index, int filter = GL_NEAREST, int wrap = GL_CLAMP_TO_EDGE);
 	void BindCurrentFB();
 	void BindNextFB();
@@ -211,6 +215,9 @@ private:
 	PPGLFrameBuffer mSceneFB;
 	PPGLFrameBuffer mSceneDataFB;
 	bool mSceneUsesTextures = false;
+	// Grab pass background: single-sample scene color copy.
+	PPGLTexture mSceneColorBackgroundTex;
+	PPGLFrameBuffer mSceneColorBackgroundFB;
 
 	// Effect/HUD buffers
 	PPGLTexture mPipelineTexture[NumPipelineTextures];

--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -416,6 +416,8 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 		uniform sampler2D texture10;
 		uniform sampler2D texture11;
 		uniform sampler2D texture12;
+		// Auto-bound scene framebuffer copy captured before translucent (for refraction in material shaders).
+		uniform sampler2D SceneColor;
 
 		// timer data
 		uniform float timer;
@@ -785,6 +787,9 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 
 	int lightmapindex = glGetUniformLocation(hShader, "LightMap");
 	if (lightmapindex != -1) glUniform1i(lightmapindex, 17);
+
+	int scenecolorindex = glGetUniformLocation(hShader, "SceneColor");
+	if (scenecolorindex != -1) glUniform1i(scenecolorindex, 18);
 
 	glUseProgram(0);
 	return true;

--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -255,6 +255,8 @@ public:
 	virtual int Backend() { return 0; }
 	virtual const char* DeviceName() const { return "Unknown"; }
 	virtual void AmbientOccludeScene(float m5) {}
+	// Grab pass before translucent for material shaders to read as SceneColor. Default no-op.
+	virtual void GrabSceneColor() {}
 	virtual void FirstEye() {}
 	virtual void NextEye(int eyecount) {}
 	virtual void SetSceneRenderTarget(bool useSSAO) {}

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.cpp
@@ -212,6 +212,49 @@ void VkPostprocess::BlitCurrentToImage(VkTextureImage *dstimage, VkImageLayout f
 		.Execute(cmdbuffer);
 }
 
+void VkPostprocess::GrabSceneColor()
+{
+	// Blit current SceneColor into SceneColorBackground for material shaders to sample during translucent.
+	auto buffers = fb->GetBuffers();
+	auto srcimage = &buffers->SceneColor;
+	auto dstimage = &buffers->SceneColorBackground;
+	if (!srcimage->Image || !dstimage->Image)
+		return;
+
+	fb->GetRenderState()->EndRenderPass();
+	auto cmdbuffer = fb->GetCommands()->GetDrawCommands();
+
+	VkImageTransition()
+		.AddImage(srcimage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, false)
+		.AddImage(dstimage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, false)
+		.Execute(cmdbuffer);
+
+	VkImageBlit blit = {};
+	blit.srcOffsets[0] = { 0, 0, 0 };
+	blit.srcOffsets[1] = { srcimage->Image->width, srcimage->Image->height, 1 };
+	blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	blit.srcSubresource.mipLevel = 0;
+	blit.srcSubresource.baseArrayLayer = 0;
+	blit.srcSubresource.layerCount = 1;
+	blit.dstOffsets[0] = { 0, 0, 0 };
+	blit.dstOffsets[1] = { dstimage->Image->width, dstimage->Image->height, 1 };
+	blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	blit.dstSubresource.mipLevel = 0;
+	blit.dstSubresource.baseArrayLayer = 0;
+	blit.dstSubresource.layerCount = 1;
+
+	// Linear filter resolves MSAA when the source is multisampled.
+	cmdbuffer->blitImage(
+		srcimage->Image->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+		dstimage->Image->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+		1, &blit, VK_FILTER_LINEAR);
+
+	VkImageTransition()
+		.AddImage(srcimage, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, false)
+		.AddImage(dstimage, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, false)
+		.Execute(cmdbuffer);
+}
+
 void VkPostprocess::CopyCurrentToImage(VkTextureImage *dstimage, VkImageLayout finallayout)
 {
 	fb->GetRenderState()->EndRenderPass();

--- a/src/common/rendering/vulkan/renderer/vk_postprocess.h
+++ b/src/common/rendering/vulkan/renderer/vk_postprocess.h
@@ -58,6 +58,8 @@ public:
 	void BlitSceneToPostprocess();
 	void BlitCurrentToImage(VkTextureImage *image, VkImageLayout finallayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	void CopyCurrentToImage(VkTextureImage *image, VkImageLayout finallayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+	// Grab pass: blit SceneColor into SceneColorBackground for material shaders (linear filter resolves MSAA).
+	void GrabSceneColor();
 	void DrawPresentTexture(const IntRect &box, bool applyGamma, bool screenshot);
 
 	int GetCurrentPipelineImage() const { return mCurrentPipelineImage; }

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -277,6 +277,8 @@ static const char *shaderBindings = R"(
 	layout(set = 2, binding = 9) uniform sampler2D texture10;
 	layout(set = 2, binding = 10) uniform sampler2D texture11;
 	layout(set = 2, binding = 11) uniform sampler2D texture12;
+	// Auto-bound scene framebuffer copy captured before translucent (for refraction in material shaders).
+	layout(set = 2, binding = 12) uniform sampler2D SceneColor;
 
 	// This must match the PushConstants struct
 	layout(push_constant) uniform PushConstants

--- a/src/common/rendering/vulkan/shaders/vk_shader.h
+++ b/src/common/rendering/vulkan/shaders/vk_shader.h
@@ -31,7 +31,8 @@
 #include "zvulkan/vulkanbuilders.h"
 #include <list>
 
-#define SHADER_MIN_REQUIRED_TEXTURE_LAYERS 11
+// Bumped from 11 to 13: slot 12 reserved for SceneColor (auto-bound framebuffer copy captured before translucent).
+#define SHADER_MIN_REQUIRED_TEXTURE_LAYERS 13
 
 class VulkanRenderDevice;
 class VulkanDevice;

--- a/src/common/rendering/vulkan/system/vk_renderdevice.cpp
+++ b/src/common/rendering/vulkan/system/vk_renderdevice.cpp
@@ -552,6 +552,12 @@ void VulkanRenderDevice::AmbientOccludeScene(float m5)
 	mPostprocess->AmbientOccludeScene(m5);
 }
 
+// Grab pass: delegates to mPostprocess (see VkPostprocess::GrabSceneColor).
+void VulkanRenderDevice::GrabSceneColor()
+{
+	mPostprocess->GrabSceneColor();
+}
+
 void VulkanRenderDevice::SetSceneRenderTarget(bool useSSAO)
 {
 	mRenderState->SetRenderTarget(&GetBuffers()->SceneColor, GetBuffers()->SceneDepthStencil.View.get(), GetBuffers()->GetWidth(), GetBuffers()->GetHeight(), VK_FORMAT_R16G16B16A16_SFLOAT, GetBuffers()->GetSceneSamples());

--- a/src/common/rendering/vulkan/system/vk_renderdevice.h
+++ b/src/common/rendering/vulkan/system/vk_renderdevice.h
@@ -88,6 +88,7 @@ public:
 	void BlurScene(float amount) override;
 	void PostProcessScene(bool swscene, int fixedcm, float flash, const std::function<void()> &afterBloomDrawEndScene2D) override;
 	void AmbientOccludeScene(float m5) override;
+	void GrabSceneColor() override;
 	void SetSceneRenderTarget(bool useSSAO) override;
 	void SetLevelMesh(hwrenderer::LevelMesh* mesh) override;
 	void UpdateShadowMap() override;

--- a/src/common/rendering/vulkan/textures/vk_hwtexture.cpp
+++ b/src/common/rendering/vulkan/textures/vk_hwtexture.cpp
@@ -375,10 +375,15 @@ VulkanDescriptorSet* VkMaterial::GetDescriptorSet(const FMaterialState& state)
 	}
 
 	auto dummyImage = fb->GetTextureManager()->GetNullTextureView();
-	for (int i = numLayers; i < SHADER_MIN_REQUIRED_TEXTURE_LAYERS; i++)
+	// Slots 0..(N-2) are material/dummy; slot N-1 is reserved for SceneColor (dummy fallback).
+	for (int i = numLayers; i < SHADER_MIN_REQUIRED_TEXTURE_LAYERS - 1; i++)
 	{
 		update.AddCombinedImageSampler(descriptor.get(), i, dummyImage, sampler, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 	}
+
+	auto buffers = fb->GetBuffers();
+	auto sceneColorView = (buffers && buffers->SceneColorBackground.View) ? buffers->SceneColorBackground.View.get() : dummyImage;
+	update.AddCombinedImageSampler(descriptor.get(), SHADER_MIN_REQUIRED_TEXTURE_LAYERS - 1, sceneColorView, sampler, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 	update.Execute(fb->device.get());
 	mDescriptorSets.emplace_back(clampmode, translationp, std::move(descriptor));

--- a/src/common/rendering/vulkan/textures/vk_renderbuffers.cpp
+++ b/src/common/rendering/vulkan/textures/vk_renderbuffers.cpp
@@ -152,17 +152,21 @@ void VkRenderBuffers::CreateScene(int width, int height, VkSampleCountFlagBits s
 	SceneDepthStencil.Reset(fb);
 	SceneNormal.Reset(fb);
 	SceneFog.Reset(fb);
+	SceneColorBackground.Reset(fb);
 
 	CreateSceneColor(width, height, samples);
 	CreateSceneDepthStencil(width, height, samples);
 	CreateSceneNormal(width, height, samples);
 	CreateSceneFog(width, height, samples);
 
+	CreateSceneColorBackground(width, height);
+
 	VkImageTransition()
 		.AddImage(&SceneColor, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true)
 		.AddImage(&SceneDepthStencil, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL, true)
 		.AddImage(&SceneNormal, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true)
 		.AddImage(&SceneFog, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, true)
+		.AddImage(&SceneColorBackground, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, true)
 		.Execute(fb->GetCommands()->GetDrawCommands());
 }
 
@@ -227,6 +231,22 @@ void VkRenderBuffers::CreateSceneFog(int width, int height, VkSampleCountFlagBit
 	SceneFog.View = ImageViewBuilder()
 		.Image(SceneFog.Image.get(), VK_FORMAT_R8G8B8A8_UNORM)
 		.DebugName("VkRenderBuffers.SceneFogView")
+		.Create(fb->device.get());
+}
+
+void VkRenderBuffers::CreateSceneColorBackground(int width, int height)
+{
+	// Single-sample sampleable copy of scene color, read by material shaders as SceneColor.
+	SceneColorBackground.Image = ImageBuilder()
+		.Size(width, height)
+		.Format(VK_FORMAT_R16G16B16A16_SFLOAT)
+		.Usage(VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT)
+		.DebugName("VkRenderBuffers.SceneColorBackground")
+		.Create(fb->device.get());
+
+	SceneColorBackground.View = ImageViewBuilder()
+		.Image(SceneColorBackground.Image.get(), VK_FORMAT_R16G16B16A16_SFLOAT)
+		.DebugName("VkRenderBuffers.SceneColorBackgroundView")
 		.Create(fb->device.get());
 }
 

--- a/src/common/rendering/vulkan/textures/vk_renderbuffers.h
+++ b/src/common/rendering/vulkan/textures/vk_renderbuffers.h
@@ -53,6 +53,8 @@ public:
 	VkTextureImage SceneDepthStencil;
 	VkTextureImage SceneNormal;
 	VkTextureImage SceneFog;
+	// Grab pass background: single-sample scene color copy, read as SceneColor by material shaders.
+	VkTextureImage SceneColorBackground;
 
 	VkFormat PipelineDepthStencilFormat = VK_FORMAT_D24_UNORM_S8_UINT;
 	VkFormat SceneDepthStencilFormat = VK_FORMAT_D24_UNORM_S8_UINT;
@@ -72,6 +74,7 @@ private:
 	void CreateSceneDepthStencil(int width, int height, VkSampleCountFlagBits samples);
 	void CreateSceneFog(int width, int height, VkSampleCountFlagBits samples);
 	void CreateSceneNormal(int width, int height, VkSampleCountFlagBits samples);
+	void CreateSceneColorBackground(int width, int height);
 	VkSampleCountFlagBits GetBestSampleCount();
 
 	VulkanRenderDevice* fb = nullptr;

--- a/src/common/textures/textures.h
+++ b/src/common/textures/textures.h
@@ -99,6 +99,7 @@ struct UserShaderDesc
 	MaterialShaderIndex shaderType;
 	FString defines;
 	bool disablealphatest = false;
+	bool samplesscene = false;
 	uint8_t shaderFlags = 0;
 };
 

--- a/src/r_data/gldefs.cpp
+++ b/src/r_data/gldefs.cpp
@@ -1820,6 +1820,10 @@ class GLDefsParser
 				{
 					no_mipmap = true;
 				}
+				else if (sc.Compare("samplesscene"))
+				{
+					desc.samplesscene = true;
+				}
 				else if (sc.Compare("speed"))
 				{
 					sc.MustGetFloat();

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -580,6 +580,9 @@ void HWDrawInfo::RenderTranslucent(FRenderState &state)
 {
 	RenderAll.Clock();
 
+	// HWDrawInfo is pooled, reset here to ensure first refractive item triggers a grab.
+	sceneColorDirty = true;
+
 	// final pass: translucent stuff
 	state.AlphaFunc(Alpha_GEqual, gl_mask_sprite_threshold);
 	state.SetRenderStyle(STYLE_Translucent);
@@ -1040,6 +1043,7 @@ void HWDrawInfo::DrawScene(int drawmode)
 	recursion++;
 	portalState.EndFrame(this, RenderState);
 	recursion--;
+
 	RenderTranslucent(RenderState);
 }
 

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -174,6 +174,8 @@ struct HWDrawInfo
 	//TArray<ACorona*> Coronas;
 	uint64_t LastFrameTime = 0;
 
+	bool sceneColorDirty = true;
+
 	TArray<MissingTextureInfo> MissingUpperTextures;
 	TArray<MissingTextureInfo> MissingLowerTextures;
 

--- a/src/rendering/hwrenderer/scene/hw_drawlist.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawlist.cpp
@@ -24,8 +24,10 @@
 #include "hw_walldispatcher.h"
 #include "hwrenderer/scene/hw_drawlist.h"
 #include "hwrenderer/scene/hw_drawstructs.h"
+#include "models.h"
 #include "r_sky.h"
 #include "r_utility.h"
+#include "texturemanager.h"
 
 FMemArena RenderDataAllocator(1024*1024);	// Use large blocks to reduce allocation time.
 
@@ -785,8 +787,79 @@ HWSprite *HWDrawList::NewSprite()
 //
 //
 //==========================================================================
+int HWDrawList::GetShaderIndexForDrawItem(int i)
+{
+	switch(drawitems[i].rendertype)
+	{
+	case DrawType_FLAT:
+		if (auto t = flats[drawitems[i].index]->texture) return t->GetShaderIndex();
+		return 0;
+
+	case DrawType_WALL:
+		if (auto t = walls[drawitems[i].index]->texture) return t->GetShaderIndex();
+		return 0;
+
+	case DrawType_SPRITE:
+		{
+			auto s = sprites[drawitems[i].index];
+			if (s->OverrideShader >= 0) return s->OverrideShader;
+			// Model-rendered sprites use modelframe skins, not the sprite's frame texture.
+			if (s->modelframe)
+			{
+				for (auto& skinid : s->modelframe->skinIDs)
+				{
+					if (auto t = TexMan.GetGameTexture(skinid))
+					{
+						int idx = t->GetShaderIndex();
+						if (idx >= FIRST_USER_SHADER &&
+							usershaders[idx - FIRST_USER_SHADER].samplesscene)
+							return idx;
+					}
+				}
+				for (auto& skinid : s->modelframe->surfaceskinIDs)
+				{
+					if (auto t = TexMan.GetGameTexture(skinid))
+					{
+						int idx = t->GetShaderIndex();
+						if (idx >= FIRST_USER_SHADER &&
+							usershaders[idx - FIRST_USER_SHADER].samplesscene)
+							return idx;
+					}
+				}
+			}
+			if (s->texture) return s->texture->GetShaderIndex();
+			return 0;
+		}
+	}
+	return 0;
+}
+
+//==========================================================================
+//
+//
+//
+//==========================================================================
 void HWDrawList::DoDraw(HWDrawInfo *di, FRenderState &state, bool translucent, int i)
 {
+	if (translucent)
+	{
+		int shaderIdx = GetShaderIndexForDrawItem(i);
+		bool needsGrab = (shaderIdx >= FIRST_USER_SHADER) &&
+			usershaders[shaderIdx - FIRST_USER_SHADER].samplesscene;
+		if (needsGrab)
+		{
+			if (di->sceneColorDirty)
+			{
+				screen->GrabSceneColor();
+				di->sceneColorDirty = false;
+			}
+		}
+		else
+		{
+			di->sceneColorDirty = true;
+		}
+	}
+
 	switch(drawitems[i].rendertype)
 	{
 	case DrawType_FLAT:

--- a/src/rendering/hwrenderer/scene/hw_drawlist.h
+++ b/src/rendering/hwrenderer/scene/hw_drawlist.h
@@ -126,6 +126,7 @@ public:
 	SortNode * DoSort(HWDrawInfo *di, SortNode * head);
 	void Sort(HWDrawInfo *di);
 
+	int GetShaderIndexForDrawItem(int i);
 	void DoDraw(HWDrawInfo *di, FRenderState &state, bool translucent, int i);
 	void Draw(HWDrawInfo *di, FRenderState &state, bool translucent);
 	void DrawWalls(HWDrawInfo *di, FRenderState &state, bool translucent);


### PR DESCRIPTION
I'm building a weapons gameplay mod and I wanted a shockwave for my grenade and didn't want to go down the sprite route or use the CameraTextures workaround since I'm trying to mirror the look of a game in the unreal 4 engine. So after some research it appears I've stumbled onto an issue that's been talked about for decades and mentioned by Nash several times in the forums which is that currently the engine doesn't expose the SceneColor to create effects like true refraction from the player's perspective.

This implementation does exactly that and though it does touch a bunch of files it doesn't actually even add that much code, I think it was just a case of folks not wanting to do the work since the workarounds were serviceable because as it turns out the GrabPass pattern I went with was first proposed by Xabis all the way back in 2017.

**Screenshot Examples:**
<img width="600" alt="Screenshot 2026-05-05 141953" src="https://github.com/user-attachments/assets/87567647-adc3-4b08-95c9-03cb551b3d0f" />
<img width="600" alt="Screenshot 2026-05-05 142547" src="https://github.com/user-attachments/assets/527d31f8-a4d9-476a-9112-8646b0fcd84e" />

**Some Technical Details:**
- **`SceneColor`** gets auto-bound to every material HardwareShader, exposing a sampleable copy of the scene framebuffer for spatial effects like refraction.
- **Per-draw on-demand grab** triggers when a material with the `samplesscene` flag draws and something non-refractive has been drawn since the last grab (dedup). This correctly captures sprites and actors into the grab so refractive surfaces can see them. Same explicit declaration pattern as Unity GrabPass and Unreal SceneColor node.
- **New GLDEFS keyword `samplesscene`** on HardwareShader bindings tells the engine which materials should trigger grabs.
- Both backends grab scene color into a dedicated background texture (see diff for backend-specific details: `glBlitFramebuffer` on GL, `vkCmdBlitImage` with layout transitions on Vulkan). Vulkan side bumps `SHADER_MIN_REQUIRED_TEXTURE_LAYERS` from 11 to 13 to add SceneColor at descriptor binding 12.
- Tested locally on NVIDIA RTX 5080 with Windows 11 on both Vulkan and OpenGL backends.

**GLDEFS Example:**
```
HardwareShader "MYTEXTURE"
{
Shader "shaders/refraction.fp" 330
samplesscene
}
```

**Some Caveats:**
- The GLES backend is out of scope. It uses renderbuffers for the scene buffers and would need a much bigger refactor.
- No refraction-of-refraction. Refractive surfaces read scene state from before they draw, so they can't sample other refractive surfaces drawn after them.
- Materials with `samplesscene` applied to opaque-pass items (e.g. 3D models marked solid) would see stale grab data since the per-draw check only fires during the translucent pass. Same architectural restriction as Unreal's SceneColor node which is disallowed in opaque materials.

**Historical References:**
- [Topic #64103](https://forum.zdoom.org/viewtopic.php?t=64103) - Nash - March 2019 - "Things that are not available based on what I see from that COD video: Depth-based water fade (requires depth buffer on material shaders); Localized distortion (rotating submarine blades): requires access to scene buffer in material shaders"
- [Topic #1122947](https://forum.zdoom.org/viewtopic.php?p=1122947) - Nash - October 2019 - "Material textures do not have access to the current screen colour and depth, so no that's currently not possible. Those two things are needed to do any effects that seemingly affect what is 'behind' a texture — for example, refraction behind a glass or water, or 'heat haze'."
- [Topic #57385](https://forum.zdoom.org/viewtopic.php?t=57385) - Xabis - October 2017 - "Seems a simple approach to allow distorting the scene would be by doing something like unity's GrabPass, which simply copies the underlying pixels to a separate texture that can be accessed by the shader. Since it can be expensive to capture, it should be opt-in. For textures/flats, it could be another config param in GLDEFS."

**Demo PK3 ZIP:**
- I've attached a demo zip file that adds a shockwave to the ordinary rocket launcher using a refraction shader. The bubble correctly refracts walls, sprites, and gore behind it.
- Just do uzdoom.exe -iwad doom2.wad -file SceneColorDemo and fire a rocket
- Download [SceneColorDemo.zip](https://github.com/user-attachments/files/27609468/SceneColorDemo.zip)

**Follow up PR:**
I was also thinking about doing a follow up PR once this one is merged that would directly address [Issue #311](https://github.com/UZDoom/UZDoom/issues/311) and create a Refraction fuzz option.

**AI Disclaimer:**
No code was generated or copy-pasted for this PR, however I did use Claude for initial discovery and diagnosis, code review and suggestions and helping me with some of the math for getting the refraction shader to look right.

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.