### PR TITLE
cmake: make IWYU opt-in to prevent crash on ObjC++ files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1294,18 +1294,17 @@ set_source_files_properties( common/engine/sc_man.cpp PROPERTIES OBJECT_DEPENDS 
 set_source_files_properties( ${NOT_COMPILED_SOURCE_FILES} PROPERTIES HEADER_FILE_ONLY TRUE )
 set_source_files_properties( ${GAME_NONPCH_SOURCES} common/textures/hires/hqresize.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS TRUE )
 
-option(ENABLE_IWYU "Enable Include-What-You-Use analysis" ON)
-if (ENABLE_IWYU)
-	find_program(IWYU NAMES include-what-you-use iwyu)
-	if(IWYU)
-		message(STATUS "Using IWYU, found at ${IWYU}")
-		set_target_properties(zdoom PROPERTIES
-			CXX_INCLUDE_WHAT_YOU_USE "${IWYU}"
-			"-Xiwyu" "--mapping_file=${CMAKE_SOURCE_DIR}/tools/iwyu.imp"
-		)
-	else()
-		message(WARNING "IWYU not found.")
-	endif()
+option(USE_IWYU "Run include-what-you-use analysis" OFF)
+
+if(USE_IWYU)
+    find_program(IWYU NAMES include-what-you-use iwyu)
+    if(IWYU)
+        set_target_properties(zdoom PROPERTIES
+            CXX_INCLUDE_WHAT_YOU_USE "${IWYU}"
+            OBJCXX_INCLUDE_WHAT_YOU_USE ""
+            ...
+        )
+    endif()
 endif()
 
 if(BUILD_FLATPAK)


### PR DESCRIPTION
- [x] I have reviewed [CONTRIBUTING.md] and agree to its terms.
## Fix: make IWYU opt-in to prevent crash on Objective-C++ files

### Problem

On macos, if "include-what-you-use" is installed (for example via "brew install include-what-you-use"),
CMake's "find_program" silently picks it up and enables it for the entire zdoom target.
This causes the build to crash when compiling .mm files (Objective-C++). "fatal error: 'cstdio' file not found
Assertion failed: !isa<ObjCObjectType>(type) && "IWYU doesn't support Objective-C"
Subprocess aborted"
### Root cause

`find_program(IWYU ...)` finds any system-installed IWYU binary and unconditionally sets
`CXX_INCLUDE_WHAT_YOU_USE` on the target, with no way to opt out without uninstalling the tool.

### Fix

Wrap IWYU in an `option(USE_IWYU OFF)` so it is disabled by default and only enabled explicitly:

```bash
cmake .. -DUSE_IWYU=ON
```