### PR TITLE
fix stupid windows bullshit with _wexecv

### DIFF
--- a/src/widgets/updatebuttonbar.cpp
+++ b/src/widgets/updatebuttonbar.cpp
@@ -1360,15 +1360,27 @@ public:
 						int argc;
 						LPWSTR * argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 
-						std::string updater_filename = (progdir + "updater.exe");
+						std::string updater_filename(progdir + "updater.exe");
 
+						FString updater_filename_quoted((progdir + "updater.exe").c_str());
+
+						updater_filename_quoted.Substitute("\\", "\\\\");
+						updater_filename_quoted.Substitute("\"", "\\\"");
+						updater_filename_quoted = "\""+updater_filename_quoted+"\"";
+						
 						int numchars = MultiByteToWideChar(CP_UTF8, 0, updater_filename.c_str(), updater_filename.length(), NULL, 0);
 
 						WCHAR * updater_filename_w = new WCHAR[numchars + 1];
 						MultiByteToWideChar(CP_UTF8, 0, updater_filename.c_str(), updater_filename.length(), updater_filename_w, numchars);
 						updater_filename_w[numchars] = 0;
 
-						argv[0] = updater_filename_w;
+						numchars = MultiByteToWideChar(CP_UTF8, 0, updater_filename_quoted.GetChars(), updater_filename_quoted.Len(), NULL, 0);
+
+						WCHAR * updater_filename_quoted_w = new WCHAR[numchars + 1];
+						MultiByteToWideChar(CP_UTF8, 0, updater_filename_quoted.GetChars(), updater_filename_quoted.Len(), updater_filename_quoted_w, numchars);
+						updater_filename_quoted_w[numchars] = 0;
+
+						argv[0] = updater_filename_quoted_w;
 						_wexecv(updater_filename_w, argv);
 					}}
 				}, 500.0, POPUPF_DISALLOW_CLOSE);

--- a/src/win32/updater.c
+++ b/src/win32/updater.c
@@ -292,9 +292,24 @@ int WINAPI wWinMain (HINSTANCE hInstance, HINSTANCE nothing, LPWSTR cmdline, int
 		op.pFrom = backup_path_fucked_up.str;
 		SHFileOperationW(&op);
 
+		wstr_t exe_path_new = wstr_raw(L"\"");
+
+		wchar_t tmp[2] = L"\0\0";
+
+		for(int i = 0; i < exe_path.len; i++)
+		{
+			if(exe_path.str[i] == L'\"' || exe_path.str[i] == L'\\')
+			{
+				exe_path_new = str_concat(exe_path_new, (wstr_t){L"\\", 1});
+			}
+			tmp[0] = exe_path.str[i];
+			exe_path_new = str_concat(exe_path_new, (wstr_t){tmp, 1});
+		}
+		exe_path_new = str_concat(exe_path_new, (wstr_t){L"\"", 1});
+
 		int argc;
 		LPWSTR * argv = CommandLineToArgvW(GetCommandLineW(), &argc);
-		argv[0] = exe_path.str;
+		argv[0] = exe_path_new.str;
 		_wexecv(exe_path.str, (const wchar_t * const *)argv);
 		return 0;
 	}


### PR DESCRIPTION
windows treats single _wexecv args with spaces as multiple args?????????????????? fucking shitty OS, but this fixes handling for that

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
