### PR TITLE
Force fogmode to radial for orthographic projection if lightmode is ZDoomSoftware

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
+++ b/src/rendering/hwrenderer/scene/hw_drawinfo.cpp
@@ -153,15 +153,16 @@ void HWDrawInfo::StartScene(FRenderViewpoint &parentvp, HWViewpointUniforms *uni
 		VPUniforms.mNormalViewMatrix.loadIdentity();
 		ProjectionMatrix2.loadIdentity();
 		VPUniforms.mViewHeight = viewheight;
+		int fogmode = Viewpoint.bDoOrtho && (lightmode == ELightMode::ZDoomSoftware) ? 2 : gl_fogmode; // Force radial if Ortho and ZDoomSoftware
 		if (lightmode == ELightMode::Build)
 		{
 			VPUniforms.mGlobVis = 1 / 64.f;
-			VPUniforms.mPalLightLevels = 32 | (static_cast<int>(gl_fogmode) << 8) | ((int)lightmode << 16);
+			VPUniforms.mPalLightLevels = 32 | (static_cast<int>(fogmode) << 8) | ((int)lightmode << 16);
 		}
 		else
 		{
 			VPUniforms.mGlobVis = (float)R_GetGlobVis(r_viewwindow, r_visibility) / 32.f;
-			VPUniforms.mPalLightLevels = static_cast<int>(gl_bandedswlight) | (static_cast<int>(gl_fogmode) << 8) | ((int)lightmode << 16);
+			VPUniforms.mPalLightLevels = static_cast<int>(gl_bandedswlight) | (static_cast<int>(fogmode) << 8) | ((int)lightmode << 16);
 		}
 		VPUniforms.mClipLine.X = -10000000.0f;
 		VPUniforms.mShadowmapFilter = gl_shadowmap_filter;


### PR DESCRIPTION
Force `gl_fogmode` to be radial if `gl_lightmode` is set to `ELightMode::ZDoomSoftware` when using orthographic projection. All other fog modes untouched for all other light modes.

This fogboundary effect doesn't look good or correct if not in perspective projection. And adds visual noise/distraction:
<img width="480" height="135" alt="output" src="https://github.com/user-attachments/assets/38628fcf-0ec5-4c31-9c25-49983f7f424c" />


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
