### PR TITLE
Account for equal 3d-floor top and secport floor heights rendering 3dfloor internal walls

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_walls.cpp
+++ b/src/rendering/hwrenderer/scene/hw_walls.cpp
@@ -2076,7 +2076,7 @@ void HWWall::DoFFloorBlocks(HWWallDispatcher *di, seg_t * seg, sector_t * fronts
 		GetPlanePos(&rover->bottom, ff_bottomleft, ff_bottomright);
 
 		// completely below floor
-		if (ff_topleft < bottomleft && ff_topright < bottomright) continue;
+		if (ff_topleft <= bottomleft && ff_topright <= bottomright) continue;
 
 		// completely above ceiling
 		if (ff_bottomleft > topleft && ff_bottomright > topright && !renderedsomething) continue;


### PR DESCRIPTION
Forgot to account for when top height of 3d floor is EQUAL to floor height of a sector portal, which was still rendering its internal walls.

Minor update to PR 1496.

Example wad: 
[bugexample.wad.zip](https://github.com/user-attachments/files/29275972/bugexample.wad.zip)


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
