### PR TITLE
Actually load rng state from saves

### DIFF
--- a/src/common/engine/m_random.cpp
+++ b/src/common/engine/m_random.cpp
@@ -341,6 +341,7 @@ void FRandom::StaticReadRNGState(FSerializer &arc)
 					if (rng->NameCRC == crc)
 					{
 						arc.Array("u", s32.data(), s32.size());
+						rng->from_s32(s32);
 						break;
 					}
 				}

--- a/src/common/engine/m_random.h
+++ b/src/common/engine/m_random.h
@@ -53,6 +53,10 @@ public:
 		};
 	}
 
+	void from_s32(std::array<uint32_t, 2> s32) {
+		this->s = static_cast<uint64_t>(s32[0]) | (static_cast<uint64_t>(s32[1]) << 32);
+	}
+
 	uint64_t GenRand64() {
 		return (uint64_t(GenRand32()) << 32) + uint64_t(GenRand32());
 	}


### PR DESCRIPTION
Resolves #1340 

Tested by comparing all of the RNG `s` values before & after a save

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
