### PR TITLE
Fix cache invalidation issue

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -259,7 +259,7 @@ jobs:
         BUILD_TYPE: ${{ inputs.build_type }}
         BUILD_OPTS: ${{ inputs.build_opts }}
       run: |
-        config () { cmake -B build -S . -DPK3_QUIET_ZIPDIR=ON -G Ninja -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS ; }
+        config () { cmake -B build -S . -G Ninja -DPK3_QUIET_ZIPDIR=ON -DUSE_PCH=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE $BUILD_OPTS ; }
         build () { cmake --build build --config $BUILD_TYPE ; }
 
         if [[ "$CACHED" == "okay" ]] ; then

--- a/libraries/ZWidget/include/zwidget/core/colorf.h
+++ b/libraries/ZWidget/include/zwidget/core/colorf.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
-#include <cmath>
 
 class Colorf
 {

--- a/libraries/ZWidget/src/core/canvas.cpp
+++ b/libraries/ZWidget/src/core/canvas.cpp
@@ -8,10 +8,13 @@
 #include "core/truetypefont.h"
 #include "core/pathfill.h"
 #include "window/window.h"
-#include <vector>
-#include <unordered_map>
-#include <stdexcept>
+
+#include <algorithm>
+#include <cmath>
 #include <cstring>
+#include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 #if defined(__SSE2__) || defined(_M_X64)
 #include <immintrin.h>

--- a/libraries/ZWidget/src/widgets/lineedit/lineedit.cpp
+++ b/libraries/ZWidget/src/widgets/lineedit/lineedit.cpp
@@ -2,7 +2,9 @@
 #include "widgets/lineedit/lineedit.h"
 #include "core/utf8reader.h"
 #include "core/colorf.h"
+
 #include <algorithm>
+#include <cmath>
 
 LineEdit::LineEdit(Widget* parent) : Widget(parent)
 {

--- a/libraries/ZWidget/src/widgets/listview/listview.cpp
+++ b/libraries/ZWidget/src/widgets/listview/listview.cpp
@@ -1,6 +1,8 @@
 #include "widgets/listview/listview.h"
 #include "widgets/scrollbar/scrollbar.h"
 
+#include <cmath>
+
 ListView::ListView(Widget* parent) : Widget(parent)
 {
 	SetStyleClass("listview");

--- a/libraries/ZWidget/src/widgets/textedit/textedit.cpp
+++ b/libraries/ZWidget/src/widgets/textedit/textedit.cpp
@@ -3,7 +3,9 @@
 #include "widgets/scrollbar/scrollbar.h"
 #include "core/utf8reader.h"
 #include "core/colorf.h"
+
 #include <algorithm>
+#include <cmath>
 
 #ifdef _MSC_VER
 #pragma warning(disable: 4267) // warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1321,7 +1321,10 @@ add_executable( zdoom WIN32 MACOSX_BUNDLE ${GAME_SOURCES} )
 
 target_include_directories( zdoom PRIVATE ${CMAKE_BINARY_DIR} )
 
-target_precompile_headers( zdoom PRIVATE g_pch.h )
+option(USE_PCH "Enable Pre-compiled headers" ON)
+if (USE_PCH)
+	target_precompile_headers( zdoom PRIVATE g_pch.h )
+endif()
 
 set_source_files_properties( ${FASTMATH_SOURCES} PROPERTIES COMPILE_FLAGS ${ZD_FASTMATH_FLAG} )
 set_source_files_properties( xlat/parse_xlat.cpp PROPERTIES OBJECT_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xlat_parser.c" )
@@ -1338,6 +1341,7 @@ if (ENABLE_IWYU)
 			CXX_INCLUDE_WHAT_YOU_USE "${IWYU}"
 			"-Xiwyu" "--mapping_file=${CMAKE_SOURCE_DIR}/tools/iwyu.imp"
 		)
+		set_source_files_properties(utility/name.cpp PROPERTIES SKIP_LINTING ON)
 	else()
 		message(WARNING "IWYU not found.")
 	endif()

--- a/src/common/scripting/dap/IdMap.h
+++ b/src/common/scripting/dap/IdMap.h
@@ -21,8 +21,10 @@
 */
 
 #pragma once
+
 #include "IdProvider.h"
 
+#include <memory>
 #include <unordered_map>
 
 namespace DebugServer

--- a/src/common/scripting/dap/Utilities.h
+++ b/src/common/scripting/dap/Utilities.h
@@ -30,6 +30,7 @@
 #include <dap/protocol.h>
 
 #include "printf.h"
+#include "tarray.h"
 
 namespace DebugServer
 {

--- a/src/common/utility/vga2ansi.cpp
+++ b/src/common/utility/vga2ansi.cpp
@@ -21,10 +21,11 @@
 **
 */
 
-#include <stdio.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <stdlib.h>
+#include <cstdbool>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #ifdef _WIN32
 // windows platform code uses special stdout handling, let's make sure to use that

--- a/src/utility/colorspace.cpp
+++ b/src/utility/colorspace.cpp
@@ -15,6 +15,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <cstring>
 
 #include "basics.h"
 #include "colorspace.h"
@@ -121,8 +122,8 @@ void oklch2oklab(Color& lch)
 {
 	CONVERT(lch, OKLCH, OKLAB);
 	auto c = lch.lch.c, h = lch.lch.h;
-	lch.lab.a = isnan(h) ? 0 : c * cos(h * N_PI / N_180);
-	lch.lab.b = isnan(h) ? 0 : c * sin(h * N_PI / N_180);
+	lch.lab.a = std::isnan(h) ? 0 : c * cos(h * N_PI / N_180);
+	lch.lab.b = std::isnan(h) ? 0 : c * sin(h * N_PI / N_180);
 }
 
 Color oklab(ColorP L, ColorP a, ColorP b)
@@ -177,8 +178,8 @@ void oklab2oklch(Color& lab)
 }
 
 inline ColorP alerp(ColorP a, ColorP b, float t) {
-	if (isnan(a)) return isnan(b)? 0: b;
-	if (isnan(b)) return isnan(a)? 0: a;
+	if (std::isnan(a)) return std::isnan(b)? 0: b;
+	if (std::isnan(b)) return std::isnan(a)? 0: a;
 	ColorP delta = fmod(b - a, N_360);
 	if (delta > N_180) delta -= N_360;
 	if (delta < -N_180) delta += N_360;

--- a/src/utility/name.cpp
+++ b/src/utility/name.cpp
@@ -21,6 +21,10 @@
 **
 */
 
+// NOTE: This file has all linting disabled through cmake.
+//       This is due to IWYU segfaulting when it encounters this file.
+//       It's less than ideal, but it's the only solution I have right now.
+
 #include <cstdint>
 #include <string.h>
 #include <string_view>

--- a/src/utility/system_theme.cpp
+++ b/src/utility/system_theme.cpp
@@ -23,6 +23,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <memory>
 #ifdef _WIN32
 #include <windows.h>
 #elif defined(__linux__)

--- a/src/widgets/updatebuttonbar.cpp
+++ b/src/widgets/updatebuttonbar.cpp
@@ -42,6 +42,7 @@
 #include <filesystem>
 #include "filesystem.h"
 #include "cmdlib.h"
+#include "zstring.h"
 #ifdef _WIN32
 	#include <shellapi.h>
 #endif
@@ -705,7 +706,7 @@ bool UpdateButtonBar::OnMouseUp(const Point& pos, InputKey key)
 	return false;
 }
 
-double UpdateButtonBar::GetPreferredHeight() const
+double UpdateButtonBar::GetPreferredHeight()
 {
 	return bar_height;
 }

--- a/src/widgets/updatebuttonbar.h
+++ b/src/widgets/updatebuttonbar.h
@@ -20,6 +20,7 @@
 
 #include "basics.h"
 #include "version.h"
+#include "zstring.h"
 
 class LauncherWindow;
 class PushButton;
@@ -41,7 +42,7 @@ class UpdateButtonBar : public Widget
 		UpdateButtonBar(LauncherWindow *parent);
 		void UpdateLanguage();
 
-		double GetPreferredHeight() const;
+		double GetPreferredHeight() override;
 
 		void CheckForUpdate(bool force = false);
 


### PR DESCRIPTION
PCH is casing cache issues on the windows runner. Since the overall speed of ci is dependant on the slowest build, the cache is basically pointless when windows decides to act up.

Disabling PCH only slightly increases build time, but the cache more than makes up for this.

Initially I tried having some builds keep it enabled, instead not caching the pch files. [msvc is too dumb to regenerate them when they're missing](https://github.com/the-phinet/UZDoom/actions/runs/27758042508/job/82124819329#step:12:167).

Disabling PCH uncovered some build errors, so those needed correcting. It also has the side-effect of making IWYU work properly, which is nice.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
