### PR TITLE
Tweaked double click values

### DIFF
--- a/src/common/console/c_bind.cpp
+++ b/src/common/console/c_bind.cpp
@@ -136,7 +136,7 @@ const char *KeyNames[NUM_KEYS] =
 	"Guide",       "Pad_Misc",   "Pad_Touchpad",               //
 };
 
-CVAR(Int, cl_doubleclickthreshold, 250, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Int, cl_doubleclickthreshold, 225, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 FKeyBindings Bindings;
 FKeyBindings DoubleBindings;

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -2934,10 +2934,10 @@ OptionMenu AccessibilityOptions protected
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_EXTRA"
 	Slider "$ACCMNU_LIGHT_RADIUS", "r_visibility", 0.0, 16.0, 1.0, 1
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"
-	Slider "$ACCMNU_DOUBLECLICK_THRESHOLD", "cl_doubleclickthreshold", 100, 1000, 50, 0
-	Tooltip "$ACCMNU_TOOLTIP_DOUBLECLICK_THRESHOLD"
-
+	
 	StaticText ""
+	Slider "$ACCMNU_DOUBLECLICK_THRESHOLD", "cl_doubleclickthreshold", 100, 600, 25, 0
+	Tooltip "$ACCMNU_TOOLTIP_DOUBLECLICK_THRESHOLD"
 	Slider "$DSPLYMNU_QUAKEINTENSITY",         r_quakeintensity,       0.0, 1.0, 0.05, 0, "", 0, Gray, 100, "$VALFORMAT_PERCENT"
 
 	StaticText ""


### PR DESCRIPTION
Currently the default time window for double tap binds is 250ms. While this is fine for the double tap execution, it means the single tap command on it must wait at least this long before it can also execute. To try and help alleviate this gap, I did some testing to find a better balance and landed on around 225ms. While this can go lower, it depends on the level of deliberateness we want to enforce as I found values lower than 200ms to be noticeably intense. As a reminder, an accessibility option is included to fine tune this manually, this is just to get the most "useful" default out of the box.

Also included are some tweaks to the menu ranges with the max being reduced reduced to a more reasonable 600ms (the original value before the rework was a bit over 500ms), though this can easily be changed back if desired. I found increments of 25ms instead of 50ms to give better control when adjusting via keyboard as 50ms can be too large at times.

There's likely ways this can be improved to more dynamically tell what a player wants to do, but seeing as 5.0 is the first time this feature is being exposed proper, that can wait until later. In general I'd like to expand input functionality to also allow things like hold binds and possibly bringing back the old hidden double tap system.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
