### PR TITLE
Add the Suffix to the message itsself to prevent breakage

### DIFF
--- a/src/console/c_notifybuffer.cpp
+++ b/src/console/c_notifybuffer.cpp
@@ -115,6 +115,12 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 		countedIdentical = 1;
 	}
 
+    // Make the suffix directly a part ofthe message string
+    if (countedIdentical > 1)
+    {
+        source.AppendFormat(" (x%d)", countedIdentical);
+    }
+
 
 	// [MK] allow the status bar to take over notify printing
 	if (StatusBar != nullptr)
@@ -169,36 +175,17 @@ void FNotifyBuffer::Draw()
 				color = PrintColors[notify.PrintLevel];
 
 			int scale = active_con_scaletext(twod, generic_ui);
-			FString suffix      = "";
-			int     suffixWidth = 0;
+			int textWidth = font->StringWidth(notify.Text);
+			int xPos = 0;
 
-			if (con_stackident && i == Text.Size() - 1 && countedIdentical > 1)
-			{
-				suffix.Format(" (x%d)", countedIdentical);
-				suffixWidth = font->StringWidth(suffix);
-			}
+            if (center)
+            {
+				xPos = (twod->GetWidth() / scale - textWidth) / 2;
+            }
 
-			int textWidth  = font->StringWidth(notify.Text);
-			int totalWidth = textWidth + suffixWidth;
-			int xPos       = 0;
-
-			if (center)
-			{
-				// Calculate center of text + suffix
-				xPos = (twod->GetWidth() / scale - totalWidth) / 2;
-			}
-
-			// Draw the main text
-			DrawText(twod, font, color, xPos, line, notify.Text.GetChars(), DTA_VirtualWidth, twod->GetWidth() / scale,
-			         DTA_VirtualHeight, twod->GetHeight() / scale, DTA_KeepRatio, true, DTA_Alpha, alpha, TAG_DONE);
-
-			// Draw the suffix if it exists
-			if (suffixWidth > 0)
-			{
-				DrawText(twod, font, color, xPos + textWidth, line, suffix.GetChars(), DTA_VirtualWidth,
-				         twod->GetWidth() / scale, DTA_VirtualHeight, twod->GetHeight() / scale, DTA_KeepRatio, true,
-				         DTA_Alpha, alpha, TAG_DONE);
-			}
+            // Draw the main text
+            DrawText(twod, font, color, xPos, line, notify.Text.GetChars(), DTA_VirtualWidth, twod->GetWidth() / scale,
+                     DTA_VirtualHeight, twod->GetHeight() / scale, DTA_KeepRatio, true, DTA_Alpha, alpha, TAG_DONE);
 
 			line += lineadv;
 			canskip = false;

--- a/src/console/c_notifybuffer.cpp
+++ b/src/console/c_notifybuffer.cpp
@@ -29,6 +29,7 @@
 #include "i_time.h"
 #include "printf.h"
 #include "sbar.h"
+#include "gstrings.h"
 #include "v_video.h"
 #include "vm.h"
 
@@ -119,8 +120,10 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
     // insert the suffix directly as part ofthe message string 
     if (countedIdentical > 1)
     {
-        source.AppendFormat(" (x%d)", countedIdentical);
-    }
+		source += " (";
+		source.AppendFormat(GStrings.GetString("VALFORMAT_MULTIPLIER"), std::to_string(countedIdentical).c_str());
+		source += ")";
+	}
 	source += '\n';
 
 	// [MK] allow the status bar to take over notify printing

--- a/src/console/c_notifybuffer.cpp
+++ b/src/console/c_notifybuffer.cpp
@@ -115,12 +115,13 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 		countedIdentical = 1;
 	}
 
-    // Make the suffix directly a part ofthe message string
+	source.StripRight();
+    // insert the suffix directly as part ofthe message string 
     if (countedIdentical > 1)
     {
         source.AppendFormat(" (x%d)", countedIdentical);
     }
-
+	source += '\n';
 
 	// [MK] allow the status bar to take over notify printing
 	if (StatusBar != nullptr)


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

While testing the notification system in combination with the recently added Fadeout option, I realized that there is a bug in the message stacking. When the message is pushed up in the queue, it loses its suffix. This PR fixes that by tying the suffix to the message itsself rather than appending it dynamically, thus staying together when pushed up.

Before:
<img width="461" height="162" alt="grafik" src="https://github.com/user-attachments/assets/a48921ba-7bc4-45e6-98f2-430ae9730b86" />

After:
<img width="523" height="138" alt="grafik" src="https://github.com/user-attachments/assets/dc54a17e-6593-44cc-8634-511390434c83" />


