### PR TITLE
Disable automap sector fill by default

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -290,7 +290,7 @@ CVAR (Color, am_thingcolor_ncmonster,	0xfcfcfc,	CVAR_ARCHIVE);
 CVAR (Color, am_thingcolor_item,	0xfcfcfc,	CVAR_ARCHIVE);
 CVAR (Color, am_thingcolor_citem,	0xfcfcfc,	CVAR_ARCHIVE);
 CVAR (Color, am_sectorfillcolor,	0x4e3621,	CVAR_ARCHIVE);
-CVAR (Float, am_sectorfillalpha,	0.4f,		CVAR_ARCHIVE);
+CVAR (Float, am_sectorfillalpha,	0.0f,		CVAR_ARCHIVE);
 CVAR (Color, am_portalcolor,		0x404040,	CVAR_ARCHIVE);
 
 CVAR (Color, am_ovyourcolor,		0xfce8d8,	CVAR_ARCHIVE);
@@ -314,7 +314,7 @@ CVAR (Color, am_ovthingcolor_ncmonster,	0xe88800,	CVAR_ARCHIVE);
 CVAR (Color, am_ovthingcolor_item,		0xe88800,	CVAR_ARCHIVE);
 CVAR (Color, am_ovthingcolor_citem,		0xe88800,	CVAR_ARCHIVE);
 CVAR (Color, am_ovsectorfillcolor,		0x000000,	CVAR_ARCHIVE);
-CVAR (Float, am_ovsectorfillalpha,		0.2f,		CVAR_ARCHIVE);
+CVAR (Float, am_ovsectorfillalpha,		0.0f,		CVAR_ARCHIVE);
 CVAR (Color, am_ovportalcolor,			0x004022,	CVAR_ARCHIVE);
 
 //=============================================================================


### PR DESCRIPTION
The new SectorFillColor feature works great, but having it enabled by default has some unintended consequences for map designers. eg., revealing non-secret sectors that have their linedefs hidden, or accidentally revealing map boundaries that were hidden.

These effects are also present on the textured automap, but that option isn't enabled by default. In that case, you need to dig into the options menu to get a different automap presentation than the map designer may have expected, rather than having it enabled out of the box.

This PR changes the default values of am_sectorfillalpha and am_ovsectorfillalpha to 0.0. I was going to submit this as an issue first, but after raising it on the UZDoom Discord, it sounds like this is a reasonable no-fuss change that can be submitted as a PR instead. Tested working with no issues.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
