### PR TITLE
Apply LOOKALLAROUND to enemy+TID search

### DIFF
--- a/src/playsim/p_enemy.cpp
+++ b/src/playsim/p_enemy.cpp
@@ -1401,7 +1401,7 @@ bool ValidEnemyInBlock(AActor* lookee, AActor* other, void* lookparams)
 
 	// [KS] Hey, shouldn't there be a check for MF3_NOSIGHTCHECK here?
 
-	if (!keepChecking || !P_IsVisible(lookee, other, true, params))
+	if (!keepChecking || !P_IsVisible(lookee, other, (lookee->flags4 & MF4_LOOKALLAROUND), params))
 		return false;			// out of sight
 
 	return true;
@@ -1552,7 +1552,7 @@ AActor *LookForTIDInBlock (AActor *lookee, int index, void *extparams)
 
 		if (!(lookee->flags3 & MF3_NOSIGHTCHECK))
 		{
-			if (!P_IsVisible(lookee, other, true, params))
+			if (!P_IsVisible(lookee, other, (lookee->flags4 & MF4_LOOKALLAROUND), params))
 				continue;			// out of sight
 		}
 


### PR DESCRIPTION
Should resolve #796.

I narrowed this down to ZDoom/GZDoom#2433. The follow-up at ZDoom/GZDoom#2547 suggests that the solution is to apply the `LOOKALLAROUND` flag instead of `true` in these cases.

Neither of these pull requests have any additional details or example mods that needed this behavior changed, so beyond just the example mod in #796, I was not sure what to test. If this change has any adverse side effects, then the pull requests mentioned earlier would need reverted instead.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
