### PR TITLE
update-subtrees.sh: provide simple linear commit history instead of merge commits

### DIFF
--- a/tools/update-subtrees.sh
+++ b/tools/update-subtrees.sh
@@ -7,8 +7,21 @@
 
 export GITROOT="$(git rev-parse --show-toplevel)"
 
-pull() {
-	name=${1}; shift; dest=${1}; shift; repo=${1}; shift; ref=${1}; shift
+if [[ "${1}" == "--allow-empty" ]]
+then
+	EMPTY_COMMIT_FLAG="--allow-empty"
+	shift
+fi
+if [[ "${1}" == "add" || "${1}" == "pull" ]]
+then
+	operation="${1}"
+	shift
+else
+	operation="pull"
+fi
+
+subtree_action() {
+	name="${1}"; shift; dest="${1}"; shift; repo="${1}"; shift; ref="${1}"; shift
 
 	if [[ "${1}" == "${name}" || "${1}" == "all" ]]
 	then
@@ -18,16 +31,35 @@ pull() {
 	fi
 	shift
 
-	[[ -z ${1} ]] || ref=${1}
+	[[ -n "${1}" ]] && ref="${1}"
 	shift
-	[[ -z ${1} ]] || repo=${1}
+	[[ -n "${1}" ]] && repo="${1}"
 	shift
 
-	git -C $GITROOT subtree pull --prefix="${dest}" "${repo}" "${ref}" \
-		--squash --message "Update ${dest} to ${ref}" || exit
+	# Exit script if there's any error
+	set -e
+	RANDOM_COMMIT_MESSAGE="${SRANDOM}"
+	git -C "${GITROOT}" subtree "${operation}" --prefix="${dest}" "${repo}" "${ref}" --squash --message "${RANDOM_COMMIT_MESSAGE}"
+	COMMIT_MESSAGE_TMP_FILE="$(mktemp)"
+	trap 'set +e && rm "${COMMIT_MESSAGE_TMP_FILE}"' RETURN
+	[[ "$(git log --format=%B -n 1)" != "${RANDOM_COMMIT_MESSAGE}" ]] && return
+	if [[ "${operation}" == "add" ]]
+	then
+		printf "Add ${dest} from ${ref}\n\n" > "${COMMIT_MESSAGE_TMP_FILE}"
+	else
+		printf "Update ${dest} to ${ref}\n\n" > "${COMMIT_MESSAGE_TMP_FILE}"
+	fi
+	cat <(git log --format=%B -n 1 HEAD^2) >> "${COMMIT_MESSAGE_TMP_FILE}"
+	git reset --soft HEAD^
+	if [[ -z "$(git status --porcelain)" ]]
+	then
+		echo "Fetched '${name}' has different commit hash but no actual changes!"
+		[[ -z "${EMPTY_COMMIT_FLAG}" ]] && return
+	fi
+	git commit ${EMPTY_COMMIT_FLAG} -F "${COMMIT_MESSAGE_TMP_FILE}"
 }
 
-pull 'zwidget'     'libraries/ZWidget'     'https://github.com/UZDoom/ZWidget'     'legacy' "${@}"
-pull 'zmusic'      'libraries/ZMusic'      'https://github.com/UZDoom/ZMusic'      'trunk'  "${@}"
-pull 'translation' 'libraries/Translation' 'https://github.com/UZDoom/Translation' 'main'   "${@}"
-pull 'zvulkan'     'libraries/ZVulkan'     'https://github.com/UZDoom/ZVulkan'     'legacy' "${@}"
+subtree_action 'zwidget'     'libraries/ZWidget'     'https://github.com/UZDoom/ZWidget'     'legacy' "${@}"
+subtree_action 'zmusic'      'libraries/ZMusic'      'https://github.com/UZDoom/ZMusic'      'trunk'  "${@}"
+subtree_action 'translation' 'libraries/Translation' 'https://github.com/UZDoom/Translation' 'main'   "${@}"
+subtree_action 'zvulkan'     'libraries/ZVulkan'     'https://github.com/UZDoom/ZVulkan'     'legacy' "${@}"


### PR DESCRIPTION
~This PR is meant to be merged via "Rebase and merge" option because it also fixes ZMusic subtree tracking~
Edit: Squash and merge for this PR is fine as long as the commit message, specially the bottom of it isn't touched.

With this change, now "Sync subtrees" PRs can be safely merged via "Rebase and merge" option, which preserves git subtree tracking, so the maintainer/s doesn't have to reset subtrees each time they want to open a PR to update them.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
