### PR TITLE
Prevent rendering internal sidewalls of 3DFloors below sector-portal floors

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -2075,6 +2075,9 @@ void HWWall::DoFFloorBlocks(HWWallDispatcher *di, seg_t * seg, sector_t * fronts
 		GetPlanePos(&rover->top, ff_topleft, ff_topright);
 		GetPlanePos(&rover->bottom, ff_bottomleft, ff_bottomright);
 
+		// completely below floor
+		if (ff_topleft < bottomleft && ff_topright < bottomright) continue;
+
 		// completely above ceiling
 		if (ff_bottomleft > topleft && ff_bottomright > topright && !renderedsomething) continue;
 


### PR DESCRIPTION
Prevent internal sidewalls of 3D-floors from being rendered when they are below a stacked-sector-portal floor and viewed from above it.

Closes #1284 

Simple test map that reproduces the rendering bug (simply look down into the sector portal from above): 
[supplice_renderbugtest.wad.zip](https://github.com/user-attachments/files/29151602/supplice_renderbugtest.wad.zip)

Note that there is a different rendering bug if you view the same 3d-floor from the bottom floor. You will even physically collide with it. I know how to fix it, but it will be a slightly bigger PR, since I'd like to handle sloped flats and sloped 3d floors as well. Supplice won't run into that bug since they define the same 3D floor sector on both sides of the portal.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
