### PR TITLE
Allow SectorFillAlpha from MAPINFO

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -812,6 +812,11 @@ void FMapInfoParser::ParseAMColors(bool overlay)
 				cset.displayLocks = true;
 			}
 		}
+		else if (nextKey.CompareNoCase("SectorFillAlpha") == 0)
+		{
+			sc.MustGetToken(TK_FloatConst);
+			cset.fillAlpha = clamp(sc.Float, 0.0, 1.0);
+		}
 		else
 		{
 			int i;


### PR DESCRIPTION
Forgot to test [MAPINFO Automap definitions](https://zdoom.org/w/index.php?title=MAPINFO/Automap_definition) with my earlier pull request (#1350)

Example lump, load with `-file` to test: [mapinfo.txt](https://github.com/user-attachments/files/27783440/mapinfo.txt)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
