### PR TITLE
Fix SDL3 related crash on macos

### DIFF
--- a/.github/workflows/build_core.yml
+++ b/.github/workflows/build_core.yml
@@ -384,6 +384,7 @@ jobs:
         fi
 
         mkdir -p ${app}/Contents/Frameworks
+        cp -L $(brew --prefix sdl3)/lib/libSDL3.dylib ${app}/Contents/Frameworks/libSDL3.dylib
         cp $(brew --prefix molten-vk)/lib/libMoltenVK.dylib ${app}/Contents/Frameworks/
         dylibbundler -ns -of -cd -b \
           -x ./${app}/Contents/MacOS/uzdoom \

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -394,3 +394,4 @@ Júlia Rosell Saldaña
 Libre
 Matt Silverwood
 Tóth János
+kryksyh


### PR DESCRIPTION
on june 18 [sdl2 was replaced with sdl2-compat](https://github.com/Homebrew/homebrew-core/commit/ad4806814e498656ca06816d4d65341a139169a9) which is a wrapper over SDL3.

This PR fixes a crash on start on macos:
<img width="267" height="214" alt="image" src="https://github.com/user-attachments/assets/aa90efca-6e7f-461f-bd0d-6938b352e3b9" />


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
