### PR TITLE
Launcher Improvements

### DIFF
--- a/libraries/ZWidget/include/zwidget/core/widget.h
+++ b/libraries/ZWidget/include/zwidget/core/widget.h
@@ -33,7 +33,7 @@ enum class WidgetEvent
 class Widget : DisplayWindowHost
 {
 public:
-	Widget(Widget* parent = nullptr, WidgetType type = WidgetType::Child, RenderAPI api = RenderAPI::Unspecified, bool windowResizable = true);
+	Widget(Widget* parent = nullptr, WidgetType type = WidgetType::Child, RenderAPI api = RenderAPI::Unspecified, struct WindowParams = {});
 	virtual ~Widget();
 
 	void SetParent(Widget* parent);

--- a/libraries/ZWidget/include/zwidget/window/window.h
+++ b/libraries/ZWidget/include/zwidget/window/window.h
@@ -149,10 +149,20 @@ public:
 	virtual bool OnFileDrop(std::string path) = 0;
 };
 
+struct WindowParams {
+	bool utility = false;
+	bool popup = false;
+	struct { unsigned width = 320; unsigned height = 200; } size;
+	bool resizable = true;
+	struct { unsigned width = 0; unsigned height = 0; } minSize;
+	struct { unsigned width = 0; unsigned height = 0; } maxSize;
+	bool centered = true;
+};
+
 class DisplayWindow
 {
 public:
-	static std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility);
+	static std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params);
 
 	static void ProcessEvents();
 	static void RunLoop();
@@ -230,7 +240,7 @@ public:
 	virtual bool IsWin32() { return false; }
 	virtual bool IsSDL2() { return false; }
 
-	virtual std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility) = 0;
+	virtual std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams) = 0;
 	virtual void ProcessEvents() = 0;
 	virtual void RunLoop() = 0;
 	virtual void ExitLoop() = 0;

--- a/libraries/ZWidget/src/core/widget.cpp
+++ b/libraries/ZWidget/src/core/widget.cpp
@@ -2,16 +2,19 @@
 #include "core/timer.h"
 #include "core/colorf.h"
 #include "core/theme.h"
+#include "window/window.h"
 #include <stdexcept>
 #include <cmath>
 #include <algorithm>
 
-Widget::Widget(Widget* parent, WidgetType type, RenderAPI renderAPI, bool windowResizable) : Type(type)
+Widget::Widget(Widget* parent, WidgetType type, RenderAPI renderAPI, struct WindowParams params) : Type(type)
 {
 	if (type != WidgetType::Child)
 	{
 		Widget* owner = parent ? parent->Window() : nullptr;
-		DispWindow = DisplayWindow::Create(this, type == WidgetType::Popup, owner ? owner->DispWindow.get() : nullptr, renderAPI, windowResizable, type == WidgetType::Utility);
+		params.popup = type == WidgetType::Popup;
+		params.utility = type == WidgetType::Utility;
+		DispWindow = DisplayWindow::Create(this, owner ? owner->DispWindow.get() : nullptr, renderAPI, params);
 		if (renderAPI == RenderAPI::Unspecified || renderAPI == RenderAPI::Bitmap)
 		{
 			DispCanvas = Canvas::create();

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_backend.cpp
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_backend.cpp
@@ -1,5 +1,6 @@
 #include "sdl2_display_backend.h"
 #include "sdl2_display_window.h"
+#include "window/window.h"
 #include <stdexcept>
 #include <SDL2/SDL_video.h>
 #ifndef WIN32
@@ -61,9 +62,9 @@ SDL2DisplayBackend::SDL2DisplayBackend()
 	}
 }
 
-std::unique_ptr<DisplayWindow> SDL2DisplayBackend::Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility)
+std::unique_ptr<DisplayWindow> SDL2DisplayBackend::Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params)
 {
-	return std::make_unique<SDL2DisplayWindow>(windowHost, popupWindow, static_cast<SDL2DisplayWindow*>(owner), renderAPI, UIScale, resizable, utility);
+	return std::make_unique<SDL2DisplayWindow>(windowHost, static_cast<SDL2DisplayWindow*>(owner), renderAPI, UIScale, params);
 }
 
 void SDL2DisplayBackend::ProcessEvents()

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_backend.h
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_backend.h
@@ -7,7 +7,7 @@ class SDL2DisplayBackend : public DisplayBackend
 public:
 	SDL2DisplayBackend();
 
-	std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility) override;
+	std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams) override;
 	void ProcessEvents() override;
 	void RunLoop() override;
 	void ExitLoop() override;

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_window.cpp
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_window.cpp
@@ -11,7 +11,7 @@ Uint32 SDL2DisplayWindow::PaintEventNumber = 0xffffffff;
 bool SDL2DisplayWindow::ExitRunLoop;
 std::unordered_map<int, SDL2DisplayWindow*> SDL2DisplayWindow::WindowList;
 
-SDL2DisplayWindow::SDL2DisplayWindow(DisplayWindowHost* windowHost, bool popupWindow, SDL2DisplayWindow* owner, RenderAPI renderAPI, double uiscale, bool resizable, bool utility) : WindowHost(windowHost), UIScale(uiscale)
+SDL2DisplayWindow::SDL2DisplayWindow(DisplayWindowHost* windowHost, SDL2DisplayWindow* owner, RenderAPI renderAPI, double uiscale, struct WindowParams params) : WindowHost(windowHost), UIScale(uiscale)
 {
 	unsigned int flags = SDL_WINDOW_HIDDEN /*| SDL_WINDOW_ALLOW_HIGHDPI*/;
 	if (renderAPI == RenderAPI::Vulkan)
@@ -23,19 +23,31 @@ SDL2DisplayWindow::SDL2DisplayWindow(DisplayWindowHost* windowHost, bool popupWi
 		flags |= SDL_WINDOW_METAL;
 #endif
 
-	if (resizable)
+	auto pos = params.centered? SDL_WINDOWPOS_CENTERED: SDL_WINDOWPOS_UNDEFINED;
+	if (params.resizable)
+	{
 		flags |= SDL_WINDOW_RESIZABLE;
-	if (popupWindow)
+	}
+	if (params.popup)
 		flags |= SDL_WINDOW_BORDERLESS;
-	if (utility)
+	if (params.utility)
 	{
 		Owner = owner;
 		flags |= (SDL_WINDOW_UTILITY | SDL_WINDOW_ALWAYS_ON_TOP | SDL_WINDOW_SKIP_TASKBAR);
 	}
 
-	Handle.window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 320, 200, flags);
+	Handle.window = SDL_CreateWindow("", pos, pos, params.size.width*uiscale, params.size.height*uiscale, flags);
 	if (!Handle.window)
 		throw std::runtime_error(std::string("Unable to create SDL window:") + SDL_GetError());
+
+	if (params.resizable)
+	{
+		SDL_SetWindowMinimumSize(Handle.window, params.minSize.width*uiscale, params.minSize.height*uiscale);
+		if (params.maxSize.width >= params.minSize.width && params.maxSize.height >= params.minSize.height)
+		{
+			SDL_SetWindowMinimumSize(Handle.window, params.maxSize.width*uiscale, params.maxSize.height*uiscale);
+		}
+	}
 
 	switch (renderAPI)
 	{

--- a/libraries/ZWidget/src/window/sdl2/sdl2_display_window.h
+++ b/libraries/ZWidget/src/window/sdl2/sdl2_display_window.h
@@ -8,7 +8,7 @@
 class SDL2DisplayWindow : public DisplayWindow
 {
 public:
-	SDL2DisplayWindow(DisplayWindowHost* windowHost, bool popupWindow, SDL2DisplayWindow* owner, RenderAPI renderAPI, double uiscale, bool resizable, bool utility);
+	SDL2DisplayWindow(DisplayWindowHost* windowHost, SDL2DisplayWindow* owner, RenderAPI renderAPI, double uiscale, struct WindowParams);
 	~SDL2DisplayWindow();
 
 	void SetWindowTitle(const std::string& text) override;

--- a/libraries/ZWidget/src/window/win32/win32_display_backend.cpp
+++ b/libraries/ZWidget/src/window/win32/win32_display_backend.cpp
@@ -5,9 +5,9 @@
 #include "win32_save_file_dialog.h"
 #include "win32_open_folder_dialog.h"
 
-std::unique_ptr<DisplayWindow> Win32DisplayBackend::Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility)
+std::unique_ptr<DisplayWindow> Win32DisplayBackend::Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params)
 {
-	return std::make_unique<Win32DisplayWindow>(windowHost, popupWindow, static_cast<Win32DisplayWindow*>(owner), renderAPI, resizable, utility);
+	return std::make_unique<Win32DisplayWindow>(windowHost, static_cast<Win32DisplayWindow*>(owner), renderAPI, params);
 }
 
 void Win32DisplayBackend::ProcessEvents()

--- a/libraries/ZWidget/src/window/win32/win32_display_backend.h
+++ b/libraries/ZWidget/src/window/win32/win32_display_backend.h
@@ -5,7 +5,7 @@
 class Win32DisplayBackend : public DisplayBackend
 {
 public:
-	std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility) override;
+	std::unique_ptr<DisplayWindow> Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams) override;
 	void ProcessEvents() override;
 	void RunLoop() override;
 	void ExitLoop() override;

--- a/libraries/ZWidget/src/window/win32/win32_display_window.cpp
+++ b/libraries/ZWidget/src/window/win32/win32_display_window.cpp
@@ -1,4 +1,3 @@
-
 #include "win32_display_window.h"
 #include <zwidget/core/image.h>
 #include <windowsx.h>
@@ -80,7 +79,7 @@ static double DelayLoadGetDpiScale(HWND hwnd)
 	}
 }
 
-Win32DisplayWindow::Win32DisplayWindow(DisplayWindowHost* windowHost, bool popupWindow, Win32DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility) : WindowHost(windowHost), PopupWindow(popupWindow)
+Win32DisplayWindow::Win32DisplayWindow(DisplayWindowHost* windowHost, Win32DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params) : WindowHost(windowHost), PopupWindow(params.popup)
 {
 	Windows.push_front(this);
 	WindowsIterator = Windows.begin();
@@ -99,8 +98,22 @@ Win32DisplayWindow::Win32DisplayWindow(DisplayWindowHost* windowHost, bool popup
 	// WS_SYSMENU shows the min/max/close buttons
 	// WS_THICKFRAME makes the window resizable
 
+	resizable = params.resizable;
+	minW = params.minSize.width;
+	minH = params.minSize.height;
+	maxW = params.maxSize.width;
+	maxH = params.maxSize.height;
+
+	int x = 0, y = 0;
+	if (params.centered)
+	{
+		auto s = GetScreenSize();
+		x = std::max(0.0, s.width - params.size.width) / 2;
+		y = std::max(0.0, s.height - params.size.height) / 2;
+	}
+
 	DWORD style = 0, exstyle = 0;
-	if (popupWindow)
+	if (params.popup)
 	{
 		exstyle = WS_EX_NOACTIVATE;
 		style = WS_POPUP;
@@ -108,9 +121,9 @@ Win32DisplayWindow::Win32DisplayWindow(DisplayWindowHost* windowHost, bool popup
 	else
 	{
 		exstyle = WS_EX_APPWINDOW | WS_EX_DLGMODALFRAME;
-		style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | (resizable ? (WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX) : WS_MINIMIZEBOX);
+		style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | (params.resizable ? (WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX) : WS_MINIMIZEBOX);
 	}
-	CreateWindowEx(exstyle, L"ZWidgetWindow", L"", style, 0, 0, 100, 100, owner ? owner->WindowHandle.hwnd : 0, 0, GetModuleHandle(0), this);
+	CreateWindowEx(exstyle, L"ZWidgetWindow", L"", style, x, y, params.size.width, params.size.height, owner ? owner->WindowHandle.hwnd : 0, 0, GetModuleHandle(0), this);
 }
 
 Win32DisplayWindow::~Win32DisplayWindow()
@@ -574,6 +587,19 @@ LRESULT Win32DisplayWindow::OnWindowMessage(UINT msg, WPARAM wparam, LPARAM lpar
 			}
 		}
 		return DefWindowProc(WindowHandle.hwnd, msg, wparam, lparam);
+	}
+	else if (msg == WM_GETMINMAXINFO)
+	{
+		if (resizable)
+		{
+			LPMINMAXINFO lpMMI = (LPMINMAXINFO)lparam;
+			int minWL = GetSystemMetrics(SM_CXMINTRACK), minHL = GetSystemMetrics(SM_CYMINTRACK);
+			int maxWL = GetSystemMetrics(SM_CXMAXTRACK), maxHL = GetSystemMetrics(SM_CYMAXTRACK);
+			lpMMI->ptMinTrackSize.x = std::max(minW, minWL);
+			lpMMI->ptMinTrackSize.y = std::max(minH, minHL);
+			lpMMI->ptMaxTrackSize.x = std::min(maxW >= minW? maxW: maxWL, maxWL);
+			lpMMI->ptMaxTrackSize.y = std::min(maxH >= minH? maxH: maxHL, maxHL);
+		}
 	}
 	else if (msg == WM_PAINT)
 	{

--- a/libraries/ZWidget/src/window/win32/win32_display_window.h
+++ b/libraries/ZWidget/src/window/win32/win32_display_window.h
@@ -10,7 +10,7 @@
 class Win32DisplayWindow : public DisplayWindow
 {
 public:
-	Win32DisplayWindow(DisplayWindowHost* windowHost, bool popupWindow, Win32DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility);
+	Win32DisplayWindow(DisplayWindowHost* windowHost, Win32DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params);
 	~Win32DisplayWindow();
 
 	void SetWindowTitle(const std::string& text) override;
@@ -98,4 +98,7 @@ public:
 	HICON LargeIcon = {};
 
 	StandardCursor CurrentCursor = StandardCursor::arrow;
+private:
+	bool resizable;
+	int minW, maxW, minH, maxH;
 };

--- a/libraries/ZWidget/src/window/window.cpp
+++ b/libraries/ZWidget/src/window/window.cpp
@@ -7,9 +7,9 @@
 #include "core/widget.h"
 #include <stdexcept>
 
-std::unique_ptr<DisplayWindow> DisplayWindow::Create(DisplayWindowHost* windowHost, bool popupWindow, DisplayWindow* owner, RenderAPI renderAPI, bool resizable, bool utility)
+std::unique_ptr<DisplayWindow> DisplayWindow::Create(DisplayWindowHost* windowHost, DisplayWindow* owner, RenderAPI renderAPI, struct WindowParams params)
 {
-	return DisplayBackend::Get()->Create(windowHost, popupWindow, owner, renderAPI, resizable, utility);
+	return DisplayBackend::Get()->Create(windowHost, owner, renderAPI, params);
 }
 
 void DisplayWindow::ProcessEvents()

--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -84,6 +84,13 @@ struct FStartupSelectionInfo
 	const TArray<WadStuff>* Wads = nullptr;
 	FArgs* Args = nullptr;
 
+	// Launcher settings
+	bool notifyNewRelease = true;
+	FName prideColors = {};
+	float prideMix = 0;
+	unsigned LauncherWidth = 0;
+	unsigned LauncherHeight = 0;
+
 	// Local game info
 	int DefaultIWAD = 0;
 	FString DefaultArgs = {};
@@ -97,9 +104,6 @@ struct FStartupSelectionInfo
 	int DefaultBackend = 1;
 	bool DefaultFullscreen = true;
 	int DefaultFileLoadBehaviour = 0;
-	bool notifyNewRelease = true;
-	FName prideColors = {};
-	float prideMix = 0;
 
 	// Net game info
 	int DefaultNetIWAD = 0;

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -58,6 +58,10 @@ CVARD(Bool, i_searchdistributors, true, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "Search 
 // Show release notes upon update 0:no, 1: yes, 2: always for testing
 CVARD(Int, i_display_new_release, 1, CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "Show release notes upon update");
 
+CVARD(Bool, ui_remember_size, true,  CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "Launcher retains size between launches");
+CVARD(Int, ui_launcher_width, 0,  CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "Launcher width");
+CVARD(Int, ui_launcher_height, 0,  CVAR_ARCHIVE|CVAR_GLOBALCONFIG, "Launcher height");
+
 EXTERN_FARG(iwad);
 EXTERN_FARG(host);
 EXTERN_FARG(join);
@@ -849,6 +853,12 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 		info.isNewRelease = (i_display_new_release>1) || i_is_new_release;
 		info.notifyNewRelease = !!i_display_new_release;
 
+		if (ui_remember_size)
+		{
+			info.LauncherWidth = ui_launcher_width;
+			info.LauncherHeight = ui_launcher_height;
+		}
+
 		if (I_PickIWad((queryiwad || showlauncher) || HoldingQueryKey(queryiwad_key), info))
 		{
 			pick = info.SaveInfo();
@@ -860,6 +870,11 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 			i_exit_on_not_found = info.DefaultFileLoadBehaviour;
 			if (!info.notifyNewRelease)
 				i_display_new_release = 0; // don't change truthy values
+			if (ui_remember_size)
+			{
+				ui_launcher_width = info.LauncherWidth;
+				ui_launcher_height = info.LauncherHeight;
+			}
 		}
 		else
 		{

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -39,12 +39,15 @@
 
 bool LauncherWindow::ExecModal(FStartupSelectionInfo& info)
 {
-	unsigned height = 800, width = 650;
+	unsigned width = 650, height = 800;
 
 #ifdef HAS_UPDATER
 	LoadCurl();
 	if (IsCurlLoaded()) height += 34;
 #endif
+
+	if (info.LauncherWidth > 0) width = info.LauncherWidth;
+	if (info.LauncherHeight > 0) height = info.LauncherHeight;
 
 	auto launcher = std::make_unique<LauncherWindow>(info, WindowParams{
 		.size = { width, height },
@@ -200,6 +203,9 @@ void LauncherWindow::OnClose()
 
 void LauncherWindow::OnGeometryChanged()
 {
+	Info->LauncherWidth = GetWidth();
+	Info->LauncherHeight = GetHeight();
+
 	double top = Banner->GetPreferredHeight();
 	double bottom = GetHeight();
 

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -39,9 +39,20 @@
 
 bool LauncherWindow::ExecModal(FStartupSelectionInfo& info)
 {
-	auto launcher = std::make_unique<LauncherWindow>(info);
+	unsigned height = 700, width = 615;
 
-	launcher->UpdateSize();
+#ifdef HAS_UPDATER
+	LoadCurl();
+	if (IsCurlLoaded()) height += 34;
+#endif
+
+	auto launcher = std::make_unique<LauncherWindow>(info, WindowParams{
+		.size = { width, height },
+		.resizable = true,
+		.minSize = { 450, 550 },
+		.centered = true,
+	});
+
 	launcher->Show();
 
 	DisplayWindow::RunLoop();
@@ -49,28 +60,8 @@ bool LauncherWindow::ExecModal(FStartupSelectionInfo& info)
 	return launcher->ExecResult;
 }
 
-void LauncherWindow::UpdateSize()
+LauncherWindow::LauncherWindow(FStartupSelectionInfo& info, struct WindowParams params) : Widget(nullptr, WidgetType::Window, RenderAPI::Unspecified, params), Info(&info)
 {
-	Size screenSize = GetScreenSize();
-
-	double windowWidth = 615.0;
-	double windowHeight = 700.0;
-
-#ifdef HAS_UPDATER
-	if(IsCurlLoaded())
-	{
-		windowHeight += UpdateBar->GetPreferredHeight() + UpdateBar->GetMargin();
-	}
-#endif
-
-	SetFrameGeometry((screenSize.width - windowWidth) * 0.5, (screenSize.height - windowHeight) * 0.5, windowWidth, windowHeight);
-}
-
-LauncherWindow::LauncherWindow(FStartupSelectionInfo& info) : Widget(nullptr, WidgetType::Window), Info(&info)
-{
-#ifdef HAS_UPDATER
-	LoadCurl();
-#endif
 	SetWindowTitle(GAMENAME);
 	this->SetStyleColor("background-color", Theme::getHeader(COLOR_BACKGROUND));
 

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -39,7 +39,7 @@
 
 bool LauncherWindow::ExecModal(FStartupSelectionInfo& info)
 {
-	unsigned height = 700, width = 615;
+	unsigned height = 800, width = 650;
 
 #ifdef HAS_UPDATER
 	LoadCurl();
@@ -49,7 +49,7 @@ bool LauncherWindow::ExecModal(FStartupSelectionInfo& info)
 	auto launcher = std::make_unique<LauncherWindow>(info, WindowParams{
 		.size = { width, height },
 		.resizable = true,
-		.minSize = { 450, 550 },
+		.minSize = { 550, 450 },
 		.centered = true,
 	});
 
@@ -200,11 +200,12 @@ void LauncherWindow::OnClose()
 
 void LauncherWindow::OnGeometryChanged()
 {
-	double top = 0.0;
+	double top = Banner->GetPreferredHeight();
 	double bottom = GetHeight();
 
-	Banner->SetFrameGeometry(0.0, top, GetWidth(), Banner->GetPreferredHeight());
-	top += Banner->GetPreferredHeight();
+	if (top > bottom/3) top = 0;
+
+	Banner->SetFrameGeometry(0, 0, GetWidth(), top);
 
 #ifdef HAS_UPDATER
 	if(IsCurlLoaded())

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -66,7 +66,7 @@ void LauncherWindow::UpdateSize()
 	SetFrameGeometry((screenSize.width - windowWidth) * 0.5, (screenSize.height - windowHeight) * 0.5, windowWidth, windowHeight);
 }
 
-LauncherWindow::LauncherWindow(FStartupSelectionInfo& info) : Widget(nullptr, WidgetType::Window, RenderAPI::Unspecified, false), Info(&info)
+LauncherWindow::LauncherWindow(FStartupSelectionInfo& info) : Widget(nullptr, WidgetType::Window), Info(&info)
 {
 #ifdef HAS_UPDATER
 	LoadCurl();

--- a/src/widgets/launcherwindow.h
+++ b/src/widgets/launcherwindow.h
@@ -41,7 +41,7 @@ class LauncherWindow : public Widget
 public:
 	static bool ExecModal(FStartupSelectionInfo& info);
 
-	LauncherWindow(FStartupSelectionInfo& info);
+	LauncherWindow(FStartupSelectionInfo& info, struct WindowParams params);
 	void UpdateLanguage();
 
 	void UpdateSize();

--- a/src/widgets/updatebuttonbar.cpp
+++ b/src/widgets/updatebuttonbar.cpp
@@ -172,7 +172,7 @@ protected:
 	std::vector<TextLabel *> text;
 public:
 	ChoicePopup(Widget * parent, const std::string &title, const std::vector<std::string> &text, const PopupBase::ActionListType &actions, double _windowWidth, int flags)
-		: PopupBase(parent->Window(), WidgetType::Utility, RenderAPI::Unspecified, false)
+		: PopupBase(parent->Window(), WidgetType::Utility, RenderAPI::Unspecified, { .resizable = false })
 	{
 		allowCloseButton = !(flags & POPUPF_DISALLOW_CLOSE);
 


### PR DESCRIPTION
- Restores resize functionality to launcher
- Adds minimum size to launcher (and slightly increases default size)
- Makes so the banner is hidden when the window is too small
- Launcher will now spawn with the last-used size. This has the side-effect of making tiling window managers happier.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
