### PR TITLE
Properly orient sprite canvas textures when drawing them

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1072,7 +1072,7 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 			return;
 
 		// Canvas textures are stored upside down
-		if (texture && texture->isHardwareCanvas()) std::swap(vt, vb);
+		if (!isPicnumOverride && texture && texture->isHardwareCanvas()) std::swap(vt, vb);
 
 		if (thing->renderflags & RF_SPRITEFLIP) // [SP] Flip back
 			thing->renderflags ^= RF_XFLIP;

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -1071,6 +1071,9 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		if (!texture || !texture->isValid())
 			return;
 
+		// Canvas textures are stored upside down
+		if (texture && texture->isHardwareCanvas()) std::swap(vt, vb);
+
 		if (thing->renderflags & RF_SPRITEFLIP) // [SP] Flip back
 			thing->renderflags ^= RF_XFLIP;
 

--- a/src/rendering/hwrenderer/scene/hw_weapon.cpp
+++ b/src/rendering/hwrenderer/scene/hw_weapon.cpp
@@ -536,6 +536,10 @@ bool HUDSprite::GetWeaponRect(HWDrawInfo *di, DPSprite *psp, float sx, float sy,
 	// handled here by multiplying SCREENWIDTH by 200 instead of
 	// 240, but now the baseScale var defines this from now on.
 	scale = psp->baseScale.Y * (SCREENHEIGHT*vw) / (SCREENWIDTH * 240.0f);
+
+	// Canvas textures are stored upside down
+	if (tex && tex->isHardwareCanvas()) scale *= -1;
+
 	y1 = viewwindowy + vh / 2 - (ftexturemid * scale);
 	y2 = y1 + (r.height * scale) + 1;
 


### PR DESCRIPTION
- Flip sprites and weapon sprites vertically if they are canvas textures.

This matches the handling of textures and flats, where the engine vertically flips the contents of any hardware canvases before rendering them.

The lack of handling for this case led to automap sprites being flipped vertically from their in-game counterparts.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
