### PR TITLE
Update zdoom-info.plist

### DIFF
--- a/src/posix/osx/zdoom-info.plist
+++ b/src/posix/osx/zdoom-info.plist
@@ -50,5 +50,7 @@
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Just added a line to enable OSX's built-in compatibility mode to accommodate the camera notch

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
