### PR TITLE
Add actor render flag to set an actor's sprite's normal

### DIFF
--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -505,6 +505,7 @@ enum ActorRenderFlag2
 	RF2_INTERPOLATESCALE		= 0x1000,
 	RF2_INTERPOLATEALPHA		= 0x2000,
 	RF2_NODYNAMICLIGHTING		= 0x4000,	// [MC] Disable dynamic lighting effects on sprites/models
+	RF2_SETSPRITENORMAL			= 0x8000,	// [AFA] Set the sprite's normal and allow individual dynamic lights to affect sprites
 };
 
 // This translucency value produces the closest match to Heretic's TINTTAB.

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -272,9 +272,6 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 
 		if (!modelframe)
 		{
-			state.SetNormal(0, 0, 0);
-
-
 			if (screen->BuffersArePersistent())
 			{
 				CreateVertices(di);
@@ -283,7 +280,20 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			{
 				state.SetDepthBias(-1, -128);
 			}
-			state.SetLightIndex(-1);
+
+			if (actor && (actor->renderflags2 & RF2_SETSPRITENORMAL))
+			{
+				auto actorpos = actor->InterpolatedPosition(vp.TicFrac);
+				auto diff = (actorpos - vp.Pos).Angle().ToVector();
+			    state.SetNormal(-diff.X, 0, -diff.Y);
+				state.SetLightIndex(dynlightindex);
+			}
+			else
+			{
+				state.SetNormal(0, 0, 0);
+				state.SetLightIndex(-1);
+			}
+
 			state.Draw(DT_TriangleStrip, vertexindex, 4);
 
 			if (foglayer)
@@ -597,7 +607,8 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 inline void HWSprite::PutSprite(HWDrawInfo *di, bool translucent)
 {
 	// That's a lot of checks...
-	if (modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING) && RenderStyle.BlendOp != STYLEOP_Shadow
+	if (((modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING)) ||
+		(actor && (actor->renderflags2 & RF2_SETSPRITENORMAL))) && RenderStyle.BlendOp != STYLEOP_Shadow
 		&& gl_light_sprites && di->Level->HasDynamicLights && !di->isFullbrightScene() && !fullbright
 		&& actor && !(actor->renderflags2 & RF2_NODYNAMICLIGHTING))
 	{

--- a/src/scripting/thingdef_data.cpp
+++ b/src/scripting/thingdef_data.cpp
@@ -380,6 +380,7 @@ static FFlagDef ActorFlagDefs[]=
 	DEFINE_FLAG(RF2, INTERPOLATESCALE, AActor, renderflags2),
 	DEFINE_FLAG(RF2, INTERPOLATEALPHA, AActor, renderflags2),
 	DEFINE_FLAG(RF2, NODYNAMICLIGHTING, AActor, renderflags2),
+	DEFINE_FLAG(RF2, SETSPRITENORMAL, AActor, renderflags2),
 
 	// Bounce flags
 	DEFINE_FLAG2(BOUNCE_Walls, BOUNCEONWALLS, AActor, BounceFlags),


### PR DESCRIPTION
Added the +SETSPRITENORMAL flag for actors.

- This flag triggers the engine to set the normal of each rendered sprite for that actor to the vector facing toward the current viewpoint.

- With this flag set, dynamic lights can individually affect the actor's sprite (with no shader-side changes necessary), and you can have 'back-lit' sprite actors who are silhouetted against a dynamic light.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
