### PR TITLE
Move Earthquake Intensity slider to Accessibility settings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -274,3 +274,4 @@ Sam "LordEntr0py" Widdowson
 Sierra0451
 CM "Vault."
 Jay Smithen
+Matt Silverwood

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -972,7 +972,6 @@ OptionMenu "VideoOptions" protected
 	Option "$DSPLYMNU_PLAYERSPRITES",          r_drawplayersprites,    OnOff
 	Option "$DSPLYMNU_DEATHCAM",               r_deathcamera,          OnOff
 	Option "$DSPLYMNU_TELEZOOM",               telezoom,               OnOff
-	Slider "$DSPLYMNU_QUAKEINTENSITY",         r_quakeintensity,       0.0, 1.0, 0.05, 0, "", 0, Gray, 100, "$VALFORMAT_PERCENT"
 	Option "$DSPLYMNU_NOMONSTERINTERPOLATION", nomonsterinterpolation, NoYes
 }
 
@@ -2935,6 +2934,9 @@ OptionMenu AccessibilityOptions protected
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"
 	Slider "$ACCMNU_DOUBLECLICK_THRESHOLD", "cl_doubleclickthreshold", 100, 1000, 50, 0
 	Tooltip "$ACCMNU_TOOLTIP_DOUBLECLICK_THRESHOLD"
+
+	StaticText ""
+	Slider "$DSPLYMNU_QUAKEINTENSITY",         r_quakeintensity,       0.0, 1.0, 0.05, 0, "", 0, Gray, 100, "$VALFORMAT_PERCENT"
 
 	StaticText ""
 	SafeCommand "$OPTMNU_DEFAULTS", "acc_reset2defaults"


### PR DESCRIPTION
Moves the Earthquake intensity slider definition to the accessibility menu. Addresses #1387.

Not very sure about the separation, but I felt it necessary to separate it visually as no other setting is "related" to it, in a manner of speaking. Not sure if another header should be added, nor what it should be called. Capitalisation may also need adjusting? Seems inconsistent when compared to the rest of the options.

First contribution, keeping this one minor as I get more comfortable with the codebase. I know it's mentioned in the contributing file and as silly it is to say for such a small change, no AI is involved in this.

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
