### PR TITLE
fix uninitialized field in ParseVersion

### DIFF
--- a/src/common/scripting/frontend/zcc_parser.cpp
+++ b/src/common/scripting/frontend/zcc_parser.cpp
@@ -445,6 +445,9 @@ PNamespace *ParseOneScript(const int baselump, ZCCParseState &state)
 		{
 			char *endp;
 			sc.MustGetString();
+
+			state.ParseVersion.distance = 0;
+
 			state.ParseVersion.major = (int16_t)clamp<unsigned long long>(strtoull(sc.String, &endp, 10), 0, USHRT_MAX);
 			if (*endp != '.')
 			{

--- a/wadsrc/static/zscript.txt
+++ b/wadsrc/static/zscript.txt
@@ -1,4 +1,4 @@
-version "4.15.1"
+version "5.0.0"
 
 // Generic engine code
 #include "zscript/engine/base.zs"


### PR DESCRIPTION
(also bump uzdoom.pk3's zscript version to 5.0 instead of 4.15.1)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
