### PR TITLE
Logging improvements

### DIFF
--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -409,7 +409,9 @@ void WriteLineToLog(FILE *LogFile, const char *outline)
 	fflush(LogFile);
 }
 
-inline int _PrintString(PrintFlag iprintlevel, const char *outline)
+namespace detail
+{
+inline int PrintString(PrintFlag iprintlevel, const char *outline)
 {
 	PrintFlag printlevel = static_cast<PrintFlag>(iprintlevel & PRINT_TYPES);
 	bool toScreen = printlevel != PRINT_LOG;
@@ -448,6 +450,8 @@ inline int _PrintString(PrintFlag iprintlevel, const char *outline)
 
 	return count;
 }
+}
+
 
 extern bool gameisdead;
 struct BufferedWrite { PrintFlag l; std::string s; };
@@ -465,13 +469,13 @@ int PrintString (PrintFlag iprintlevel, const char *outline)
 		return 0;
 	}
 
-	auto ret = _PrintString(iprintlevel, outline);
+	auto ret = ::detail::PrintString(iprintlevel, outline);
 
 	if (prebuffer) // we want the version string to be the first thing printed
 	{
 		for (auto &line: *prebuffer)
 		{
-			_PrintString(line.l, line.s.c_str());
+			::detail::PrintString(line.l, line.s.c_str());
 		}
 		prebuffer.reset();
 	}
@@ -510,16 +514,19 @@ int Printf (const char *format, ...)
 	return count;
 }
 
-inline int _DPrintf(DPrintLevel level, PrintFlag printlevel, const char *format, va_list argptr)
+namespace detail
+{
+inline int DPrintf(DPrintLevel level, PrintFlag printlevel, const char *format, va_list argptr)
 {
 	return (!developer.get() || developer >= level)? VPrintf(printlevel, format, argptr): 0;
+}
 }
 
 int DPrintf (DPrintLevel level, PrintFlag printlevel, const char *format, ...)
 {
 	va_list argptr;
 	va_start(argptr, format);
-	int count = _DPrintf(level, printlevel, format, argptr);
+	int count = ::detail::DPrintf(level, printlevel, format, argptr);
 	va_end(argptr);
 	return count;
 }
@@ -528,12 +535,14 @@ int DPrintf(DPrintLevel level, const char *format, ...)
 {
 	va_list argptr;
 	va_start(argptr, format);
-	int count = _DPrintf(level, PRINT_HIGH, format, argptr);
+	int count = ::detail::DPrintf(level, PRINT_HIGH, format, argptr);
 	va_end(argptr);
 	return count;
 }
 
-void __DebugLog(std::string_view file, size_t line, const char * format, ...)
+namespace detail
+{
+void DebugLog(std::string_view file, size_t line, const char * format, ...)
 {
 	static const size_t start = [&file]() {
 		std::string here = __FILE__;
@@ -556,6 +565,7 @@ void __DebugLog(std::string_view file, size_t line, const char * format, ...)
 	data.VFormat(format, argptr);
 	va_end(argptr);
 	DPrintf(DMSG_SPAMMY, PRINT_HIGH, "%s:%lu : %s\n", file.data(), line, data.GetChars());
+}
 }
 
 void C_FlushDisplay ()

--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -408,6 +408,46 @@ void WriteLineToLog(FILE *LogFile, const char *outline)
 	fflush(LogFile);
 }
 
+inline int _PrintString(PrintFlag iprintlevel, const char *outline)
+{
+	PrintFlag printlevel = static_cast<PrintFlag>(iprintlevel & PRINT_TYPES);
+	bool toScreen = printlevel != PRINT_LOG;
+	bool toFile = Logfile != nullptr && !(iprintlevel & PRINT_NOLOG);
+	bool toDebugger = !(iprintlevel & PRINT_NODAPEVENT);
+	int count = 0;
+
+	if (toScreen || toFile || toDebugger)
+	{
+		// Convert everything coming through here to UTF-8 so that all console text is in a consistent format
+		outline = MakeUTF8(outline, &count);
+	}
+	if (count == 0) return 0;
+
+	if (toScreen)
+	{
+		I_PrintStr(outline);
+		if (!(iprintlevel & PRINT_NOCONSOLE))
+			conbuffer->AddText(printlevel, outline);
+		if (vidactive && screen && !(iprintlevel & PRINT_NONOTIFY) && NotifyStrings)
+		{
+			if (printlevel >= msglevel)
+			{
+				NotifyStrings->AddString(iprintlevel, outline);
+			}
+		}
+	}
+	if (toFile)
+	{
+		WriteLineToLog(Logfile, outline);
+	}
+	if (toDebugger)
+	{
+		DebugServer::RuntimeEvents::EmitLogEvent(iprintlevel, outline);
+	}
+
+	return count;
+}
+
 extern bool gameisdead;
 
 int PrintString (PrintFlag iprintlevel, const char *outline)
@@ -415,42 +455,9 @@ int PrintString (PrintFlag iprintlevel, const char *outline)
 	if (gameisdead)
 		return 0;
 
-	if (!conbuffer) return 0;	// when called too early
-	PrintFlag printlevel = static_cast<PrintFlag>(iprintlevel & PRINT_TYPES);
-	if (*outline == '\0')
-	{
-		return 0;
-	}
-	if (printlevel != PRINT_LOG || !(iprintlevel & PRINT_NODAPEVENT) || Logfile != nullptr)
-	{
-		// Convert everything coming through here to UTF-8 so that all console text is in a consistent format
-		int count;
-		outline = MakeUTF8(outline, &count);
+	if (!conbuffer) return 0;
 
-		if (printlevel != PRINT_LOG)
-		{
-			I_PrintStr(outline);
-			if (!(iprintlevel & PRINT_NOCONSOLE))
-				conbuffer->AddText(printlevel, outline);
-			if (vidactive && screen && !(iprintlevel & PRINT_NONOTIFY) && NotifyStrings)
-			{
-				if (printlevel >= msglevel)
-				{
-					NotifyStrings->AddString(iprintlevel, outline);
-				}
-			}
-		}
-		if (Logfile != nullptr && !(iprintlevel & PRINT_NOLOG))
-		{
-			WriteLineToLog(Logfile, outline);
-		}
-		if (!(iprintlevel & PRINT_NODAPEVENT))
-		{
-			DebugServer::RuntimeEvents::EmitLogEvent(iprintlevel, outline);
-		}
-		return count;
-	}
-	return 0;	// Don't waste time on calculating this if nothing at all was printed...
+	return _PrintString(iprintlevel, outline);
 }
 
 int VPrintf (PrintFlag printlevel, const char *format, va_list parms)

--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -53,6 +53,7 @@
 #include "zstring.h"
 #include <array>
 #include <string_view>
+#include <vector>
 
 namespace Console::Defaults
 {
@@ -449,15 +450,33 @@ inline int _PrintString(PrintFlag iprintlevel, const char *outline)
 }
 
 extern bool gameisdead;
+struct BufferedWrite { PrintFlag l; std::string s; };
+std::unique_ptr<std::vector<BufferedWrite>> prebuffer;
 
 int PrintString (PrintFlag iprintlevel, const char *outline)
 {
 	if (gameisdead)
 		return 0;
 
-	if (!conbuffer) return 0;
+	if (!conbuffer)
+	{
+		if (!prebuffer) prebuffer = std::make_unique<std::vector<BufferedWrite>>();
+		if (prebuffer) prebuffer->push_back({iprintlevel, outline});
+		return 0;
+	}
 
-	return _PrintString(iprintlevel, outline);
+	auto ret = _PrintString(iprintlevel, outline);
+
+	if (prebuffer) // we want the version string to be the first thing printed
+	{
+		for (auto &line: *prebuffer)
+		{
+			_PrintString(line.l, line.s.c_str());
+		}
+		prebuffer.reset();
+	}
+
+	return ret;
 }
 
 int VPrintf (PrintFlag printlevel, const char *format, va_list parms)

--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -486,7 +486,7 @@ int Printf (const char *format, ...)
 
 inline int _DPrintf(DPrintLevel level, PrintFlag printlevel, const char *format, va_list argptr)
 {
-	return (developer >= level)? VPrintf(printlevel, format, argptr): 0;
+	return (!developer.get() || developer >= level)? VPrintf(printlevel, format, argptr): 0;
 }
 
 int DPrintf (DPrintLevel level, PrintFlag printlevel, const char *format, ...)

--- a/src/common/console/c_console.h
+++ b/src/common/console/c_console.h
@@ -78,8 +78,11 @@ void C_SetNotifyFontScale(double scale);
 extern const char *console_bar;
 extern int chatmodeon;
 
+namespace detail
+{
 // Don't call me directly
-void __DebugLog(std::string_view, size_t, const char *, ...) ATTRIBUTE((format(printf,3,4)));
+void DebugLog(std::string_view, size_t, const char *, ...) ATTRIBUTE((format(printf,3,4)));
+}
 
 // Heavy print statement that knows where it was called from
-#define DEBUG_LOG(format, ...) __DebugLog(__FILE__, __LINE__, format, __VA_ARGS__);
+#define DEBUG_LOG(format, ...) ::detail::DebugLog(__FILE__, __LINE__, format, __VA_ARGS__);

--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -171,6 +171,13 @@ FString I_DetectOS()
 
 void I_StartupJoysticks();
 
+#define SDL_SETENV(k, v)                                           \
+	do {                                                           \
+		auto old = SDL_getenv(k);                                  \
+		if (old) DEBUG_LOG("%s already set as '%s'", k, old);      \
+		if (SDL_setenv(k, v, 0)) DEBUG_LOG("Failed to set %s", k); \
+	} while (0);
+
 int main (int argc, char **argv)
 {
 #if !defined (__APPLE__)
@@ -195,7 +202,7 @@ int main (int argc, char **argv)
 
 /* currently this is causing issues in the appimage build
 #ifdef __linux
-	SDL_setenv("SDL_VIDEODRIVER", "wayland,x11", 0);
+	SDL_SETENV("SDL_VIDEODRIVER", "wayland,x11");
 #endif
 */
 

--- a/src/common/utility/utf8.cpp
+++ b/src/common/utility/utf8.cpp
@@ -185,6 +185,8 @@ uint16_t win1252map[] = {
 
 int GetCharFromString(const uint8_t *&string)
 {
+	if (!string) return 0;
+
 	int z;
 
 	z = *string;
@@ -226,10 +228,12 @@ static TArray<char> UTF8String;
 
 const char *MakeUTF8(const char *outline, int *numchars)
 {
+	if (numchars) *numchars = 0;
+	if (!outline) return nullptr;
+
 	UTF8String.Clear();
 	const uint8_t *in = (const uint8_t*)outline;
 
-	if (numchars) *numchars = 0;
 	while (int chr = GetCharFromString(in))
 	{
 		int size = 0;


### PR DESCRIPTION
Game would swallow any prints that happen early in the engine's boot sequence, making debugging annoying

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
