### PR TITLE
Map marker rendering now accounts for interpolation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -271,3 +271,4 @@ Charles the Thobe
 Leah Anderson
 wallabra
 Sam "LordEntr0py" Widdowson
+Sierra0451

--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -3303,8 +3303,9 @@ void DAutomap::drawAuthorMarkers ()
 		auto it = Level->GetActorIterator(mark->args[0]);
 		AActor *marked = mark->args[0] == 0 ? mark : it.Next();
 
-		double xscale = mark->Scale.X;
-		double yscale = mark->Scale.Y;
+        DVector2 markscale = mark->InterpolatedScale(r_viewpoint.TicFrac);
+		double xscale = markscale.X;
+		double yscale = markscale.Y;
 		// [MK] scale with automap zoom if args[2] is 1, otherwise keep a constant scale
 		if (mark->args[2] == 1)
 		{
@@ -3316,8 +3317,9 @@ void DAutomap::drawAuthorMarkers ()
 		{
 			if (mark->args[1] == 0 || (mark->args[1] == 1 && (marked->subsector->flags & SSECMF_DRAWN)))
 			{
-				DrawMarker (tex, marked->X(), marked->Y(), 0, flip, xscale, yscale, mark->Translation,
-					mark->Alpha, mark->fillcolor, mark->RenderStyle);
+			    DVector2 markedpos = marked->InterpolatedPosition(r_viewpoint.TicFrac).XY();
+				DrawMarker (tex, markedpos.X, markedpos.Y, 0, flip, xscale, yscale, mark->Translation,
+					mark->InterpolatedAlpha(r_viewpoint.TicFrac), mark->fillcolor, mark->RenderStyle);
 			}
 			marked = mark->args[0] != 0 ? it.Next() : nullptr;
 		}


### PR DESCRIPTION
Hi! First time contributing to a project like this, I hope I'm doing it right. Just wanting to start off with a simple change, making map markers account for interpolation in the automap, regarding position, scale, and alpha, which helps fix some jaggedness especially if the marker is attached to the same player the automap is following.

Because this is my first contribution, I've also added myself to the contributors list.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
