### PR TITLE
Fix ThickFog in Skybox when rendered in other portals 

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -157,13 +157,13 @@ bool FPortalSceneState::RenderFirstSkyPortal(int recursion, HWDrawInfo *outer_di
 
 void FPortalSceneState::RenderPortal(HWPortal *p, FRenderState &state, bool usestencil, HWDrawInfo *outer_di)
 {
-	if (outer_di->Viewpoint.bDoOrtho && (strcmp(p->GetName(), "Sky") == 0))
+	if (outer_di->Viewpoint.bDoOrtho && p->IsRealSky())
 	{
 		tempmatrix = outer_di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
 		outer_di->VPUniforms.mProjectionMatrix = outer_di->ProjectionMatrix2;
 	}
 	if (gl_portals) outer_di->RenderPortal(p, state, usestencil);
-	if (outer_di->Viewpoint.bDoOrtho && (strcmp(p->GetName(), "Sky") == 0)) outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
+	if (outer_di->Viewpoint.bDoOrtho && p->IsRealSky()) outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
 }
 
 
@@ -731,8 +731,6 @@ bool HWSkyboxPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 
 	di->VPUniforms.mThickFogDistance /= 16.0; // Skyviewpoint sectors are scaled up by 16x
 	di->VPUniforms.mThickFogMultiplier *= 16.0; // Skyviewpoint sectors are scaled up by 16x
-	tempmatrix = di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
-	di->VPUniforms.mProjectionMatrix = di->ProjectionMatrix2;
 	di->SetupView(rstate, vp.Pos.X, vp.Pos.Y, vp.Pos.Z, !!(state->MirrorFlag & 1), !!(state->PlaneMirrorFlag & 1));
 	vp.OffPos = vp.Pos; // Do this after di->SetupView()
 	di->SetViewArea();
@@ -748,7 +746,6 @@ void HWSkyboxPortal::Shutdown(HWDrawInfo *di, FRenderState &rstate)
 
 	di->VPUniforms.mThickFogDistance *= 16.0; // Revert back
 	di->VPUniforms.mThickFogMultiplier /= 16.0; // Revert back
-	di->VPUniforms.mProjectionMatrix = tempmatrix;
 	auto state = mState;
 	portal->mFlags &= ~PORTSF_INSKYBOX;
 	state->inskybox = false;

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -157,13 +157,17 @@ bool FPortalSceneState::RenderFirstSkyPortal(int recursion, HWDrawInfo *outer_di
 
 void FPortalSceneState::RenderPortal(HWPortal *p, FRenderState &state, bool usestencil, HWDrawInfo *outer_di)
 {
-	if (outer_di->Viewpoint.bDoOrtho && p->IsRealSky())
+	VSMatrix tempmatrix;
+	if (outer_di->Viewpoint.bDoOrtho && ((p->GetHWPortalType() == HWP_SKY) || (p->GetHWPortalType() == HWP_SKYBOX)))
 	{
 		tempmatrix = outer_di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
 		outer_di->VPUniforms.mProjectionMatrix = outer_di->ProjectionMatrix2;
 	}
 	if (gl_portals) outer_di->RenderPortal(p, state, usestencil);
-	if (outer_di->Viewpoint.bDoOrtho && p->IsRealSky()) outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
+	if (outer_di->Viewpoint.bDoOrtho && ((p->GetHWPortalType() == HWP_SKY) || (p->GetHWPortalType() == HWP_SKYBOX)))
+	{
+		outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
+	}
 }
 
 
@@ -941,6 +945,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 	state->PlaneMirrorFlag++;
 	di->SetClipHeight(planez, state->PlaneMirrorMode < 0 ? -1.f : 1.f);
 	di->SetupView(rstate, vp.Pos.X, vp.Pos.Y, vp.Pos.Z, !!(state->MirrorFlag & 1), !!(state->PlaneMirrorFlag & 1));
+	vp.ViewVector3D.Z = - vp.ViewVector3D.Z;
 	SetupCoverage(di);
 	ClearClipper(di, clipper);
 

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -123,7 +123,7 @@ bool FPortalSceneState::RenderFirstSkyPortal(int recursion, HWDrawInfo *outer_di
 	for (int i = portals.Size() - 1; i >= 0; --i)
 	{
 		auto p = portals[i];
-		if (p->lines.Size() > 0 && p->IsSky(outer_di))
+		if (p->lines.Size() > 0 && p->IsSky())
 		{
 			// Cannot clear the depth buffer inside a portal recursion
 			if (recursion && p->NeedDepthBuffer()) continue;
@@ -147,18 +147,7 @@ bool FPortalSceneState::RenderFirstSkyPortal(int recursion, HWDrawInfo *outer_di
 	if (best)
 	{
 		portals.Delete(bestindex);
-		if (usestencil && ((strcmp(best->GetName(), "Sky") == 0) || (strcmp(best->GetName(), "Skybox") == 0)))
-		{
-			tempmatrix = outer_di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
-			outer_di->VPUniforms.mProjectionMatrix = outer_di->ProjectionMatrix2;
-		}
-		outer_di->VPUniforms.mThickFogDistance /= 16.0; // Skyviewpoint sectors are scaled up by 16x
-		outer_di->VPUniforms.mThickFogMultiplier *= 16.0; // Skyviewpoint sectors are scaled up by 16x
 		RenderPortal(best, state, usestencil, outer_di);
-		outer_di->VPUniforms.mThickFogDistance *= 16.0; // Revert back
-		outer_di->VPUniforms.mThickFogMultiplier /= 16.0; // Revert back
-		if (usestencil && ((strcmp(best->GetName(), "Sky") == 0) || (strcmp(best->GetName(), "Skybox") == 0)))
-			outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
 		delete best;
 		return true;
 	}
@@ -168,7 +157,13 @@ bool FPortalSceneState::RenderFirstSkyPortal(int recursion, HWDrawInfo *outer_di
 
 void FPortalSceneState::RenderPortal(HWPortal *p, FRenderState &state, bool usestencil, HWDrawInfo *outer_di)
 {
+	if (outer_di->Viewpoint.bDoOrtho && (strcmp(p->GetName(), "Sky") == 0))
+	{
+		tempmatrix = outer_di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
+		outer_di->VPUniforms.mProjectionMatrix = outer_di->ProjectionMatrix2;
+	}
 	if (gl_portals) outer_di->RenderPortal(p, state, usestencil);
+	if (outer_di->Viewpoint.bDoOrtho && (strcmp(p->GetName(), "Sky") == 0)) outer_di->VPUniforms.mProjectionMatrix = tempmatrix;
 }
 
 
@@ -734,6 +729,10 @@ bool HWSkyboxPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 
 	vp.ViewActor = origin;
 
+	di->VPUniforms.mThickFogDistance /= 16.0; // Skyviewpoint sectors are scaled up by 16x
+	di->VPUniforms.mThickFogMultiplier *= 16.0; // Skyviewpoint sectors are scaled up by 16x
+	tempmatrix = di->VPUniforms.mProjectionMatrix; // ensure perspective projection matrix for skies
+	di->VPUniforms.mProjectionMatrix = di->ProjectionMatrix2;
 	di->SetupView(rstate, vp.Pos.X, vp.Pos.Y, vp.Pos.Z, !!(state->MirrorFlag & 1), !!(state->PlaneMirrorFlag & 1));
 	vp.OffPos = vp.Pos; // Do this after di->SetupView()
 	di->SetViewArea();
@@ -747,6 +746,9 @@ void HWSkyboxPortal::Shutdown(HWDrawInfo *di, FRenderState &rstate)
 {
 	rstate.SetDepthClamp(oldclamp);
 
+	di->VPUniforms.mThickFogDistance *= 16.0; // Revert back
+	di->VPUniforms.mThickFogMultiplier /= 16.0; // Revert back
+	di->VPUniforms.mProjectionMatrix = tempmatrix;
 	auto state = mState;
 	portal->mFlags &= ~PORTSF_INSKYBOX;
 	state->inskybox = false;
@@ -807,11 +809,6 @@ void HWSectorStackPortal::SetupCoverage(HWDrawInfo *di)
 		}
 	}
 	SetCoverage(di, di->Level->HeadNode());
-}
-
-bool HWSectorStackPortal::IsSky(HWDrawInfo *di)
-{
-	return di->Level->thickfogdistance <= 0.0; // although this isn't a real sky it can be handled as one. Unless thickfog is active. That requires depth buffer.
 }
 
 //-----------------------------------------------------------------------------

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -97,6 +97,7 @@ public:
 	virtual const char *GetName() = 0;
 	virtual bool AllowSSAO() { return true; }
 	virtual bool IsSky() { return false; }
+	virtual bool IsRealSky() { return false; }
 	virtual bool NeedCap() { return true; }
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state) = 0;
@@ -266,11 +267,11 @@ struct HWSkyboxPortal : public HWScenePortalBase
 	FSectorPortal * portal;
 
 protected:
-	VSMatrix tempmatrix;
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return portal; }
 	virtual bool IsSky() { return true; }
+	virtual bool IsRealSky() { return true; }
 	virtual const char *GetName();
 	virtual bool AllowSSAO() override;
 
@@ -384,6 +385,7 @@ protected:
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state);
 	virtual void * GetSource() const { return origin; }
 	virtual bool IsSky() { return true; }
+	virtual bool IsRealSky() { return true; }
 	virtual bool NeedDepthBuffer() { return false; }
 	virtual const char *GetName();
 

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -60,6 +60,17 @@ struct HWHorizonInfo
 
 struct FPortalSceneState;
 
+enum HWPortalTypes
+{
+	HWP_SKY = 0,
+	HWP_HORIZON,
+	HWP_SKYBOX,
+	HWP_SECTORSTACK,
+	HWP_PLANEMIRROR,
+	HWP_MIRROR,
+	HWP_LINETOLINE,
+};
+
 class HWPortal
 {
 	friend struct FPortalSceneState;
@@ -97,7 +108,7 @@ public:
 	virtual const char *GetName() = 0;
 	virtual bool AllowSSAO() { return true; }
 	virtual bool IsSky() { return false; }
-	virtual bool IsRealSky() { return false; }
+	virtual int GetHWPortalType() { return HWP_SKY; }
 	virtual bool NeedCap() { return true; }
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state) = 0;
@@ -132,8 +143,6 @@ struct FPortalSceneState
 	UniqueList<secplane_t> UniquePlaneMirrors;
 
 	int skyboxrecursion = 0;
-
-	VSMatrix tempmatrix;
 
 	void BeginScene()
 	{
@@ -232,6 +241,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_MIRROR; }
 	HWMirrorPortal(FPortalSceneState *state, line_t * line)
 		: HWLinePortal(state, line)
 	{
@@ -252,6 +262,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_LINETOLINE; }
 	HWLineToLinePortal(FPortalSceneState *state, FLinePortalSpan *ll)
 		: HWLinePortal(state, ll)
 	{
@@ -271,13 +282,12 @@ protected:
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return portal; }
 	virtual bool IsSky() { return true; }
-	virtual bool IsRealSky() { return true; }
 	virtual const char *GetName();
 	virtual bool AllowSSAO() override;
 
 public:
 
-
+	virtual int GetHWPortalType() { return HWP_SKYBOX; }
 	HWSkyboxPortal(FPortalSceneState *state, FSectorPortal * pt) : HWScenePortalBase(state)
 	{
 		portal = pt;
@@ -289,6 +299,7 @@ public:
 struct HWSectorStackPortal : public HWScenePortalBase
 {
 	TArray<subsector_t *> subsectors;
+
 protected:
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
 	void DrawPortalStencil(FRenderState &state, int pass) override;
@@ -300,6 +311,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_SECTORSTACK; }
 	HWSectorStackPortal(FPortalSceneState *state, FSectorPortalGroup *pt) : HWScenePortalBase(state)
 	{
 		origin = pt;
@@ -325,6 +337,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_PLANEMIRROR; }
 	int GetMirrorSide() const override;
 
 	HWPlaneMirrorPortal(FPortalSceneState *state, secplane_t * pt) : HWScenePortalBase(state)
@@ -352,6 +365,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_HORIZON; }
 	HWHorizonPortal(FPortalSceneState *state, HWHorizonInfo * pt, FRenderViewpoint &vp, bool local = false);
 };
 
@@ -368,6 +382,7 @@ protected:
 
 public:
 
+	virtual int GetHWPortalType() { return HWP_HORIZON; }
 	HWEEHorizonPortal(FPortalSceneState *state, FSectorPortal *pt) : HWPortal(state)
 	{
 		portal = pt;
@@ -385,13 +400,12 @@ protected:
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state);
 	virtual void * GetSource() const { return origin; }
 	virtual bool IsSky() { return true; }
-	virtual bool IsRealSky() { return true; }
 	virtual bool NeedDepthBuffer() { return false; }
 	virtual const char *GetName();
 
 public:
 
-
+	virtual int GetHWPortalType() { return HWP_SKY; }
 	HWSkyPortal(FSkyVertexBuffer *vertexbuffer, FPortalSceneState *state, HWSkyInfo *  pt, bool local = false)
 		: HWPortal(state, local)
 	{

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -96,7 +96,7 @@ public:
 	virtual void * GetSource() const = 0;	// GetSource MUST be implemented!
 	virtual const char *GetName() = 0;
 	virtual bool AllowSSAO() { return true; }
-	virtual bool IsSky(HWDrawInfo *di) { return false; }
+	virtual bool IsSky() { return false; }
 	virtual bool NeedCap() { return true; }
 	virtual bool NeedDepthBuffer() { return true; }
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state) = 0;
@@ -266,10 +266,11 @@ struct HWSkyboxPortal : public HWScenePortalBase
 	FSectorPortal * portal;
 
 protected:
+	VSMatrix tempmatrix;
 	bool Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clipper) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return portal; }
-	virtual bool IsSky(HWDrawInfo *di) { return true; }
+	virtual bool IsSky() { return true; }
 	virtual const char *GetName();
 	virtual bool AllowSSAO() override;
 
@@ -292,7 +293,7 @@ protected:
 	void DrawPortalStencil(FRenderState &state, int pass) override;
 	void Shutdown(HWDrawInfo *di, FRenderState &rstate) override;
 	virtual void * GetSource() const { return origin; }
-	bool IsSky(HWDrawInfo *di) override;
+	virtual bool IsSky() { return true; }	// although this isn't a real sky it can be handled as one.
 	virtual const char *GetName();
 	FSectorPortalGroup *origin;
 
@@ -382,7 +383,7 @@ struct HWSkyPortal : public HWPortal
 protected:
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state);
 	virtual void * GetSource() const { return origin; }
-	virtual bool IsSky(HWDrawInfo *di) { return true; }
+	virtual bool IsSky() { return true; }
 	virtual bool NeedDepthBuffer() { return false; }
 	virtual const char *GetName();
 


### PR DESCRIPTION
Fixing `ThickFog` calculations in `Skybox` portals recursively rendered in other portals, like stacked sector portals and line mirrors.

Moved `ThickFog` distance and density multiplier modifications (by factor of 16) out of the `RenderFirstSkyPortal()` function, and into the specific `RenderPortal()` functions. The `RenderFirstSkyPortal()` optimization is skipped when recursion is active and the depth buffer is needed.

Closes #1375.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
