### PR TITLE
Disabled CLIENTSIDE ACS scripts

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -659,9 +659,11 @@ static bool ShouldIgnoreClientSideScript(AActor* activator)
 	return !owner->Level->isConsolePlayer(owner);
 }
 
+// TODO: Disabled until a new flag can be created for UZDoom's specific type of
+// client-side handling. It was breaking too many existing CLIENTSIDE scripts.
 static bool IsClientSideScript(const ScriptPtr& script)
 {
-	return (script.Flags & SCRIPTF_ClientSide);
+	return false;
 }
 
 class DLevelScript : public DObject

--- a/src/playsim/p_acs.h
+++ b/src/playsim/p_acs.h
@@ -328,9 +328,9 @@ enum
 // Script flags
 enum
 {
-	SCRIPTF_Net = 0x0001,		 // Safe to "puke" in multiplayer
-	SCRIPTF_ClientSide = 0x0002, // Executed locally for clients but not across them
-	SCRIPTF_Busy = 0x0004,		 // [TDRR] Not affected by the runaway script limit
+	SCRIPTF_Net = 0x0001,		// Safe to "puke" in multiplayer
+	SCRIPTF_Ignored = 0x0002,	// This flag has no meaning in ZDoom
+	SCRIPTF_Busy = 0x0004,		// [TDRR] Not affected by the runaway script limit
 };
 
 enum ACSFormat { ACS_Old, ACS_Enhanced, ACS_LittleEnhanced, ACS_Unknown };


### PR DESCRIPTION
Revert these back to being read as server scripts. This was breaking too many existing scripts and a new keyword will be needed for UZDoom's unique handling.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
