### PR TITLE
move bindings reset to a per-game version

### DIFF
--- a/src/common/utility/configfile.h
+++ b/src/common/utility/configfile.h
@@ -44,7 +44,14 @@ public:
 	void MoveSectionToStart (const char *name);
 	void SetSectionNote (const char *section, const char *note);
 	void SetSectionNote (const char *note);
+
 	bool SetSection (const char *section, bool allowCreate=false);
+
+	bool SetSection (FString section, bool allowCreate=false)
+	{
+		return SetSection(section.GetChars(), allowCreate);
+	}
+
 	bool SetFirstSection ();
 	bool SetNextSection ();
 	const char *GetCurrentSection () const;

--- a/src/d_defcvars.cpp
+++ b/src/d_defcvars.cpp
@@ -34,8 +34,8 @@
 void D_GrabCVarDefaults()
 {
 	int lump, lastlump = 0;
-	int lumpversion, gamelastrunversion;
-	gamelastrunversion = atoi(LASTRUNVERSION);
+	int lumpversion, lastrunversion;
+	lastrunversion = atoi(ENGINELASTRUNVERSION);
 
 	while ((lump = fileSystem.FindLump("DEFCVARS", &lastlump)) != -1)
 	{
@@ -51,13 +51,13 @@ void D_GrabCVarDefaults()
 
 		sc.MustGetString();
 		if (!sc.Compare("version"))
-			sc.ScriptError("Must declare version for defcvars! (currently: %i)", gamelastrunversion);
+			sc.ScriptError("Must declare version for defcvars! (currently: %i)", lastrunversion);
 		sc.MustGetNumber();
 		lumpversion = sc.Number;
-		if (lumpversion > gamelastrunversion)
-			sc.ScriptError("Unsupported version %i (%i supported)", lumpversion, gamelastrunversion);
+		if (lumpversion > lastrunversion)
+			sc.ScriptError("Unsupported version %i (%i supported)", lumpversion, lastrunversion);
 		if (lumpversion < 219)
-			sc.ScriptError("Version must be at least 219 (current version %i)", gamelastrunversion);
+			sc.ScriptError("Version must be at least 219 (current version %i)", lastrunversion);
 
 		FBaseCVar* var;
 		FString CurrentFindCVar;

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -167,7 +167,7 @@ FGameConfigFile::FGameConfigFile ()
 {
 	FString pathname;
 
-	OkayToWrite = false;	// Do not allow saving of the config before DoKeySetup()
+	OkayToWrite = false;	// Do not allow saving of the config before DoGlobalSetup()
 	bModSetup = false;
 	bGameSetup = false;
 	bKeySetup = false;
@@ -699,6 +699,8 @@ void FGameConfigFile::DoGlobalSetup ()
 			language = "auto";
 		}
 	}
+
+	OkayToWrite = true;
 }
 
 void FGameConfigFile::DoGameSetup(FString section)
@@ -834,8 +836,6 @@ void FGameConfigFile::DoKeySetup(FString section)
 	}
 
 	bKeySetup = true;
-
-	OkayToWrite = true;
 }
 
 // Like DoGameSetup(), but for mod-specific cvars.

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -724,24 +724,19 @@ void FGameConfigFile::DoGameSetup (const char *gamename)
 	const char *key;
 	const char *value;
 
-	sublen = countof(section) - 1 - mysnprintf (section, countof(section), "%s.", gamename);
-	subsection = section + countof(section) - sublen - 1;
-	section[countof(section) - 1] = '\0';
+	FString section(gamename);
 
-	strncpy (subsection, "UnknownConsoleVariables", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".UnknownConsoleVariables"))
 	{
 		ReadCVars (0);
 	}
 
-	strncpy (subsection, "ConfigOnlyVariables", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".ConfigOnlyVariables"))
 	{
 		ReadCVars (0);
 	}
 
-	strncpy (subsection, "ConsoleVariables", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".ConsoleVariables"))
 	{
 		ReadCVars (0);
 	}
@@ -758,20 +753,17 @@ void FGameConfigFile::DoGameSetup (const char *gamename)
 
 	// The NetServerInfo section will be read and override anything loaded
 	// here when it's determined that a netgame is being played.
-	strncpy (subsection, "LocalServerInfo", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".LocalServerInfo"))
 	{
 		ReadCVars (0);
 	}
 
-	strncpy (subsection, "Player", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".Player"))
 	{
 		ReadCVars (0);
 	}
 
-	strncpy (subsection, "ConsoleAliases", sublen);
-	if (SetSection (section))
+	if (SetSection (section + ".ConsoleAliases"))
 	{
 		const char *name = NULL;
 		while (NextInSection (key, value))

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -924,26 +924,20 @@ void FGameConfigFile::ReadCVars (uint32_t flags)
 
 void FGameConfigFile::ArchiveGameData (const char *gamename)
 {
-	char section[32*3], *subsection;
+	FString section(gamename);
 
-	sublen = countof(section) - 1 - mysnprintf (section, countof(section), "%s.", gamename);
-	subsection = section + countof(section) - 1 - sublen;
-
-	strncpy (subsection, "Player", sublen);
-	SetSection (section, true);
+	SetSection (section + ".Player", true);
 	ClearCurrentSection ();
 	C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_USERINFO);
 
 	if (bModSetup)
 	{
-		strncpy (subsection + 6, ".Mod", sublen - 6);
-		SetSection (section, true);
+		SetSection (section + ".Player.Mod", true);
 		ClearCurrentSection ();
 		C_ArchiveCVars (this, CVAR_MOD|CVAR_ARCHIVE|CVAR_AUTO|CVAR_USERINFO);
 	}
 
-	strncpy (subsection, "ConsoleVariables", sublen);
-	SetSection (section, true);
+	SetSection (section + ".ConsoleVariables", true);
 	ClearCurrentSection ();
 	C_ArchiveCVars (this, CVAR_ARCHIVE);
 
@@ -951,55 +945,46 @@ void FGameConfigFile::ArchiveGameData (const char *gamename)
 	// this machine was not the initial host.
 	if (!netgame || consoleplayer == 0)
 	{
-		strncpy (subsection, netgame ? "NetServerInfo" : "LocalServerInfo", sublen);
-		SetSection (section, true);
+		SetSection (section + (netgame ? ".NetServerInfo" : ".LocalServerInfo"), true);
 		ClearCurrentSection ();
 		C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_SERVERINFO);
 
 		if (bModSetup)
 		{
-			strncpy (subsection, netgame ? "NetServerInfo.Mod" : "LocalServerInfo.Mod", sublen);
-			SetSection (section, true);
+			SetSection (section + (netgame ? ".NetServerInfo.Mod" : ".LocalServerInfo.Mod"), true);
 			ClearCurrentSection ();
 			C_ArchiveCVars (this, CVAR_MOD|CVAR_ARCHIVE|CVAR_AUTO|CVAR_SERVERINFO);
 		}
 	}
 
-	strncpy (subsection, "ConfigOnlyVariables", sublen);
-	SetSection (section, true);
+	SetSection (section + ".ConfigOnlyVariables", true);
 	ClearCurrentSection ();
 	C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO|CVAR_CONFIG_ONLY);
 
 	if (bModSetup)
 	{
-		strncpy (subsection, "ConfigOnlyVariables.Mod", sublen);
-		SetSection (section, true);
+		SetSection (section + ".ConfigOnlyVariables.Mod", true);
 		ClearCurrentSection ();
 		C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO|CVAR_MOD|CVAR_CONFIG_ONLY);
 	}
 
-	strncpy (subsection, "UnknownConsoleVariables", sublen);
-	SetSection (section, true);
+	SetSection (section + ".UnknownConsoleVariables", true);
 	ClearCurrentSection ();
 	C_ArchiveCVars (this, CVAR_ARCHIVE|CVAR_AUTO);
 
-	strncpy (subsection, "ConsoleAliases", sublen);
-	SetSection (section, true);
+	SetSection (section + ".ConsoleAliases", true);
 	ClearCurrentSection ();
 	C_ArchiveAliases (this);
 
-	M_SaveCustomKeys (this, section, subsection, sublen);
+	M_SaveCustomKeys (this, section);
 
-	strcpy (subsection, "Bindings");
-	SetSection (section, true);
+	SetSection (section + ".Bindings", true);
 	Bindings.ArchiveBindings (this);
 
-	strncpy (subsection, "DoubleBindings", sublen);
-	SetSection (section, true);
+	SetSection (section + ".DoubleBindings", true);
 	DoubleBindings.ArchiveBindings (this);
 
-	strncpy (subsection, "AutomapBindings", sublen);
-	SetSection (section, true);
+	SetSection (section + ".AutomapBindings", true);
 	AutomapBindings.ArchiveBindings (this);
 }
 

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -719,12 +719,10 @@ void FGameConfigFile::DoGlobalSetup ()
 	}
 }
 
-void FGameConfigFile::DoGameSetup (const char *gamename)
+void FGameConfigFile::DoGameSetup(FString section)
 {
 	const char *key;
 	const char *value;
-
-	FString section(gamename);
 
 	if (SetSection (section + ".UnknownConsoleVariables"))
 	{
@@ -782,7 +780,7 @@ void FGameConfigFile::DoGameSetup (const char *gamename)
 }
 
 // Moved from DoGameSetup so that it can happen after wads are loaded
-void FGameConfigFile::DoKeySetup(const char *gamename)
+void FGameConfigFile::DoKeySetup(FString section)
 {
 	constexpr int numbindings = 3;
 
@@ -793,8 +791,6 @@ void FGameConfigFile::DoKeySetup(const char *gamename)
 		{ ".AutomapBindings", &AutomapBindings }
 	};
 	const char *key, *value;
-
-	FString section(gamename);
 
 	C_SetDefaultBindings ();
 
@@ -853,9 +849,8 @@ void FGameConfigFile::DoKeySetup(const char *gamename)
 
 // Like DoGameSetup(), but for mod-specific cvars.
 // Called after CVARINFO has been parsed.
-void FGameConfigFile::DoModSetup(const char *gamename)
+void FGameConfigFile::DoModSetup(FString section)
 {
-	FString section(gamename);
 
 	if(SetSection(section + ".Player.Mod"))
 	{
@@ -878,7 +873,7 @@ void FGameConfigFile::DoModSetup(const char *gamename)
 
 // Read cvars from a cvar section of the ini. Flags are the flags to give
 // to newly-created cvars that were not already defined.
-void FGameConfigFile::ReadCVars (uint32_t flags)
+void FGameConfigFile::ReadCVars(uint32_t flags)
 {
 	const char *key, *value;
 	FBaseCVar *cvar;
@@ -897,9 +892,8 @@ void FGameConfigFile::ReadCVars (uint32_t flags)
 	}
 }
 
-void FGameConfigFile::ArchiveGameData (const char *gamename)
+void FGameConfigFile::ArchiveGameData(FString section)
 {
-	FString section(gamename);
 
 	SetSection (section + ".Player", true);
 	ClearCurrentSection ();

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -865,21 +865,23 @@ void FGameConfigFile::DoKeySetup(const char *gamename)
 // Called after CVARINFO has been parsed.
 void FGameConfigFile::DoModSetup(const char *gamename)
 {
-	mysnprintf(section, countof(section), "%s.Player.Mod", gamename);
-	if (SetSection(section))
+	FString section(gamename);
+
+	if(SetSection(section + ".Player.Mod"))
 	{
 		ReadCVars(CVAR_MOD|CVAR_USERINFO|CVAR_IGNORE);
 	}
-	mysnprintf(section, countof(section), "%s.LocalServerInfo.Mod", gamename);
-	if (SetSection (section))
+
+	if(SetSection(section + ".LocalServerInfo.Mod"))
 	{
 		ReadCVars (CVAR_MOD|CVAR_SERVERINFO|CVAR_IGNORE);
 	}
-	mysnprintf(section, countof(section), "%s.ConfigOnlyVariables.Mod", gamename);
-	if (SetSection (section))
+
+	if(SetSection(section + ".ConfigOnlyVariables.Mod"))
 	{
 		ReadCVars (CVAR_MOD|CVAR_CONFIG_ONLY|CVAR_IGNORE);
 	}
+
 	// Signal that these sections should be rewritten when saving the config.
 	bModSetup = true;
 }

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -187,17 +187,18 @@ FGameConfigFile::FGameConfigFile ()
 	// LASTRUN < 227: convert GZDoom ini's by ensuring all
 	// system paths have the corresponding UZDoom version
 	// already present
-	double last = 0;
+	GameLastRunVer = 0;
+	EngineLastRunVer = 0;
 	if (SetSection ("LastRun"))
 	{
 		const char *lastver = GetValueForKey ("Version");
 		if (lastver != NULL)
 		{
-			last = atof(lastver);
+			EngineLastRunVer = atof(lastver);
 		}
 	}
 
-	if (last < 227)
+	if (EngineLastRunVer < 227)
 	{
 		if (SetSection("IWADSearch.Directories"))
 		{
@@ -290,14 +291,7 @@ void FGameConfigFile::DoAutoloadSetup (FIWadManager *iwad_man)
 	// Note that this totem pole is the reverse of the order that
 	// they will appear in the file.
 
-	double last = 0;
-	if (SetSection ("LastRun"))
-	{
-		const char *lastver = GetValueForKey ("Version");
-		if (lastver != NULL) last = atof(lastver);
-	}
-
-	if (last < 211)
+	if (EngineLastRunVer < 211)
 	{
 		RenameSection("Chex3.Autoload", "chex.chex3.Autoload");
 		RenameSection("Chex1.Autoload", "chex.chex1.Autoload");
@@ -315,7 +309,7 @@ void FGameConfigFile::DoAutoloadSetup (FIWadManager *iwad_man)
 		RenameSection("Doom2BFG.Autoload", "doom.id.doom2.bfg.Autoload");
 		RenameSection("Doom2.Autoload", "doom.id.doom2.commercial.Autoload");
 	}
-	else if (last < 218)
+	else if (EngineLastRunVer < 218)
 	{
 		RenameSection("doom.doom1.bfg.Autoload", "doom.id.doom1.bfg.Autoload");
 		RenameSection("doom.doom1.ultimate.Autoload", "doom.id.doom1.ultimate.Autoload");
@@ -388,335 +382,321 @@ void FGameConfigFile::DoGlobalSetup ()
 		const char *lastRelease = GetValueForKey ("Release");
 		i_is_new_release = !lastRelease || strcmp(VERSIONSTR, lastRelease) != 0;
 
-		const char *lastver = GetValueForKey ("Version");
-		if (lastver != NULL)
+		FBaseCVar *var;
+		if (EngineLastRunVer < 207)
+		{ // Now that snd_midiprecache works again, you probably don't want it on.
+			var = FindCVar ("snd_midiprecache", NULL);
+			if (var != NULL) var->ResetToDefault();
+		}
+		if (EngineLastRunVer < 208)
+		{ // Weapon sections are no longer used, so tidy up the config by deleting them.
+			const char *name;
+			size_t namelen;
+			bool more;
+
+			more = SetFirstSection();
+			while (more)
+			{
+				name = GetCurrentSection();
+				if (name != NULL &&
+					(namelen = strlen(name)) > 12 &&
+					strcmp(name + namelen - 12, ".WeaponSlots") == 0)
+				{
+					more = DeleteCurrentSection();
+				}
+				else
+				{
+					more = SetNextSection();
+				}
+			}
+		}
+		if (EngineLastRunVer < 209)
 		{
-			FBaseCVar *var;
-			double last = atof (lastver);
-			if (last < 207)
-			{ // Now that snd_midiprecache works again, you probably don't want it on.
-				var = FindCVar ("snd_midiprecache", NULL);
-				if (var != NULL) var->ResetToDefault();
+			// menu dimming is now a gameinfo option so switch user override off
+			var = FindCVar ("dimamount", NULL);
+			if (var != NULL) var->ResetToDefault ();
+		}
+		if (EngineLastRunVer < 210)
+		{
+			if (SetSection ("Hexen.Bindings"))
+			{
+				// These 2 were misnamed in earlier versions
+				SetValueForKey ("6", "use ArtiPork");
+				SetValueForKey ("5", "use ArtiInvulnerability2");
 			}
-			if (last < 208)
-			{ // Weapon sections are no longer used, so tidy up the config by deleting them.
-				const char *name;
-				size_t namelen;
-				bool more;
-
-				more = SetFirstSection();
-				while (more)
+		}
+		if (EngineLastRunVer < 213)
+		{
+			var = FindCVar("snd_channels", NULL);
+			if (var != NULL)
+			{
+				// old settings were default 32, minimum 8, new settings are default 128, minimum 64.
+				UCVarValue v = var->GetGenericRep(CVAR_Int);
+				if (v.Int < 64) var->ResetToDefault();
+			}
+		}
+		if (EngineLastRunVer < 214)
+		{
+			var = FindCVar("hud_scale", NULL);
+			if (var != NULL) var->ResetToDefault();
+			var = FindCVar("st_scale", NULL);
+			if (var != NULL) var->ResetToDefault();
+			var = FindCVar("hud_althudscale", NULL);
+			if (var != NULL) var->ResetToDefault();
+			var = FindCVar("con_scale", NULL);
+			if (var != NULL) var->ResetToDefault();
+			var = FindCVar("con_scaletext", NULL);
+			if (var != NULL) var->ResetToDefault();
+			var = FindCVar("uiscale", NULL);
+			if (var != NULL) var->ResetToDefault();
+		}
+		if (EngineLastRunVer < 215)
+		{
+			// Previously a true/false boolean. Now an on/off/auto tri-state with auto as the default.
+			var = FindCVar("snd_hrtf", NULL);
+			if (var != NULL) var->ResetToDefault();
+		}
+		if (EngineLastRunVer < 216)
+		{
+			var = FindCVar("gl_texture_hqresize", NULL);
+			if (var != NULL)
+			{
+				auto v = var->GetGenericRep(CVAR_Int);
+				switch (v.Int)
 				{
-					name = GetCurrentSection();
-					if (name != NULL &&
-						(namelen = strlen(name)) > 12 &&
-						strcmp(name + namelen - 12, ".WeaponSlots") == 0)
-					{
-						more = DeleteCurrentSection();
-					}
-					else
-					{
-						more = SetNextSection();
-					}
+				case 1:
+					gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 2;
+					break;
+				case 2:
+					gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 3;
+					break;
+				case 3:
+					gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 4;
+					break;
+				case 4:
+					gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 2;
+					break;
+				case 5:
+					gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 3;
+					break;
+				case 6:
+					gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 4;
+					break;
+				case 7:
+					gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 2;
+					break;
+				case 8:
+					gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 3;
+					break;
+				case 9:
+					gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 4;
+					break;
+				case 10:
+					gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 2;
+					break;
+				case 11:
+					gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 3;
+					break;
+				case 12:
+					gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 4;
+					break;
+				case 18:
+					gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 5;
+					break;
+				case 19:
+					gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 6;
+					break;
+				case 13:
+					gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 2;
+					break;
+				case 14:
+					gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 3;
+					break;
+				case 15:
+					gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 4;
+					break;
+				case 16:
+					gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 5;
+					break;
+				case 17:
+					gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 6;
+					break;
+				case 20:
+					gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 2;
+					break;
+				case 21:
+					gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 3;
+					break;
+				case 22:
+					gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 4;
+					break;
+				case 23:
+					gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 5;
+					break;
+				case 24:
+					gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 6;
+					break;
+				case 0:
+				default:
+					gl_texture_hqresizemode = 0; gl_texture_hqresizemult = 1;
+					break;
 				}
 			}
-			if (last < 209)
+		}
+		if (EngineLastRunVer < 217)
+		{
+			var = FindCVar("vid_scalemode", NULL);
+			if (var != NULL)
 			{
-				// menu dimming is now a gameinfo option so switch user override off
-				var = FindCVar ("dimamount", NULL);
-				if (var != NULL) var->ResetToDefault ();
-			}
-			if (last < 210)
-			{
-				if (SetSection ("Hexen.Bindings"))
+				UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
+				if (v.Int == 3) // 640x400
 				{
-					// These 2 were misnamed in earlier versions
-					SetValueForKey ("6", "use ArtiPork");
-					SetValueForKey ("5", "use ArtiInvulnerability2");
+					newvalue.Int = 2;
+					var->SetGenericRep(newvalue, CVAR_Int);
+				}
+				if (v.Int == 2) // 320x200
+				{
+					newvalue.Int = 6;
+					var->SetGenericRep(newvalue, CVAR_Int);
 				}
 			}
-			if (last < 213)
+		}
+		if (EngineLastRunVer < 219)
+		{
+			// 2019-12-06 - polybackend merge
+			// migrate vid_enablevulkan to vid_preferbackend
+			var = FindCVar("vid_enablevulkan", NULL);
+			if (var != NULL)
 			{
-				var = FindCVar("snd_channels", NULL);
-				if (var != NULL)
+				UCVarValue v = var->GetGenericRep(CVAR_Int);
+				vid_preferbackend = v.Int;
+			}
+			// 2019-12-31 - r_videoscale.cpp changes
+			var = FindCVar("vid_scale_customstretched", NULL);
+			if (var != NULL)
+			{
+				UCVarValue v = var->GetGenericRep(CVAR_Bool);
+				if (v.Bool)
+					vid_scale_custompixelaspect = 1.2f;
+				else
+					vid_scale_custompixelaspect = 1.0f;
+			}
+			var = FindCVar("vid_scalemode", NULL);
+			if (var != NULL)
+			{
+				UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
+				switch (v.Int)
 				{
-					// old settings were default 32, minimum 8, new settings are default 128, minimum 64.
-					UCVarValue v = var->GetGenericRep(CVAR_Int);
-					if (v.Int < 64) var->ResetToDefault();
+				case 1:
+					newvalue.Int = 0;
+					var->SetGenericRep(newvalue, CVAR_Int);
+					[[fallthrough]];
+				case 3:
+				case 4:
+					vid_scale_linear = true;
+					break;
+				default:
+					vid_scale_linear = false;
+					break;
 				}
 			}
-			if (last < 214)
+		}
+		if (EngineLastRunVer < 220)
+		{
+			var = FindCVar("Gamma", NULL);
+			if (var != NULL)
 			{
-				var = FindCVar("hud_scale", NULL);
-				if (var != NULL) var->ResetToDefault();
-				var = FindCVar("st_scale", NULL);
-				if (var != NULL) var->ResetToDefault();
-				var = FindCVar("hud_althudscale", NULL);
-				if (var != NULL) var->ResetToDefault();
-				var = FindCVar("con_scale", NULL);
-				if (var != NULL) var->ResetToDefault();
-				var = FindCVar("con_scaletext", NULL);
-				if (var != NULL) var->ResetToDefault();
-				var = FindCVar("uiscale", NULL);
-				if (var != NULL) var->ResetToDefault();
+				UCVarValue v = var->GetGenericRep(CVAR_Float);
+				vid_gamma = v.Float;
 			}
-			if (last < 215)
+			var = FindCVar("fullscreen", NULL);
+			if (var != NULL)
 			{
-				// Previously a true/false boolean. Now an on/off/auto tri-state with auto as the default.
-				var = FindCVar("snd_hrtf", NULL);
-				if (var != NULL) var->ResetToDefault();
+				UCVarValue v = var->GetGenericRep(CVAR_Bool);
+				vid_fullscreen = v.Float;
 			}
-			if (last < 216)
-			{
-				var = FindCVar("gl_texture_hqresize", NULL);
-				if (var != NULL)
-				{
-					auto v = var->GetGenericRep(CVAR_Int);
-					switch (v.Int)
-					{
-					case 1:
-						gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 2;
-						break;
-					case 2:
-						gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 3;
-						break;
-					case 3:
-						gl_texture_hqresizemode = 1; gl_texture_hqresizemult = 4;
-						break;
-					case 4:
-						gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 2;
-						break;
-					case 5:
-						gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 3;
-						break;
-					case 6:
-						gl_texture_hqresizemode = 2; gl_texture_hqresizemult = 4;
-						break;
-					case 7:
-						gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 2;
-						break;
-					case 8:
-						gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 3;
-						break;
-					case 9:
-						gl_texture_hqresizemode = 3; gl_texture_hqresizemult = 4;
-						break;
-					case 10:
-						gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 2;
-						break;
-					case 11:
-						gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 3;
-						break;
-					case 12:
-						gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 4;
-						break;
-					case 18:
-						gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 5;
-						break;
-					case 19:
-						gl_texture_hqresizemode = 4; gl_texture_hqresizemult = 6;
-						break;
-					case 13:
-						gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 2;
-						break;
-					case 14:
-						gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 3;
-						break;
-					case 15:
-						gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 4;
-						break;
-					case 16:
-						gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 5;
-						break;
-					case 17:
-						gl_texture_hqresizemode = 5; gl_texture_hqresizemult = 6;
-						break;
-					case 20:
-						gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 2;
-						break;
-					case 21:
-						gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 3;
-						break;
-					case 22:
-						gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 4;
-						break;
-					case 23:
-						gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 5;
-						break;
-					case 24:
-						gl_texture_hqresizemode = 6; gl_texture_hqresizemult = 6;
-						break;
-					case 0:
-					default:
-						gl_texture_hqresizemode = 0; gl_texture_hqresizemult = 1;
-						break;
-					}
-				}
-			}
-			if (last < 217)
-			{
-				var = FindCVar("vid_scalemode", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
-					if (v.Int == 3) // 640x400
-					{
-						newvalue.Int = 2;
-						var->SetGenericRep(newvalue, CVAR_Int);
-					}
-					if (v.Int == 2) // 320x200
-					{
-						newvalue.Int = 6;
-						var->SetGenericRep(newvalue, CVAR_Int);
-					}
-				}
-			}
-			if (last < 219)
-			{
-				// 2019-12-06 - polybackend merge
-				// migrate vid_enablevulkan to vid_preferbackend
-				var = FindCVar("vid_enablevulkan", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int);
-					vid_preferbackend = v.Int;
-				}
-				// 2019-12-31 - r_videoscale.cpp changes
-				var = FindCVar("vid_scale_customstretched", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Bool);
-					if (v.Bool)
-						vid_scale_custompixelaspect = 1.2f;
-					else
-						vid_scale_custompixelaspect = 1.0f;
-				}
-				var = FindCVar("vid_scalemode", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int), newvalue;
-					switch (v.Int)
-					{
-					case 1:
-						newvalue.Int = 0;
-						var->SetGenericRep(newvalue, CVAR_Int);
-						[[fallthrough]];
-					case 3:
-					case 4:
-						vid_scale_linear = true;
-						break;
-					default:
-						vid_scale_linear = false;
-						break;
-					}
-				}
-			}
-			if (last < 220)
-			{
-				var = FindCVar("Gamma", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Float);
-					vid_gamma = v.Float;
-				}
-				var = FindCVar("fullscreen", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Bool);
-					vid_fullscreen = v.Float;
-				}
-			}
-			if (last < 221)
-			{
-				// Transfer the messed up mouse scaling config to something sane and consistent.
+		}
+		if (EngineLastRunVer < 221)
+		{
+			// Transfer the messed up mouse scaling config to something sane and consistent.
 #ifndef _WIN32
-				double xfact = 3, yfact = 2;
+			double xfact = 3, yfact = 2;
 #else
-				double xfact = in_mouse == 1? 1.5 : 4, yfact = 1;
+			double xfact = in_mouse == 1? 1.5 : 4, yfact = 1;
 #endif
-				var = FindCVar("m_noprescale", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Bool);
-					if (v.Bool) xfact = yfact = 1;
-				}
+			var = FindCVar("m_noprescale", NULL);
+			if (var != NULL)
+			{
+				UCVarValue v = var->GetGenericRep(CVAR_Bool);
+				if (v.Bool) xfact = yfact = 1;
+			}
 
-				var = FindCVar("mouse_sensitivity", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Float);
-					xfact *= v.Float;
-					yfact *= v.Float;
-				}
-				m_sensitivity_x = (float)xfact;
-				m_sensitivity_y = (float)yfact;
+			var = FindCVar("mouse_sensitivity", NULL);
+			if (var != NULL)
+			{
+				UCVarValue v = var->GetGenericRep(CVAR_Float);
+				xfact *= v.Float;
+				yfact *= v.Float;
+			}
+			m_sensitivity_x = (float)xfact;
+			m_sensitivity_y = (float)yfact;
 
-				adl_volume_model = 0;
-				adl_chan_alloc = -1;
-				adl_auto_arpeggio = false;
+			adl_volume_model = 0;
+			adl_chan_alloc = -1;
+			adl_auto_arpeggio = false;
 
-				opn_volume_model = 0;
-				opn_chan_alloc = -1;
-				opn_auto_arpeggio = false;
+			opn_volume_model = 0;
+			opn_chan_alloc = -1;
+			opn_auto_arpeggio = false;
 
-				// if user originally wanted the in-game textures resized, set model skins to resize too
-				int old_targets = gl_texture_hqresize_targets;
-				old_targets |= (old_targets & 1) ? 8 : 0;
-				gl_texture_hqresize_targets = old_targets;
-			}
-			if (last < 222)
+			// if user originally wanted the in-game textures resized, set model skins to resize too
+			int old_targets = gl_texture_hqresize_targets;
+			old_targets |= (old_targets & 1) ? 8 : 0;
+			gl_texture_hqresize_targets = old_targets;
+		}
+		if (EngineLastRunVer < 222)
+		{
+			var = FindCVar("mod_dumb_mastervolume", NULL);
+			if (var != NULL)
 			{
-				var = FindCVar("mod_dumb_mastervolume", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Float);
-					v.Float /= 4.f;
-					if (v.Float < 1.f) v.Float = 1.f;
-				}
+				UCVarValue v = var->GetGenericRep(CVAR_Float);
+				v.Float /= 4.f;
+				if (v.Float < 1.f) v.Float = 1.f;
 			}
-			if (last < 223)
+		}
+		if (EngineLastRunVer < 223)
+		{
+			// ooooh boy did i open a can of worms with this one.
+			i_pauseinbackground = !(i_soundinbackground);
+		}
+		if (EngineLastRunVer < 224)
+		{
+			var = FindCVar("m_sensitivity_x", NULL);
+			if (var != NULL)
 			{
-				// ooooh boy did i open a can of worms with this one.
-				i_pauseinbackground = !(i_soundinbackground);
+				UCVarValue v = var->GetGenericRep(CVAR_Float);
+				v.Float *= 0.5f;
+				var->SetGenericRep(v, CVAR_Float);
 			}
-			if (last < 224)
+		}
+		if (EngineLastRunVer < 225)
+		{
+			var = FindCVar("gl_lightmode", NULL);
+			if (var != NULL)
 			{
-				var = FindCVar("m_sensitivity_x", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Float);
-					v.Float *= 0.5f;
-					var->SetGenericRep(v, CVAR_Float);
-				}
+				UCVarValue v = var->GetGenericRep(CVAR_Int);
+				v.Int = v.Int == 16 ? 2 : v.Int == 8 ? 1 : 0;
+				var->SetGenericRep(v, CVAR_Int);
 			}
-			if (last < 225)
-			{
-				var = FindCVar("gl_lightmode", NULL);
-				if (var != NULL)
-				{
-					UCVarValue v = var->GetGenericRep(CVAR_Int);
-					v.Int = v.Int == 16 ? 2 : v.Int == 8 ? 1 : 0;
-					var->SetGenericRep(v, CVAR_Int);
-				}
-			}
-			if (last < 226 // GZDoom 4.14.2
-				|| last == 228) // UZDoom 4.14.3 (227 was used in a bunch of 5.0 dev builds)
-			{
-				// We can't handle key config yet, because
-				// the files aren't fully loaded. Just queue
-				// up a flag to do this later.
-				bResetBindFlags |= V226GamePad;
-			}
-			if (last < 230) // UZDoom 5.0
-			{
-				// Reset brightness related settings, as the values all mean something different now
-				AddCommandString("vid_reset2defaults");
-				bResetBindFlags |= V230Gamma;
-			}
-			if (last < 231) // UZDoom 5.0
-			{
-				language = "auto";
-			}
+		}
+		if (EngineLastRunVer < 230) // UZDoom 5.0
+		{
+			// Reset brightness related settings, as the values all mean something different now
+			AddCommandString("vid_reset2defaults");
+		}
+		if (EngineLastRunVer < 231) // UZDoom 5.0
+		{
+			language = "auto";
 		}
 	}
 }
@@ -725,6 +705,13 @@ void FGameConfigFile::DoGameSetup(FString section)
 {
 	const char *key;
 	const char *value;
+
+	GameLastRunVer = 0;
+	if (SetSection (section + ".LastRun"))
+	{
+		const char *lastver = GetValueForKey ("Version");
+		if (lastver != NULL) GameLastRunVer = atof(lastver);
+	}
 
 	if (SetSection (section + ".UnknownConsoleVariables"))
 	{
@@ -813,10 +800,8 @@ void FGameConfigFile::DoKeySetup(FString section)
 		}
 	}
 
-	if (bResetBindFlags & V226GamePad)
+	if (GameLastRunVer < 1)
 	{
-		bResetBindFlags -= V226GamePad;
-
 		// Multiple gamepad reworks were done during
 		// this version. There is not any particularly
 		// good way to transfer older settings, so we
@@ -841,10 +826,8 @@ void FGameConfigFile::DoKeySetup(FString section)
 		C_SetDefaultBindings(&keys_to_reset);
 	}
 
-	if (bResetBindFlags & V230Gamma)
+	if (GameLastRunVer < 1)
 	{
-		bResetBindFlags -= V230Gamma;
-
 		// swap binds
 		Bindings.UnbindACommand("bumpgamma");
 		Bindings.DefaultBind("F11", "bumplight");
@@ -903,6 +886,10 @@ void FGameConfigFile::ReadCVars(uint32_t flags)
 void FGameConfigFile::ArchiveGameData(FString section)
 {
 	if(!bGameSetup) return;
+
+	SetSection (section + ".LastRun", true);
+	ClearCurrentSection ();
+	SetValueForKey ("Version", GAMELASTRUNVERSION);
 
 	SetSection (section + ".Player", true);
 	ClearCurrentSection ();
@@ -972,7 +959,7 @@ void FGameConfigFile::ArchiveGlobalData ()
 {
 	SetSection ("LastRun", true);
 	ClearCurrentSection ();
-	SetValueForKey ("Version", LASTRUNVERSION);
+	SetValueForKey ("Version", ENGINELASTRUNVERSION);
 	SetValueForKey ("Release", VERSIONSTR);
 
 	SetSection ("GlobalSettings", true);

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -792,25 +792,23 @@ void FGameConfigFile::DoGameSetup (const char *gamename)
 // Moved from DoGameSetup so that it can happen after wads are loaded
 void FGameConfigFile::DoKeySetup(const char *gamename)
 {
-	static const struct { const char *label; FKeyBindings *bindings; } binders[] =
+	constexpr int numbindings = 3;
+
+	static const struct { const char *label; FKeyBindings *bindings; } binders[numbindings] =
 	{
-		{ "Bindings", &Bindings },
-		{ "DoubleBindings", &DoubleBindings },
-		{ "AutomapBindings", &AutomapBindings },
-		{ NULL, NULL }
+		{ ".Bindings", &Bindings },
+		{ ".DoubleBindings", &DoubleBindings },
+		{ ".AutomapBindings", &AutomapBindings }
 	};
 	const char *key, *value;
 
-	sublen = countof(section) - 1 - mysnprintf(section, countof(section), "%s.", gamename);
-	subsection = section + countof(section) - sublen - 1;
-	section[countof(section) - 1] = '\0';
+	FString section(gamename);
 
 	C_SetDefaultBindings ();
 
-	for (int i = 0; binders[i].label != NULL; ++i)
+	for (int i = 0; i < numbindings; ++i)
 	{
-		strncpy(subsection, binders[i].label, sublen);
-		if (SetSection(section))
+		if (SetSection(section + binders[i].label))
 		{
 			FKeyBindings *bindings = binders[i].bindings;
 			bindings->UnbindAll();

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -169,6 +169,8 @@ FGameConfigFile::FGameConfigFile ()
 
 	OkayToWrite = false;	// Do not allow saving of the config before DoKeySetup()
 	bModSetup = false;
+	bGameSetup = false;
+	bKeySetup = false;
 	bResetBindFlags = 0;
 	pathname = GetConfigPath (true);
 	ChangePathName (pathname.GetChars());
@@ -777,11 +779,15 @@ void FGameConfigFile::DoGameSetup(FString section)
 			}
 		}
 	}
+
+	bGameSetup = true;
 }
 
 // Moved from DoGameSetup so that it can happen after wads are loaded
 void FGameConfigFile::DoKeySetup(FString section)
 {
+	assert(bGameSetup);
+
 	constexpr int numbindings = 3;
 
 	static const struct { const char *label; FKeyBindings *bindings; } binders[numbindings] =
@@ -844,6 +850,8 @@ void FGameConfigFile::DoKeySetup(FString section)
 		Bindings.DefaultBind("F11", "bumplight");
 	}
 
+	bKeySetup = true;
+
 	OkayToWrite = true;
 }
 
@@ -894,6 +902,7 @@ void FGameConfigFile::ReadCVars(uint32_t flags)
 
 void FGameConfigFile::ArchiveGameData(FString section)
 {
+	if(!bGameSetup) return;
 
 	SetSection (section + ".Player", true);
 	ClearCurrentSection ();
@@ -944,6 +953,8 @@ void FGameConfigFile::ArchiveGameData(FString section)
 	SetSection (section + ".ConsoleAliases", true);
 	ClearCurrentSection ();
 	C_ArchiveAliases (this);
+
+	if(!bKeySetup) return;
 
 	M_SaveCustomKeys (this, section);
 

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -884,23 +884,6 @@ void FGameConfigFile::DoModSetup(const char *gamename)
 	bModSetup = true;
 }
 
-void FGameConfigFile::ReadNetVars ()
-{
-	strncpy (subsection, "NetServerInfo", sublen);
-	if (SetSection (section))
-	{
-		ReadCVars (0);
-	}
-	if (bModSetup)
-	{
-		mysnprintf(subsection, sublen, "NetServerInfo.Mod");
-		if (SetSection(section))
-		{
-			ReadCVars(CVAR_MOD|CVAR_SERVERINFO|CVAR_IGNORE);
-		}
-	}
-}
-
 // Read cvars from a cvar section of the ini. Flags are the flags to give
 // to newly-created cvars that were not already defined.
 void FGameConfigFile::ReadCVars (uint32_t flags)

--- a/src/gameconfigfile.h
+++ b/src/gameconfigfile.h
@@ -40,11 +40,11 @@ public:
 
 	void DoAutoloadSetup (FIWadManager *iwad_man);
 	void DoGlobalSetup ();
-	void DoGameSetup (const char *gamename);
-	void DoKeySetup (const char *gamename);
-	void DoModSetup (const char *gamename);
+	void DoGameSetup (FString gamename);
+	void DoKeySetup (FString gamename);
+	void DoModSetup (FString gamename);
 	void ArchiveGlobalData ();
-	void ArchiveGameData (const char *gamename);
+	void ArchiveGameData (FString gamename);
 	void AddAutoexec (FArgs *list, const char *gamename);
 	FString GetConfigPath (bool tryProg);
 

--- a/src/gameconfigfile.h
+++ b/src/gameconfigfile.h
@@ -59,10 +59,6 @@ private:
 
 	bool bModSetup;
 	int bResetBindFlags;
-
-	char section[64];
-	char *subsection;
-	size_t sublen;
 };
 
 extern FGameConfigFile *GameConfig;

--- a/src/gameconfigfile.h
+++ b/src/gameconfigfile.h
@@ -57,6 +57,8 @@ private:
 	void SetStrifeDefaults ();
 	void ReadCVars (unsigned flags);
 
+	bool bGameSetup;
+	bool bKeySetup;
 	bool bModSetup;
 	int bResetBindFlags;
 };

--- a/src/gameconfigfile.h
+++ b/src/gameconfigfile.h
@@ -47,7 +47,6 @@ public:
 	void ArchiveGameData (const char *gamename);
 	void AddAutoexec (FArgs *list, const char *gamename);
 	FString GetConfigPath (bool tryProg);
-	void ReadNetVars ();
 
 protected:
 	void WriteCommentHeader (FileWriter *file) const;

--- a/src/gameconfigfile.h
+++ b/src/gameconfigfile.h
@@ -61,6 +61,9 @@ private:
 	bool bKeySetup;
 	bool bModSetup;
 	int bResetBindFlags;
+
+	double EngineLastRunVer;
+	double GameLastRunVer;
 };
 
 extern FGameConfigFile *GameConfig;

--- a/src/gamedata/keysections.cpp
+++ b/src/gamedata/keysections.cpp
@@ -54,7 +54,7 @@ static void LoadKeys (const char *modname, bool dbl)
 	}
 }
 
-static void DoSaveKeys (FConfigFile *config, const char *section, FKeySection *keysection, bool dbl)
+static void DoSaveKeys (FConfigFile *config, FString section, FKeySection *keysection, bool dbl)
 {
 	config->SetSection (section, true);
 	config->ClearCurrentSection ();
@@ -65,14 +65,12 @@ static void DoSaveKeys (FConfigFile *config, const char *section, FKeySection *k
 	}
 }
 
-void M_SaveCustomKeys (FConfigFile *config, char *section, char *subsection, size_t sublen)
+void M_SaveCustomKeys (FConfigFile *config, FString section)
 {
 	for (unsigned i=0; i<KeySections.Size(); i++)
 	{
-		mysnprintf (subsection, sublen, "%s.Bindings", KeySections[i].mSection.GetChars());
-		DoSaveKeys (config, section, &KeySections[i], false);
-		mysnprintf (subsection, sublen, "%s.DoubleBindings", KeySections[i].mSection.GetChars());
-		DoSaveKeys (config, section, &KeySections[i], true);
+		DoSaveKeys (config, section + KeySections[i].mSection + ".Bindings", &KeySections[i], false);
+		DoSaveKeys (config, section + KeySections[i].mSection + ".DoubleBindings", &KeySections[i], true);
 	}
 }
 

--- a/src/m_misc.h
+++ b/src/m_misc.h
@@ -38,7 +38,7 @@ void M_ScreenShot (const char *filename);
 void M_LoadDefaults ();
 
 bool M_SaveDefaults (const char *filename);
-void M_SaveCustomKeys (FConfigFile *config, char *section, char *subsection, size_t sublen);
+void M_SaveCustomKeys (FConfigFile *config, FString section);
 
 void M_OpenConfigDir();
 void M_OpenWadDir();

--- a/src/version.h
+++ b/src/version.h
@@ -45,7 +45,8 @@
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define LASTRUNVERSION "231"
+#define ENGINELASTRUNVERSION "231"
+#define GAMELASTRUNVERSION "1"
 
 // Protocol version used in demos.
 // Bump it if you change existing DEM_ commands or add new ones.


### PR DESCRIPTION
plus general cleanup of ini saving code to remove raw C string manipulation and to make saving the ini safe at any moment (lets settings changed in the launcher persist even without launching the game)

closes #1296

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
