### PR TITLE
Let all canvas textures be accessed via ZScript

### DIFF
--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -1233,9 +1233,9 @@ public:
 	}
 };
 
-FCanvas* GetTextureCanvas(const FString& texturename)
+FCanvas *GetTextureCanvas(const FString &texturename, ETextureType usetype = ETextureType::Wall, BITFIELD flags = 0)
 {
-	FTextureID textureid = TexMan.CheckForTexture(texturename.GetChars(), ETextureType::Wall, FTextureManager::TEXMAN_Overridable | FTextureManager::TEXMAN_TryAny);
+	FTextureID textureid = TexMan.CheckForTexture(texturename.GetChars(), usetype, FTextureManager::TEXMAN_Overridable | flags);
 	if (textureid.isValid())
 	{
 		// Only proceed if the texture is a canvas texture.

--- a/src/common/2d/v_2ddrawer.cpp
+++ b/src/common/2d/v_2ddrawer.cpp
@@ -1235,7 +1235,7 @@ public:
 
 FCanvas* GetTextureCanvas(const FString& texturename)
 {
-	FTextureID textureid = TexMan.CheckForTexture(texturename.GetChars(), ETextureType::Wall, FTextureManager::TEXMAN_Overridable);
+	FTextureID textureid = TexMan.CheckForTexture(texturename.GetChars(), ETextureType::Wall, FTextureManager::TEXMAN_Overridable | FTextureManager::TEXMAN_TryAny);
 	if (textureid.isValid())
 	{
 		// Only proceed if the texture is a canvas texture.

--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -574,13 +574,15 @@ DEFINE_ACTION_FUNCTION_NATIVE(_TexMan, UseGamePalette, UseGamePalette)
 	ACTION_RETURN_INT(UseGamePalette(texid));
 }
 
-FCanvas* GetTextureCanvas(const FString& texturename);
+FCanvas *GetTextureCanvas(const FString &texturename, ETextureType type, BITFIELD flags);
 
 DEFINE_ACTION_FUNCTION(_TexMan, GetCanvas)
 {
 	PARAM_PROLOGUE;
 	PARAM_STRING(texturename);
-	ACTION_RETURN_POINTER(GetTextureCanvas(texturename));
+	PARAM_INT(type);
+	PARAM_INT(flags);
+	ACTION_RETURN_POINTER(GetTextureCanvas(texturename, static_cast<ETextureType>(type), flags));
 }
 
 //=====================================================================================

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -731,6 +731,7 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 		fitwidth = oldtex->GetDisplayWidth ();
 		fitheight = oldtex->GetDisplayHeight ();
 		viewer->SetUseType(oldtex->GetUseType());
+		viewer->SetOffsets(oldtex->GetDisplayLeftOffset(), oldtex->GetDisplayTopOffset());
 		TexMan.ReplaceTexture (picnum, viewer, true);
 	}
 	else

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -715,6 +715,8 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 	int width, height;
 	double fitwidth, fitheight;
 	FString picname;
+	int offsetx = 0;
+	int offsety = 0;
 
 	sc.MustGetString ();
 	picname = sc.String;
@@ -725,13 +727,15 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 	FTextureID picnum = TexMan.CheckForTexture (picname.GetChars(), ETextureType::Flat, texflags);
 	auto canvas = new FCanvasTexture(width, height);
 	FGameTexture *viewer = MakeGameTexture(canvas, picname.GetChars(), ETextureType::Wall);
+
 	if (picnum.Exists())
 	{
 		auto oldtex = TexMan.GameTexture(picnum);
 		fitwidth = oldtex->GetDisplayWidth ();
 		fitheight = oldtex->GetDisplayHeight ();
+		offsetx = oldtex->GetDisplayLeftOffset();
+		offsety = oldtex->GetDisplayTopOffset();
 		viewer->SetUseType(oldtex->GetUseType());
-		viewer->SetOffsets(oldtex->GetDisplayLeftOffset(), oldtex->GetDisplayTopOffset());
 		TexMan.ReplaceTexture (picnum, viewer, true);
 	}
 	else
@@ -741,51 +745,43 @@ void FTextureAnimator::ParseCameraTexture(FScanner &sc)
 		// [GRB] No need for oldtex
 		TexMan.AddGameTexture (viewer);
 	}
-	if (sc.GetString())
+
+	while (sc.GetString())
 	{
 		if (sc.Compare ("hdr"))
 		{
 			canvas->SetHDR(true);
 		}
-		else
-		{
-			sc.UnGet();
-		}
-	}
-	if (sc.GetString())
-	{
-		if (sc.Compare ("fit"))
+		else if (sc.Compare ("fit"))
 		{
 			sc.MustGetNumber ();
 			fitwidth = sc.Number;
 			sc.MustGetNumber ();
 			fitheight = sc.Number;
 		}
-		else
-		{
-			sc.UnGet ();
-		}
-	}
-	if (sc.GetString())
-	{
-		if (sc.Compare("WorldPanning"))
+		else if (sc.Compare("WorldPanning"))
 		{
 			viewer->SetWorldPanning(true);
 		}
-		else
-		{
-			sc.UnGet();
-		}
-	}
-	if (sc.GetString())
-	{
-		if (sc.Compare("translucent"))
+		else if (sc.Compare("translucent"))
 		{
 			viewer->SetTranslucent(true);
 		}
+		else if (sc.Compare("offset"))
+		{
+			if (sc.CheckNumber())
+			{
+				offsetx = sc.Number;
+				sc.MustGetNumber();
+				offsety = sc.Number;
+			}
+
+			viewer->SetOffsets(offsetx, offsety);
+		}
 		else
 		{
 			sc.UnGet();
+			break;
 		}
 	}
 

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -341,7 +341,7 @@ struct TexMan
 	native static int CheckRealHeight(TextureID tex);
 	native static bool OkForLocalization(TextureID patch, String textSubstitute);
 	native static bool UseGamePalette(TextureID tex);
-	native static Canvas GetCanvas(String texture);
+	native static Canvas GetCanvas(String texture, int usetype = Type_Wall, int flags = 0);
 }
 
 /*


### PR DESCRIPTION
Currently any canvas texture that shares a name with a non-wall image (e.g., a sprite) cannot be accessed via ZScript because the canvas gets assigned to that image's namespace.  

This change allows canvas textures to be looked up in any namespace.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
