### PR TITLE
Fix nombf21 2 electric boogaloo

### DIFF
--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -233,12 +233,13 @@ enum ELevelCompatFlag2 : uint32_t
 	COMPATF2_SCRIPTWAIT		= 1 << 11,	// Use old scriptwait implementation where it doesn't wait on a non-running script.
 	COMPATF2_AVOID_HAZARDS	= 1 << 12,	// another MBF thing.
 	COMPATF2_STAYONLIFT		= 1 << 13,	// yet another MBF thing.
-	COMPATF2_RESERVEDLINEFLAG		= 1 << 14,	// disable certain linedef flag features that may clash with certain maps
+	COMPATF2_NOMBF21		= 1 << 14,	// Unused. Kept for backwards compatibility.
 	COMPATF2_VOODOO_ZOMBIES = 1 << 15,	// [RL0] allow playerinfo, playerpawn, and voodoo health to all be different, and skip killing the player's mobj if a voodoo doll dies to allow voodoo zombies
 	COMPATF2_FDTELEPORT		= 1 << 16,	// Emulate Final Doom's teleporter z glitch.
 	COMPATF2_NOACSARGCHECK	= 1 << 17,	// Disable arg count checking for ACS
 	COMPATF2_NOVDOLLLOCKMSG = 1 << 18,	// Voodoo dolls no longer trigger lock messages
 	COMPATF2_EMULATEMIKOPORTALS = 1 << 19, // Emulate Mikoportals Z Underflow
+	COMPATF2_RESERVEDLINEFLAG	= 1 << 20, // disable certain linedef flag features that may clash with certain maps
 };
 using ELevelCompatFlags2 = TFlags<ELevelCompatFlag2>;
 DEFINE_TFLAGS_OPERATORS(ELevelCompatFlags2)

--- a/src/gamedata/p_xlat.cpp
+++ b/src/gamedata/p_xlat.cpp
@@ -96,7 +96,7 @@ void FLevelLocals::TranslateLineDef (line_t *ld, maplinedef_t *mld, int lineinde
 	if (i_compatflags2 & COMPATF2_RESERVEDLINEFLAG && maptype == MAPTYPE_DOOM && newflags2 & ML2_RESERVEDLINEFLAG)
 	{
 		flags &= (ML_BLOCKING|ML_BLOCKMONSTERS|ML_TWOSIDED|ML_DONTPEGTOP|ML_DONTPEGBOTTOM|ML_SECRET|ML_SOUNDBLOCK|ML_DONTDRAW|ML_MAPPED);
-		newflags2 = 0;
+		ld->flags2 = 0;
 	}
 
 	if (lineindexforid >= 0)

--- a/wadsrc/static/zscript/constants.zs
+++ b/wadsrc/static/zscript/constants.zs
@@ -1504,8 +1504,13 @@ enum ECompatFlags
 	COMPATF2_SCRIPTWAIT		= 1 << 11,	// Use old scriptwait implementation where it doesn't wait on a non-running script.
 	COMPATF2_AVOID_HAZARDS	= 1 << 12,	// another MBF thing.
 	COMPATF2_STAYONLIFT		= 1 << 13,	// yet another MBF thing.
-	COMPATF2_RESERVEDLINEFLAG		= 1 << 14,	// disable certain linedef flag features that may clash with certain maps
+	COMPATF2_NOMBF21		= 1 << 14,	// Unused. Kept for backwards compatibility.
 	COMPATF2_VOODOO_ZOMBIES = 1 << 15,  // allow playerinfo, playerpawn, and voodoo health to all be different, and allow monster targetting of 'dead' players that have positive health
+	COMPATF2_FDTELEPORT		= 1 << 16,	// Emulate Final Doom's teleporter z glitch.
+	COMPATF2_NOACSARGCHECK	= 1 << 17,	// Disable arg count checking for ACS
+	COMPATF2_NOVDOLLLOCKMSG = 1 << 18,	// Voodoo dolls no longer trigger lock messages
+	COMPATF2_EMULATEMIKOPORTALS = 1 << 19, // Emulate Mikoportals Z Underflow
+	COMPATF2_RESERVEDLINEFLAG	= 1 << 20,	// disable certain linedef flag features that may clash with certain maps
 };
 
 enum HitWaterFlags


### PR DESCRIPTION
Restored the ZScript `NOMBF21` compatflag to prevent existing mods from erroring at launch. Adds remaining `COMPATF2` flags to ZScripts. Fixes a minor oversight in the line flag translation step from the previous `NOMBF21` PR.

Fixes #1511

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
