### PR TITLE
Allow fog compute from points other than Viewpoint position

### DIFF
--- a/src/common/rendering/gl/gl_shader.cpp
+++ b/src/common/rendering/gl/gl_shader.cpp
@@ -309,6 +309,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump, const char * 
 			mat4 NormalViewMatrix;
 
 			vec4 uCameraPos;
+			vec4 uFogCenterPos;
 			vec4 uClipLine;
 
 			float uGlobVis;			// uGlobVis = R_GetGlobVis(r_visibility) / 32.0

--- a/src/common/rendering/gles/gles_renderstate.cpp
+++ b/src/common/rendering/gles/gles_renderstate.cpp
@@ -214,6 +214,7 @@ bool FGLRenderState::ApplyShader()
 		activeShader->cur->muViewMatrix.Set(&mHwUniforms->mViewMatrix);
 		activeShader->cur->muNormalViewMatrix.Set(&mHwUniforms->mNormalViewMatrix);
 		activeShader->cur->muCameraPos.Set(&mHwUniforms->mCameraPos.X);
+		activeShader->cur->muFogCenterPos.Set(&mHwUniforms->mFogCenterPos.X);
 		activeShader->cur->muClipLine.Set(&mHwUniforms->mClipLine.X);
 		activeShader->cur->muGlobVis.Set(mHwUniforms->mGlobVis);
 		activeShader->cur->muPalLightLevels.Set(mHwUniforms->mPalLightLevels & 0xFF); // JUST pass the pal levels, clear the top bits

--- a/src/common/rendering/gles/gles_shader.cpp
+++ b/src/common/rendering/gles/gles_shader.cpp
@@ -264,6 +264,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump_, const char *
 		uniform	mat4 NormalViewMatrix;
 
 		uniform	vec4 uCameraPos;
+		uniform	vec4 uFogCenterPos;
 		uniform	vec4 uClipLine;
 
 		uniform	float uGlobVis;			// uGlobVis = R_GetGlobVis(r_visibility) / 32.0
@@ -565,6 +566,7 @@ bool FShader::Load(const char * name, const char * vert_prog_lump_, const char *
 	shaderData->muNormalViewMatrix.Init(shaderData->hShader, "NormalViewMatrix");
 
 	shaderData->muCameraPos.Init(shaderData->hShader, "uCameraPos");
+	shaderData->muFogCenterPos.Init(shaderData->hShader, "uFogCenterPos");
 	shaderData->muClipLine.Init(shaderData->hShader, "uClipLine");
 
 	shaderData->muGlobVis.Init(shaderData->hShader, "uGlobVis");

--- a/src/common/rendering/gles/gles_shader.h
+++ b/src/common/rendering/gles/gles_shader.h
@@ -306,6 +306,7 @@ public: class ShaderVariantData
 		FBufferedUniformMat4fv muNormalViewMatrix;
 
 		FUniform4f muCameraPos;
+		FUniform4f muFogCenterPos;
 		FUniform4f muClipLine;
 
 		FBufferedUniform1f muGlobVis;

--- a/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
+++ b/src/common/rendering/hwrenderer/data/hw_viewpointuniforms.h
@@ -35,6 +35,7 @@ struct HWViewpointUniforms
 	VSMatrix mViewMatrix;
 	VSMatrix mNormalViewMatrix;
 	FVector4 mCameraPos;
+	FVector4 mFogCenterPos;
 	FVector4 mClipLine;
 
 	float mGlobVis = 1.f;

--- a/src/common/rendering/vulkan/shaders/vk_shader.cpp
+++ b/src/common/rendering/vulkan/shaders/vk_shader.cpp
@@ -194,6 +194,7 @@ static const char *shaderBindings = R"(
 		mat4 NormalViewMatrix;
 
 		vec4 uCameraPos;
+		vec4 uFogCenterPos;
 		vec4 uClipLine;
 
 		float uGlobVis;			// uGlobVis = R_GetGlobVis(r_visibility) / 32.0

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -161,6 +161,7 @@ sector_t* RenderViewpoint(FRenderViewpoint& mainvp, AActor* camera, IntRect* bou
 
 		// Stereo mode specific viewpoint adjustment
 		vp.Pos += eye.GetViewShift(vp.HWAngles.Yaw.Degrees());
+		vp.bFromPortal = false;
 		di->SetupView(RenderState, vp.Pos.X, vp.Pos.Y, vp.Pos.Z, false, false);
 
 		di->ProcessScene(toscreen);

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -425,7 +425,7 @@ void HWDrawInfo::SetupView(FRenderState &state, float vx, float vy, float vz, bo
 	auto &vp = Viewpoint;
 	vp.SetViewAngle(r_viewwindow);
 	SetViewMatrix(vp.HWAngles, vx, vy, vz, mirror, planemirror);
-	SetCameraPos(vp.Pos);
+	SetCameraPos(vp.Pos, vp.FogCenterPos);
 	VPUniforms.CalcDependencies();
 	vpIndex = screen->mViewpoints->SetViewpoint(state, &VPUniforms);
 }

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -234,9 +234,10 @@ private:
 	void PreparePlayerSprites3D(sector_t * viewsector, area_t in_area);
 public:
 
-	void SetCameraPos(const DVector3 &pos)
+	void SetCameraPos(const DVector3 &pos, const DVector3 &fogpos)
 	{
 		VPUniforms.mCameraPos = { (float)pos.X, (float)pos.Z, (float)pos.Y, 0.f };
+		VPUniforms.mFogCenterPos = { (float)fogpos.X, (float)fogpos.Z, (float)fogpos.Y, 0.f };
 	}
 
 	void SetClipHeight(float h, float d)

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -741,6 +741,7 @@ bool HWSkyboxPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 
 	oldclamp = rstate.SetDepthClamp(false);
 	vp.Pos = origin->InterpolatedPosition(vp.TicFrac);
+	vp.FogCenterPos = vp.Pos;
 	vp.ActorPos = origin->Pos();
 	vp.Angles.Yaw += (origin->PrevAngles.Yaw + deltaangle(origin->PrevAngles.Yaw, origin->Angles.Yaw) * vp.TicFrac);
 

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -521,6 +521,7 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 	}
 
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 	state->vpIsAllowedOoB = vp.bDoOob;
 	// di->UpdateCurrentMapSection();
 	if (linedef->sidedef[0] && linedef->sidedef[0]->numsegs > 0)
@@ -531,6 +532,7 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 	di->mClipPortal = this;
 	DAngle StartAngle = vp.Angles.Yaw;
 	DVector3 StartPos = vp.Pos;
+	DVector3 StartFCPos = vp.FogCenterPos;
 
 	vertex_t *v1 = linedef->v1;
 	vertex_t *v2 = linedef->v2;
@@ -542,6 +544,7 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 	{
 		// vertical mirror
 		vp.Pos.X = 2 * v1->fX() - StartPos.X;
+		vp.FogCenterPos.X = 2 * v1->fX() - StartFCPos.X;
 
 		// Compensation for reendering inaccuracies
 		if (StartPos.X < v1->fX()) vp.Pos.X -= 0.1;
@@ -551,6 +554,7 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 	{
 		// horizontal mirror
 		vp.Pos.Y = 2 * v1->fY() - StartPos.Y;
+		vp.FogCenterPos.Y = 2 * v1->fY() - StartFCPos.Y;
 
 		// Compensation for reendering inaccuracies
 		if (StartPos.Y < v1->fY())  vp.Pos.Y -= 0.1;
@@ -574,12 +578,23 @@ bool HWMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 		vp.Pos.X = (x1 + r * dx) * 2 - x;
 		vp.Pos.Y = (y1 + r * dy) * 2 - y;
 
+		double xfc = StartFCPos.X;
+		double yfc = StartFCPos.Y;
+
+		// the above two cases catch len == 0
+		double rfc = ((xfc - x1)*dx + (yfc - y1)*dy) / (dx*dx + dy * dy);
+
+		vp.FogCenterPos.X = (x1 + rfc * dx) * 2 - xfc;
+		vp.FogCenterPos.Y = (y1 + rfc * dy) * 2 - yfc;
+
 		// Compensation for reendering inaccuracies
 		FVector2 v(-dx, dy);
 		v.MakeUnit();
 
 		vp.Pos.X += v[1] * state->renderdepth / 2;
 		vp.Pos.Y += v[0] * state->renderdepth / 2;
+		vp.FogCenterPos.X += v[1] * state->renderdepth / 2;
+		vp.FogCenterPos.Y += v[0] * state->renderdepth / 2;
 	}
 	vp.Angles.Yaw = linedef->Delta().Angle() * 2. - StartAngle;
 
@@ -630,6 +645,7 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *cl
 		return false;
 	}
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 	state->vpIsAllowedOoB = vp.bDoOob;
 	di->mClipPortal = this;
 
@@ -642,6 +658,8 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *cl
 	P_TranslatePortalXY(origin, vp.Path[1].X, vp.Path[1].Y);
 	P_TranslatePortalXY(origin, vp.OffPos.X, vp.OffPos.Y);
 	P_TranslatePortalZ(origin, vp.OffPos.Z);
+	P_TranslatePortalXY(origin, vp.FogCenterPos.X, vp.FogCenterPos.Y);
+	P_TranslatePortalZ(origin, vp.FogCenterPos.Z);
 	if (!vp.showviewer && vp.camera != nullptr && P_PointOnLineSidePrecise(vp.Path[0], glport->lines[0]->mDestination) != P_PointOnLineSidePrecise(vp.Path[1], glport->lines[0]->mDestination))
 	{
 		double distp = (vp.Path[0] - vp.Path[1]).Length();
@@ -710,6 +728,7 @@ bool HWSkyboxPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *clippe
 		return false;
 	}
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 	state->vpIsAllowedOoB = vp.bDoOob;
 
 	state->skyboxrecursion++;
@@ -827,12 +846,14 @@ bool HWSectorStackPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 
 	FSectorPortalGroup *portal = origin;
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 	state->vpIsAllowedOoB = vp.bDoOob;
 
 	vp.Pos += origin->mDisplacement;
 	vp.ActorPos += origin->mDisplacement;
 	vp.ViewActor = nullptr;
 	vp.OffPos += origin->mDisplacement;
+	vp.FogCenterPos += origin->mDisplacement;
 
 	// avoid recursions!
 	if (origin->plane != -1) screen->instack[origin->plane]++;
@@ -929,6 +950,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 	std::swap(screen->instack[sector_t::floor], screen->instack[sector_t::ceiling]);
 
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 	state->vpIsAllowedOoB = vp.bDoOob;
 	old_pm = state->PlaneMirrorMode;
 
@@ -938,6 +960,7 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 	double planez = origin->ZatPoint(vp.Pos);
 	vp.Pos.Z = 2 * planez - vp.Pos.Z;
 	vp.OffPos.Z = 2 * planez - vp.OffPos.Z;
+	// vp.FogCenterPos.Z = 2 * planez - vp.OffPos.Z; // [DVR] Leave this commented out. Reflected light travels more distance. Should be foggy.
 	vp.ViewVector3D.Z = - vp.ViewVector3D.Z;
 	vp.ViewActor = nullptr;
 	state->PlaneMirrorMode = origin->fC() < 0 ? -1 : 1;
@@ -1027,6 +1050,7 @@ HWHorizonPortal::HWHorizonPortal(FPortalSceneState *s, HWHorizonInfo * pt, FRend
 {
 	origin = pt;
 
+	vp.bFromPortal = true;
 	// create the vertex data for this horizon portal.
 	HWSectorPlane * sp = &origin->plane;
 	const float vx = vp.Pos.X;
@@ -1104,7 +1128,7 @@ void HWHorizonPortal::DrawContents(HWDrawInfo *di, FRenderState &state)
 		state.ClearScreen();
 		return;
 	}
-	di->SetCameraPos(vp.Pos);
+	di->SetCameraPos(vp.Pos, vp.FogCenterPos);
 
 
 	if (texture->isFullbright())

--- a/src/rendering/hwrenderer/scene/hw_skyportal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_skyportal.cpp
@@ -35,6 +35,7 @@ void HWSkyPortal::DrawContents(HWDrawInfo *di, FRenderState &state)
 {
 	bool drawBoth = false;
 	auto &vp = di->Viewpoint;
+	vp.bFromPortal = true;
 
 	// We have no use for Doom lighting special handling here, so disable it for this function.
 	auto oldlightmode = di->lightmode;

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -732,17 +732,33 @@ void FRenderViewpoint::SetViewAngle(const FViewWindow& viewWindow)
 	ViewVector3D.Y = v.Y * PitchCos;
 	ViewVector3D.Z = -PitchSin;
 
-	if (bDoOrtho || bDoOob) // These auto-ensure that camera and camera->ViewPos exist
+	if (camera && camera->ViewPos) // OffPos gets used by clipper when bDoOoB or bDoOrtho
 	{
 		if (camera->tracer != NULL)
 		{
 			OffPos = camera->tracer->Pos();
 		}
+		else if (!(camera->ViewPos->Flags & VPSF_ABSOLUTEPOS))
+		{
+			if (camera->ViewPos->Flags & VPSF_ABSOLUTEOFFSET)
+			{
+				OffPos = Pos - camera->ViewPos->Offset;
+			}
+			else
+			{
+				OffPos = Pos + ViewVector3D * camera->ViewPos->Offset.Length();
+			}
+		}
 		else
 		{
-			OffPos = Pos + ViewVector3D * camera->ViewPos->Offset.Length();
+			OffPos = Pos;
 		}
 	}
+	else
+	{
+			OffPos = Pos;
+	}
+	if (!bFromPortal) { FogCenterPos = OffPos; } // This is where decision on how to set FogCenterPos needs to be taken
 
 	if (bDoOrtho && (camera->ViewPos->Offset.XY().Length() > 0.0))
 	{

--- a/src/rendering/r_utility.h
+++ b/src/rendering/r_utility.h
@@ -47,6 +47,7 @@ struct FRenderViewpoint
 	DVector2		ViewVector;		// HWR only: direction the camera is facing.
 	DVector3		ViewVector3D;	// 3D direction the camera is facing.
 	DVector3        OffPos;         // Viewpoint position to use for Ortho and OoB calculations
+	DVector3        FogCenterPos;   // Center position for fog calculations
 	AActor			*ViewActor;		// either the same as camera or nullptr
 	FLevelLocals	*ViewLevel;		// The level this viewpoint is on.
 
@@ -78,6 +79,7 @@ struct FRenderViewpoint
 	void SetViewAngle(const FViewWindow& viewWindow);
 	bool IsAllowedOoB();				// Checks if camera actor exists, has viewpos, and viewpos has VPSF_ALLOWOUTOFBOUNDS flag set
 	bool IsOrtho();					// Checks if camera actor exists, has viewpos, and viewpos has VPSF_ORTHOGRAPHIC flag set
+	bool			bFromPortal;	// Is this viewpoint rendering in a portal?
 
 };
 

--- a/wadsrc/static/shaders/glsl/main.fp
+++ b/wadsrc/static/shaders/glsl/main.fp
@@ -810,7 +810,7 @@ vec3 AmbientOcclusionColor()
 	}
 	else
 	{
-		fogdist = max(16.0, distance(pixelpos.xyz, uCameraPos.xyz));
+		fogdist = max(16.0, distance(pixelpos.xyz, uFogCenterPos.xyz));
 	}
 	if (uThickFogDistance > 0.0)
 	{
@@ -875,7 +875,7 @@ void main()
 			}
 			else
 			{
-				fogdist = max(16.0, distance(pixelpos.xyz, uCameraPos.xyz));
+				fogdist = max(16.0, distance(pixelpos.xyz, uFogCenterPos.xyz));
 			}
 			if (uThickFogDistance > 0.0)
 			{

--- a/wadsrc/static/shaders_gles/glsl/main.fp
+++ b/wadsrc/static/shaders_gles/glsl/main.fp
@@ -527,7 +527,7 @@ void main()
 			#if (DEF_FOG_RADIAL == 0)
 				fogdist = max(16.0, pixelpos.w);
 			#else
-				fogdist = max(16.0, distance(pixelpos.xyz, uCameraPos.xyz));
+				fogdist = max(16.0, distance(pixelpos.xyz, uFogCenterPos.xyz));
 			#endif
 
 			if (uThickFogDistance > 0.0)


### PR DESCRIPTION
Added ability to compute fog from a point different from Viewpoint position. Useful for third-person cameras, cinematic cameras with far-away subject emphasis, etc.

Orthographic example with thickfog enabled: 
[viewpos_thickfog.zip](https://github.com/user-attachments/files/28199260/viewpos_thickfog.zip)

https://github.com/user-attachments/assets/f8988324-2c2c-47db-bb46-b0a2adb6310e

We need to decide on whether or not to add a flag to the camera actor to activate this.

In the first commit, camera actor's `ViewPos` field has to be non-`null` to activate. Sets `Viewpoint.FogCenterPos` to `camera->tracer` if not `null`, else tries to undo `ViewPos` offset and sets `Viewpoint.FogCenterPos` that way (unless `VPSF_ABSOLUTEPOS` flag is set).

Works with all manner of portals and even in camera textures.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
