### PR TITLE
fix deprecated flag chained assignment

### DIFF
--- a/src/common/scripting/backend/codegen.cpp
+++ b/src/common/scripting/backend/codegen.cpp
@@ -2949,6 +2949,7 @@ ExpEmit FxAssign::Emit(VMFunctionBuilder *build)
 		emitters.AddParameter(build, Base);
 		emitters.AddParameter(build, Right);
 		emitters.AddParameterIntConst(IsBitWrite - 64);
+		emitters.AddReturn(REGT_INT);
 		return emitters.EmitCall(build);
 	}
 }

--- a/src/scripting/thingdef.h
+++ b/src/scripting/thingdef.h
@@ -55,7 +55,7 @@ struct FFlagDef
 
 void FinalizeClass(PClass *cls, FStateDefinitions &statedef);
 FFlagDef *FindFlag (const PClass *type, const char *part1, const char *part2, bool strict = false);
-void HandleDeprecatedFlags(AActor *defaults, int set, int index);
+int HandleDeprecatedFlags(AActor *defaults, int set, int index);
 int CheckDeprecatedFlags(AActor *actor, int index);
 const char *GetFlagName(unsigned int flagnum, int flagoffset);
 void ModActorFlag(AActor *actor, FFlagDef *fd, bool set);

--- a/src/scripting/thingdef_properties.cpp
+++ b/src/scripting/thingdef_properties.cpp
@@ -257,7 +257,7 @@ INTBOOL CheckActorFlag(AActor *owner, const char *flagname, bool printerror)
 // properties is not recommended and may not do what is expected
 //
 //===========================================================================
-void HandleDeprecatedFlags(AActor *actor, int set, int index)
+int HandleDeprecatedFlags(AActor *actor, int set, int index)
 {
 	switch (index)
 	{
@@ -343,6 +343,7 @@ void HandleDeprecatedFlags(AActor *actor, int set, int index)
 	default:
 		break;	// silence GCC
 	}
+	return set;
 }
 
 // the interface here works on object, but currently all deprecated flags affect subclasses of Actor only
@@ -351,8 +352,7 @@ DEFINE_ACTION_FUNCTION_NATIVE(DObject, HandleDeprecatedFlags, HandleDeprecatedFl
 	PARAM_SELF_PROLOGUE(AActor);
 	PARAM_INT(set);
 	PARAM_INT(index);
-	HandleDeprecatedFlags(self, set, index);
-	return 0;
+	ACTION_RETURN_BOOL(HandleDeprecatedFlags(self, set, index));
 }
 //===========================================================================
 //

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -793,7 +793,7 @@ class Object native
 	private native static Class<Object> BuiltinNameToClass(Name nm, Class<Object> filter);
 	private native static Object BuiltinClassCast(Object inptr, Class<Object> test);
 	private native static Function<void> BuiltinFunctionPtrCast(Function<void> inptr, voidptr newtype);
-	private native static void HandleDeprecatedFlags(Object obj, bool set, int index);
+	private native static bool HandleDeprecatedFlags(Object obj, bool set, int index);
 	private native static bool CheckDeprecatedFlags(Object obj, int index);
 
 	native static Name ValidateNameIndex(int index);


### PR DESCRIPTION
(proper fix would be to have `bDepf = whatever` return a modifiable handle to the virtual flag but couldn't figure out how to work that out on the vm)

fixes #213

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
