### PR TITLE
Change minimum sound channels from 64 back to 8.

### DIFF
--- a/src/common/audio/sound/oalsound.cpp
+++ b/src/common/audio/sound/oalsound.cpp
@@ -51,7 +51,7 @@ FModule OpenALModule{"OpenAL"};
 
 CUSTOM_CVAR(Int, snd_channels, 128, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)	// number of channels available
 {
-	if (self < 64) self = 64;
+	if (self < 8) self = 8;
 }
 CVARD(String, snd_aldriver, DEFAULT_DRIVER, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "See alsoftrc.sample for details")
 CVAR(Bool, snd_waterreverb, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -430,9 +430,9 @@ void FGameConfigFile::DoGlobalSetup ()
 			var = FindCVar("snd_channels", NULL);
 			if (var != NULL)
 			{
-				// old settings were default 32, minimum 8, new settings are default 128, minimum 64.
+				// old settings were default 32, minimum 8, new settings are default 128, minimum 8.
 				UCVarValue v = var->GetGenericRep(CVAR_Int);
-				if (v.Int < 64) var->ResetToDefault();
+				if (v.Int < 8) var->ResetToDefault();
 			}
 		}
 		if (EngineLastRunVer < 214)

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2533,7 +2533,7 @@ OptionMenu SoundOptions protected
 	Submenu "$SNDMNU_MIDIDEVICE",       "MidiDevicesMenu"
 	Submenu "$SNDMNU_MIDIPLAYER",       "MidiPlayerOptions"
 	StaticText " "
-	Slider "$SNDMNU_CHANNELS",          "snd_channels",        8, 256, 8, 0
+	Slider "$SNDMNU_CHANNELS",          "snd_channels",        64, 256, 8, 0
 	Option "$SNDMNU_BACKGROUND",        "i_soundinbackground", "OnOff"
 	Option "$SNDMNU_UNDERWATERREVERB",  "snd_waterreverb",     "OnOff"
 	Option "$SNDMNU_RANDOMIZEPITCHES",  "snd_pitched",         "OnOff"

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2533,7 +2533,7 @@ OptionMenu SoundOptions protected
 	Submenu "$SNDMNU_MIDIDEVICE",       "MidiDevicesMenu"
 	Submenu "$SNDMNU_MIDIPLAYER",       "MidiPlayerOptions"
 	StaticText " "
-	Slider "$SNDMNU_CHANNELS",          "snd_channels",        64, 256, 8, 0
+	Slider "$SNDMNU_CHANNELS",          "snd_channels",        8, 256, 8, 0
 	Option "$SNDMNU_BACKGROUND",        "i_soundinbackground", "OnOff"
 	Option "$SNDMNU_UNDERWATERREVERB",  "snd_waterreverb",     "OnOff"
 	Option "$SNDMNU_RANDOMIZEPITCHES",  "snd_pitched",         "OnOff"


### PR DESCRIPTION
It is handy to lower the number of sound channels in chaotic battles.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
