### PR TITLE
Fix runaway counter not being incremented on BUSY scripts.

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -7037,7 +7037,7 @@ int DLevelScript::RunScript()
 
 	while (state == SCRIPT_Running)
 	{
-		if ( ptr && !(ptr->Flags & SCRIPTF_Busy) && (++runaway > 2000000) )
+		if ( (++runaway > 2000000) && ptr && !(ptr->Flags & SCRIPTF_Busy) )
 		{
 			Printf ("Runaway %s terminated\n", ScriptPresentation(script).GetChars());
 			state = SCRIPT_PleaseRemove;


### PR DESCRIPTION
Fixes the `acsprofile` CCMD not properly reporting the script's stats.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.