### PR TITLE
[save serialization freeze time] Reduce save file size and freeze time for big mods

### DIFF
--- a/src/playsim/p_acs.cpp
+++ b/src/playsim/p_acs.cpp
@@ -1624,8 +1624,9 @@ static void WriteArrayVars (FSerializer &file, FWorldGlobalArray *vars, unsigned
 
 						while (it.NextPair(pair))
 						{
-							arraykey.Format("%d", pair->Key);
 							int v = pair->Value;
+							if (v == 0) continue;
+							arraykey.Format("%d", pair->Key);
 							file(arraykey.GetChars(), v);
 						}
 						file.EndObject();


### PR DESCRIPTION
The longer you play doomrpg, the longer your save time and file size become.

## Problem

ACS global/world arrays (`ACS_GlobalArrays`, `ACS_WorldArrays`) are implemented as `TMap<int32_t, int32_t, ..., InitIntToZero>`. Any `operator[]` access — read or write — creates a pair with default value `0`. That pair then lives in the map forever and gets serialized to `globals.json` on every save, even when its value is currently `0`.

For scripts written directly against ACS this is usually invisible because arrays are used sparsely. But for **GDCC-compiled mods**, which back their own heap (`__GDCC__AllocSize = 256 MiB` by default) with `acsglobalarrays[0]`, every touched byte in the heap becomes a permanent TMap pair. `calloc()`, `memset(..., 0, ...)`, and `field = 0` — all standard C idioms — accumulate zero-valued pairs continuously over a play session.

I ran into this while investigating save bloat in **DoomRPG SE**

Roughly **20% of the save was zero-valued cells** — pure serialization overhead — with no way to remove them from script code (there is no ACS API to un-touch a cell in a global array).
After applying this patch and playing an equivalent session, a `1250 KB` savegame shrank to `750 KB` — **~40% reduction on a short session**, and the ratio grows with play time (bloat is monotone; the mod eventually saw multi-MB saves before this patch).
## Fix
In `WriteArrayVars` (`src/playsim/p_acs.cpp`), skip pairs whose value is `0`. On load, missing keys read back as `0` anyway via the `InitIntToZero` trait on `FWorldGlobalArray`, so this is **semantically lossless**: scripts cannot distinguish "never touched" from "explicitly set to 0" either before or after this change.
## Safety / compatibility
- **Load compatibility:** old saves (with zero pairs stored) load exactly as before — `ReadArrayVars` inserts every pair it reads, including zero ones. The next save simply omits them.
- **Script semantics:** unchanged. `array[k]` for absent `k` returns `0` whether it was never touched or explicitly zeroed. ACS exposes no `hasKey`-style introspection.
- **Netgames / multiplayer:** unchanged. Same on-wire semantics.
- **Performance:** slightly faster save (fewer file writes); load unchanged.
## Impact
Users of any GDCC-based mod (e.g., DoomRPG variants) will see significantly smaller save files and shorter save-time freezes. Users of pure-ACC mods will see no observable change because they rarely touch enough cells for the effect to be measurable.
## Why not fix it in the mod?
There is no ACS API to remove a touched cell from `ACS_GlobalArrays` / `ACS_WorldArrays`. A mod can zero a cell but cannot un-register it from the TMap. The engine is the only layer where this can be addressed without breaking the "user array" abstraction.


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
