### PR TITLE
Added changeepisode command

### DIFF
--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -330,7 +330,7 @@ CCMD (changemap)
 {
 	if (!players[consoleplayer].mo || !usergame)
 	{
-		Printf ("Use the map command when not in a game.\n");
+		Printf ("Cannot use changemap command when not in a game. Use map instead\n");
 		return;
 	}
 
@@ -360,7 +360,7 @@ CCMD (changemap)
 		{
 			if (!P_CheckMapData(mapname))
 			{
-				Printf ("No map %s\n", mapname);
+				Printf ("No map %s.\n", mapname);
 			}
 			else
 			{
@@ -379,12 +379,61 @@ CCMD (changemap)
 		catch(CRecoverableError &error)
 		{
 			if (error.GetMessage())
-				Printf("%s", error.GetMessage());
+				Printf("%s\n", error.GetMessage());
 		}
 	}
 	else
 	{
 		Printf ("Usage: changemap <map name> [position]\n");
+	}
+}
+
+CCMD (changeepisode)
+{
+	if (!players[consoleplayer].mo || !usergame)
+	{
+		Printf ("Cannot use changeepisode command when not in a game.\n");
+		return;
+	}
+
+	if (!players[consoleplayer].settings_controller && netgame)
+	{
+		Printf ("Only settings controllers can change the episode.\n");
+		return;
+	}
+
+	if (argv.argc() > 1)
+	{
+		int ep = 0;
+		if (!C_IsValidInt(argv[1], ep) || ep < 1 || ep > AllEpisodes.Size())
+		{
+			Printf ("Episode %s is invalid.\n", argv[1]);
+			return;
+		}
+
+		const char* mapname = AllEpisodes[--ep].mEpisodeMap.GetChars();
+		try
+		{
+			if (!P_CheckMapData(mapname))
+			{
+				Printf ("Episode %s has no valid map.\n", argv[1]);
+			}
+			else
+			{
+				Net_WriteInt8 (DEM_CHANGEMAP2);
+				Net_WriteInt8(-1);
+				Net_WriteString (mapname);
+			}
+		}
+		catch(CRecoverableError &error)
+		{
+			if (error.GetMessage())
+				Printf("%s\n", error.GetMessage());
+		}
+	}
+	else
+	{
+		Printf ("Usage: changeepisode <episode number>\n");
 	}
 }
 

--- a/src/d_net.cpp
+++ b/src/d_net.cpp
@@ -2577,7 +2577,7 @@ static void UseFlechette(int player)
 //		at the beginning of the command's actual data.
 void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player)
 {
-	uint8_t pos = 0;
+	int8_t pos = 0;
 	const char* s = nullptr;
 	int i = 0;
 
@@ -2698,7 +2698,7 @@ void Net_DoCommand(int cmd, TArrayView<uint8_t>& stream, int player)
 		// Using LEVEL_NOINTERMISSION tends to throw the game out of sync.
 		// That was a long time ago. Maybe it works now?
 		primaryLevel->flags |= LEVEL_CHANGEMAPCHEAT;
-		primaryLevel->ChangeLevel(s, pos, 0);
+		primaryLevel->ChangeLevel(s, max<int>(pos, 0), pos < 0 ? (CHANGELEVEL_RESETHEALTH | CHANGELEVEL_RESETINVENTORY) : 0);
 		break;
 
 	case DEM_SUICIDE:


### PR DESCRIPTION
Allows switching to maps via episode numbers instead of needing to know the actual map name for the start of an episode. As a bonus, this also allows passing -1 as the position in `changemap`, making going to a map with pistol starts possible in multiplayer (`map` is disabled).

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
