### PR TITLE
Fixed blank (no items) Options menu causing VM abort on key press

### DIFF
--- a/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/optionmenu.zs
@@ -741,11 +741,11 @@ class OptionMenu : Menu
 		switch (mkey)
 		{
 		case MKEY_Up:
-			MenuMoveCursor(-1);
+			if (mDesc.mItems.Size() > 0) MenuMoveCursor(-1);
 			break;
 
 		case MKEY_Down:
-			MenuMoveCursor(1);
+			if (mDesc.mItems.Size() > 0) MenuMoveCursor(1);
 			break;
 
 		case MKEY_PageUp:
@@ -759,17 +759,17 @@ class OptionMenu : Menu
 		case MKEY_Home:
 			MenuScrollViewport(-mDesc.mItems.Size(), true);
 			mDesc.mSelectedItem = -1;
-			MenuMoveCursor(1);
+			if (mDesc.mItems.Size() > 0) MenuMoveCursor(1);
 			break;
 
 		case MKEY_End:
 			MenuScrollViewport(mDesc.mItems.Size(), true);
 			mDesc.mSelectedItem = -1;
-			MenuMoveCursor(-1);
+			if (mDesc.mItems.Size() > 0) MenuMoveCursor(-1);
 			break;
 
 		case MKEY_Enter:
-			if (mDesc.mSelectedItem >= 0 && mDesc.mItems[mDesc.mSelectedItem].Activate())
+			if (mDesc.mSelectedItem >= 0 && mDesc.mItems.Size() > 0 && mDesc.mItems[mDesc.mSelectedItem].Activate())
 			{
 				return true;
 			}
@@ -778,7 +778,7 @@ class OptionMenu : Menu
 				// fall through to default
 			}
 		default:
-			if (mDesc.mSelectedItem >= 0 &&
+			if (mDesc.mSelectedItem >= 0 && mDesc.mItems.Size() > 0 &&
 				mDesc.mItems[mDesc.mSelectedItem].MenuEvent(mkey, fromcontroller)) return true;
 			return Super.MenuEvent(mkey, fromcontroller);
 		}


### PR DESCRIPTION
Fixed blank (no items) Options menu causing VM abort if Enter, Esc, Home, PgUp, or PgDn keys are pressed.

Probably no one will run into this unless they make a zero element "help screen" menu for their mod.

Closes #690 

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
