### PR TITLE
Fix mouse4 focus bug

### DIFF
--- a/src/common/platform/win32/i_mouse.cpp
+++ b/src/common/platform/win32/i_mouse.cpp
@@ -524,17 +524,25 @@ void FRawMouse::Grab()
 
 		rid.usUsagePage = HID_GENERIC_DESKTOP_PAGE;
 		rid.usUsage = HID_GDP_MOUSE;
-		rid.dwFlags = RIDEV_CAPTUREMOUSE | RIDEV_NOLEGACY;
+		rid.dwFlags = RIDEV_NOLEGACY;
 		rid.hwndTarget = mainwindow.GetHandle();
 		if (RegisterRawInputDevices(&rid, 1, sizeof(rid)))
 		{
 			GetCursorPos(&UngrabbedPointerPos);
-			Grabbed = true;
-			SetCursorState(false);
+			ClipCursor(NULL);
+
+			// Manually create the window rect for the cursor to grab
+			RECT rect;
+			GetClientRect(rid.hwndTarget, &rect);
+
 			// By setting the cursor position, we force the pointer image
 			// to change right away instead of having it delayed until
 			// some time in the future.
 			CenterMouse(-1, -1, NULL, NULL);
+			
+			ClipCursor(&rect);
+			Grabbed = true;
+			SetCursorState(false);
 		}
 	}
 }
@@ -560,6 +568,7 @@ void FRawMouse::Ungrab()
 			Grabbed = false;
 			ClearButtonState();
 		}
+		ClipCursor(NULL); // this releases the cursor again
 		SetCursorState(true);
 		SetCursorPos(UngrabbedPointerPos.x, UngrabbedPointerPos.y);
 	}


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Fixes #694.

The issues seems to reside with `RIDEV_CAPTUREMOUSE` in the grab function. According to https://stackoverflow.com/a/25398731 simply removing it and manually creating a rect to let the mouse focus to solves the issue. I have tested this with mouse 4 and the issue vanished.