### PR TITLE
Fix line portals and line mirrors getting plane-clipped at z of 0 inside flat reflections

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -144,6 +144,7 @@ void HWDrawInfo::StartScene(FRenderViewpoint &parentvp, HWViewpointUniforms *uni
 		// The clip planes will never be inherited from the parent drawinfo.
 		VPUniforms.mClipLine.X = -1000001.f;
 		VPUniforms.mClipHeight = 0;
+		VPUniforms.mClipHeightDirection = 0.f;
 	}
 	else
 	{

--- a/src/rendering/hwrenderer/scene/hw_drawinfo.h
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.h
@@ -250,6 +250,7 @@ public:
 	{
 		VPUniforms.mClipLine = { (float)line->v1->fX(), (float)line->v1->fY(), (float)line->Delta().X, (float)line->Delta().Y };
 		VPUniforms.mClipHeight = 0;
+		VPUniforms.mClipHeightDirection = 0.f;
 	}
 
 	HWPortal * FindPortal(const void * src);


### PR DESCRIPTION
Fix line portals and line mirrors getting plane-clipped at `worldcoord.y` (z-coordinate in map coordinates) of zero when rendered inside plane-mirror reflections.

There are two instances where the renderer's plane clipping is being disabled wrong. `VPUniforms.mClipHeight` was being set to `0`. The proper way is to set `VPUniforms.mClipHeightDirection` to `0.0`. Appears to be an old oversight.

See main vertex shader line:
https://github.com/UZDoom/UZDoom/blob/ceec0c52dc5f6c80a26374e5a9410abb092cc1fe/wadsrc/static/shaders/glsl/main.vp#L134

The consequence was affecting the recursive rendering of line portals or line-mirror portals inside of reflective floors/ceilings. The effect becomes visible when the z=0 plane slices through what is supposed to be rendered. The effect is total (nothing in the line portal gets rendered in the flat reflection) when the entire sector's floor and ceiling have negative z coordinates. 

Example wad: [mirrorportalbug.wad.zip](https://github.com/user-attachments/files/29534319/mirrorportalbug.wad.zip)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
