### PR TITLE
Add `nosave` and `noautoautosave` to MAPINFO.

### DIFF
--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -685,12 +685,15 @@ CVAR (Flag, sv_cooplosepowerups,	dmflags, DF_COOP_LOSE_POWERUPS);
 CVAR (Flag, sv_cooploseammo,	dmflags, DF_COOP_LOSE_AMMO);
 CVAR (Flag, sv_coophalveammo,	dmflags, DF_COOP_HALVE_AMMO);
 CVAR (Flag, sv_instantreaction,	dmflags, DF_INSTANT_REACTION);
+CVAR (Flag, sv_nosave,			dmflags3, DF3_NO_SAVE);
+CVAR (Flag, sv_allowsave,		dmflags3, DF3_YES_SAVE);
 
 // Some (hopefully cleaner) interface to these settings.
 CVAR (Mask, sv_crouch,			dmflags, DF_NO_CROUCH|DF_YES_CROUCH);
 CVAR (Mask, sv_jump,			dmflags, DF_NO_JUMP|DF_YES_JUMP);
 CVAR (Mask, sv_fallingdamage,	dmflags, DF_FORCE_FALLINGHX|DF_FORCE_FALLINGZD);
 CVAR (Mask, sv_freelook,		dmflags, DF_NO_FREELOOK|DF_YES_FREELOOK);
+CVAR (Mask, sv_save,			dmflags3, DF3_NO_SAVE|DF3_YES_SAVE);
 
 //==========================================================================
 //

--- a/src/doomdef.h
+++ b/src/doomdef.h
@@ -176,6 +176,8 @@ enum : unsigned
 	DF3_NO_COOP_ONLY_THINGS	= 1 << 5,	// Any Actor that only appears in co-op is disabled
 	DF3_REMEMBER_LAST_WEAP	= 1 << 6,	// When respawning in co-op, keep the last used weapon out instead of switching to the best new one.
 	DF3_PISTOL_START		= 1 << 7,	// Take player inventory when exiting to the next level.
+	DF3_NO_SAVE				= 1 << 8,	// Don't allow manual saving
+	DF3_YES_SAVE			= 1 << 9,	// Allow manual saving
 };
 
 // [RH] Compatibility flags.

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2416,7 +2416,7 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 
 	if (!(primaryLevel->IsSavingAllowed () || saveFromScript))
 	{
-		Printf (PRINT_HIGH, "Saving is not allowed.\n");
+		Printf (PRINT_HIGH, "%s\n", GStrings.GetString("TXT_CANNOTSAVE"));
 		return;
 	}
 	

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -119,7 +119,7 @@ void G_PlayerReborn (int player);
 
 void G_DoAutoSave ();
 void G_DoPlayDemo (void);
-void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description);
+void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description, bool saveFromScript);
 void G_DoVictory (void);
 
 void SetupLoadingCVars();
@@ -1263,13 +1263,13 @@ void G_Ticker ()
 			G_DoLoadGame ();
 			break;
 		case ga_savegame:
-			G_DoSaveGame (true, false, savegamefile, savedescription.GetChars());
+			G_DoSaveGame (true, false, savegamefile, savedescription.GetChars(), false);
 			gameaction = ga_nothing;
 			savegamefile = "";
 			savedescription = "";
 			break;
 		case ga_quicksave:
-			G_DoSaveGame(true, true, savegamefile, savedescription.GetChars());
+			G_DoSaveGame(true, true, savegamefile, savedescription.GetChars(), false);
 			gameaction = ga_nothing;
 			savegamefile = "";
 			savedescription = "";
@@ -2316,7 +2316,7 @@ void G_DoAutoSave ()
 
 	readableTime = myasctime ();
 	description.Format("Autosave %s", readableTime);
-	G_DoSaveGame (false, false, file, description.GetChars());
+	G_DoSaveGame (false, false, file, description.GetChars(), true);
 }
 
 void G_DoQuickSave ()
@@ -2400,7 +2400,16 @@ static void PutSavePic (FileWriter *file, int width, int height)
 	}
 }
 
-void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description)
+static bool IsSavingAllowed ()
+{
+	if (dmflags3 & DF3_NO_SAVE)
+		return false;
+	if (dmflags3 & DF3_YES_SAVE)
+		return true;
+	return !(level.flags3 & LEVEL3_SAVE_NO);
+}
+
+void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description, bool saveFromScript)
 {
 	TArray<FCompressedBuffer> savegame_content;
 	TArray<FString> savegame_filenames;
@@ -2414,6 +2423,12 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 		return;
 	}
 
+	if (!(IsSavingAllowed () || saveFromScript))
+	{
+		Printf (PRINT_HIGH, "Saving is not allowed.\n");
+		return;
+	}
+	
 	if (demoplayback)
 	{
 		filename = G_BuildSaveName ("demosave");

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -2400,15 +2400,6 @@ static void PutSavePic (FileWriter *file, int width, int height)
 	}
 }
 
-static bool IsSavingAllowed ()
-{
-	if (dmflags3 & DF3_NO_SAVE)
-		return false;
-	if (dmflags3 & DF3_YES_SAVE)
-		return true;
-	return !(level.flags3 & LEVEL3_SAVE_NO);
-}
-
 void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, const char *description, bool saveFromScript)
 {
 	TArray<FCompressedBuffer> savegame_content;
@@ -2423,7 +2414,7 @@ void G_DoSaveGame (bool okForQuicksave, bool forceQuicksave, FString filename, c
 		return;
 	}
 
-	if (!(IsSavingAllowed () || saveFromScript))
+	if (!(primaryLevel->IsSavingAllowed () || saveFromScript))
 	{
 		Printf (PRINT_HIGH, "Saving is not allowed.\n");
 		return;

--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -1539,7 +1539,7 @@ void FLevelLocals::DoLoadLevel(const FString &nextmapname, int position, bool au
 
 
 	// [RH] Always save the game when entering a new
-	if (autosave && !savegamerestore && disableautosave < 1)
+	if (autosave && !savegamerestore && disableautosave < 1 && (flags3 & LEVEL3_AUTOAUTOSAVE_NO) == 0)
 	{
 		CreateThinker<DAutosaver>();
 	}

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -861,6 +861,20 @@ public:
 		return !(flags & LEVEL_FREELOOK_NO);
 	}
 
+	//==========================================================================
+	//
+	//
+	//==========================================================================
+
+	bool IsSavingAllowed() const
+	{
+		if (dmflags3 & DF3_NO_SAVE)
+			return false;
+		if (dmflags3 & DF3_YES_SAVE)
+			return true;
+		return !(flags3 & LEVEL3_SAVE_NO);
+	}
+
 	bool MissileShouldClip() const
 	{
 		return (i_compatflags & COMPATF_MISSILECLIP) ||

--- a/src/g_levellocals.h
+++ b/src/g_levellocals.h
@@ -868,10 +868,10 @@ public:
 
 	bool IsSavingAllowed() const
 	{
-		if (dmflags3 & DF3_NO_SAVE)
-			return false;
 		if (dmflags3 & DF3_YES_SAVE)
 			return true;
+		if (dmflags3 & DF3_NO_SAVE)
+			return false;
 		return !(flags3 & LEVEL3_SAVE_NO);
 	}
 

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -1895,6 +1895,10 @@ MapFlagHandlers[] =
 	{ "nofogofwar",						MITYPE_SETFLAG3,	LEVEL3_NOFOGOFWAR, 0 },
 	{ "useskymist",						MITYPE_SETFLAG3,	LEVEL3_SKYMIST, 0 },
 	{ "noambientocclusion",				MITYPE_SETFLAG3,	LEVEL3_NOAMBIENTOCCLUSION, 0 },
+	{ "allowsave",						MITYPE_CLRFLAG3,    LEVEL3_SAVE_NO, 0},
+	{ "nosave",							MITYPE_SETFLAG3,    LEVEL3_SAVE_NO,	0},
+	{ "allowautoautosave",				MITYPE_CLRFLAG3,    LEVEL3_AUTOAUTOSAVE_NO, 0},
+	{ "noautoautosave",                 MITYPE_SETFLAG3,    LEVEL3_AUTOAUTOSAVE_NO, 0},
 	{ "nobotnodes",						MITYPE_IGNORE,	0, 0 },		// Skulltag option: nobotnodes
 	{ "nopassover",						MITYPE_COMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },
 	{ "passover",						MITYPE_CLRCOMPATFLAG, COMPATF_NO_PASSMOBJ, 0 },

--- a/src/gamedata/g_mapinfo.h
+++ b/src/gamedata/g_mapinfo.h
@@ -260,6 +260,8 @@ enum ELevelFlags : unsigned int
 	LEVEL3_SECRET				= 0x00200000,   // level is a secret level
 	LEVEL3_SKYMIST				= 0x00400000,   // level skyfog uses the skymist texture
 	LEVEL3_NOAMBIENTOCCLUSION	= 0x00800000,   // disables ambient occlusion on this map
+	LEVEL3_SAVE_NO				= 0x01000000,   // disables manual saving on this map
+	LEVEL3_AUTOAUTOSAVE_NO      = 0x02000000,   // disables the automatic autosaves on loading this map
 };
 
 

--- a/src/gamedata/umapinfo.cpp
+++ b/src/gamedata/umapinfo.cpp
@@ -70,6 +70,8 @@ struct UMapEntry
 	PlayerActionOption jumping = PlayerActionOption::UNSET;
 	PlayerActionOption crouching = PlayerActionOption::UNSET;
 	PlayerActionOption freeaim = PlayerActionOption::UNSET;
+	PlayerActionOption saving = PlayerActionOption::UNSET;
+	int noautoautosave = 0;
 };
 
 static TArray<UMapEntry> Maps;
@@ -612,6 +614,20 @@ void CommitUMapinfo(level_info_t *defaultinfo)
 				// noop
 				break;
 		}
+		switch (map.saving)
+		{
+			case PlayerActionOption::ALLOW:
+			case PlayerActionOption::REQUIRE:
+				levelinfo->flags3 &= ~LEVEL3_SAVE_NO;
+				break;
+			case PlayerActionOption::DISALLOW:
+				levelinfo->flags3 |= LEVEL3_SAVE_NO;
+				break;
+			case PlayerActionOption::UNSET:
+				// noop
+				break;
+		}
+		if (map.noautoautosave) levelinfo->flags3 |= LEVEL3_AUTOAUTOSAVE_NO;
 	}
 
 

--- a/src/scripting/vmthunks.cpp
+++ b/src/scripting/vmthunks.cpp
@@ -1739,6 +1739,22 @@ DEFINE_ACTION_FUNCTION_NATIVE(_Sector, SetXOffset, SetXOffset)
  }
 
  //==========================================================================
+ //
+ //
+ //==========================================================================
+
+ static int IsSavingAllowed(FLevelLocals *self)
+ {
+	 return self->IsSavingAllowed();
+ }
+
+ DEFINE_ACTION_FUNCTION_NATIVE(FLevelLocals, IsSavingAllowed, IsSavingAllowed)
+ {
+	 PARAM_SELF_STRUCT_PROLOGUE(FLevelLocals);
+	 ACTION_RETURN_BOOL(self->IsSavingAllowed());
+ }
+
+ //==========================================================================
 //
 // ZScript counterpart to ACS ChangeSky, uses TextureIDs
 //

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2219,6 +2219,7 @@ OptionMenu GameplayOptions protected
 	Option "$GMPLYMNU_ALLOWJUMP",				"sv_jump", "JumpCrouchFreeLook"
 	Option "$GMPLYMNU_ALLOWCROUCH",				"sv_crouch", "JumpCrouchFreeLook"
 	Option "$GMPLYMNU_ALLOWFREELOOK",			"sv_freelook", "JumpCrouchFreeLook"
+	Option "$GMPLYMNU_ALLOWSAVE",			    "sv_save", "JumpCrouchFreeLook"
 	Option "$GMPLYMNU_ALLOWFOV",				"sv_nofov", "NoYes"
 	Option "$GMPLYMNU_BFGFREEAIM",				"sv_nobfgaim", "NoYes"
 	Option "$GMPLYMNU_ALLOWAUTOMAP",			"sv_noautomap", "NoYes"

--- a/wadsrc/static/zscript/doombase.zs
+++ b/wadsrc/static/zscript/doombase.zs
@@ -600,6 +600,7 @@ struct LevelLocals native
 	native bool IsJumpingAllowed() const;
 	native bool IsCrouchingAllowed() const;
 	native bool IsFreelookAllowed() const;
+	native bool IsSavingAllowed() const;
 	native void StartIntermission(Name type, int state) const;
 	native play SpotState GetSpotState(bool create = true);
 	native clearscope int FindUniqueTid(int start = 0, int limit = 0, bool clientSide = false);


### PR DESCRIPTION
A new mechanism was added to control the user's option to manually save the game.
`nosave` setting can be overwritten from the Options.

The change is based on the already existing `nojump`, `nocrouch`, etc.

New MAPINFO flags:
+ `allowsave`  - Allows the user to save the game. (default)
+ `nosave`  - Forbids the user to save the game.
+ `allowautoautosave` - Enables the automatic autosave on loading a map. (default)
+ `noautoautosave` - Disables the automatic autosave on loading a map.

New CVARs:
+ `sv_save 0` - Use MAPINFO setting to determine saving availability. (default)
+ `sv_save 1` - Forbids the user to save the game.
+ `sv_save 2` - Allows the user to save the game.
+ `sv_nosave 1` - Forbids the user to save the game.
+ `sv_allowsave 1` - Allows the user to save the game.

Note: If `sv_nosave` and `sv_allowsave` are both set (invalid state) `sv_allowsave`  will be active.

New `LevelLocals` ZScipt functions:
+ `IsSavingAllowed()` - Determines if the user can save.

New language keys:
+ `GMPLYMNU_ALLOWSAVE` - "Allow saving"
+ `TXT_CANNOTSAVE` - "You cannot save the game."

It is connected to #15.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
