### PR TITLE
Fix lock on Intermission screens when Chat is open

### DIFF
--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -536,7 +536,7 @@ static bool DoSubstitution (FString &out, const char *in)
 
 CCMD (messagemode)
 {
-	if (menuactive != MENU_Off)
+	if (gamestate != GS_LEVEL || demoplayback || menuactive != MENU_Off)
 		return;
 
 	const uint64_t time = I_msTime();
@@ -612,7 +612,7 @@ CCMD (say)
 
 CCMD (messagemode2)
 {
-	if (menuactive != MENU_Off)
+	if (gamestate != GS_LEVEL || demoplayback || menuactive != MENU_Off)
 		return;
 
 	const uint64_t time = I_msTime();

--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -534,9 +534,14 @@ static bool DoSubstitution (FString &out, const char *in)
 	return true;
 }
 
+bool CanChat()
+{
+	return gamestate == GS_LEVEL && !demoplayback && menuactive == MENU_Off;
+}
+
 CCMD (messagemode)
 {
-	if (gamestate != GS_LEVEL || demoplayback || menuactive != MENU_Off)
+	if (!CanChat())
 		return;
 
 	const uint64_t time = I_msTime();
@@ -580,6 +585,12 @@ CCMD (say)
 		return;
 	}
 
+	if (!CanChat())
+	{
+		Printf("Game is not in a valid state to send messages.\n");
+		return;
+	}
+
 	const uint64_t time = I_msTime();
 	if (ChatCoolDown > time)
 	{
@@ -612,7 +623,7 @@ CCMD (say)
 
 CCMD (messagemode2)
 {
-	if (gamestate != GS_LEVEL || demoplayback || menuactive != MENU_Off)
+	if (!CanChat())
 		return;
 
 	const uint64_t time = I_msTime();
@@ -653,6 +664,12 @@ CCMD (say_team)
 	if (argv.argc() == 1)
 	{
 		Printf ("Usage: say_team <message>\n");
+		return;
+	}
+
+	if (!CanChat())
+	{
+		Printf("Game is not in a valid state to send messages.\n");
 		return;
 	}
 

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -1062,11 +1062,13 @@ bool G_Responder (event_t *ev)
 	if (ev->type != EV_Mouse && primaryLevel->localEventManager->Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
 		return true;
 
+	if (CT_Responder(ev))
+		return true; // chat ate the event
+
 	if (gamestate == GS_INTRO || gamestate == GS_CUTSCENE)
 	{
 		return ScreenJobResponder(ev);
 	}
-
 	// any other key pops up menu if in demos
 	// [RH] But only if the key isn't bound to a "special" command
 	if (gameaction == ga_nothing &&
@@ -1106,9 +1108,6 @@ bool G_Responder (event_t *ev)
 
 		return false;
 	}
-
-	if (CT_Responder (ev))
-		return true; // chat ate the event
 
 	if (gamestate == GS_LEVEL)
 	{

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -109,6 +109,9 @@ void G_DoWorldDone (void);
 
 void STAT_Serialize(FSerializer &file);
 
+bool CanChat();
+void CT_Stop();
+
 // PUBLIC FUNCTION PROTOTYPES ----------------------------------------------
 
 // PRIVATE FUNCTION PROTOTYPES ---------------------------------------------
@@ -1058,12 +1061,12 @@ CCMD (spycancel)
 //
 bool G_Responder (event_t *ev)
 {
+	if (!CanChat())
+		CT_Stop();
+
 	// check events
 	if (ev->type != EV_Mouse && primaryLevel->localEventManager->Responder(ev)) // [ZZ] ZScript ate the event // update 07.03.17: mouse events are handled directly
 		return true;
-
-	if (CT_Responder(ev))
-		return true; // chat ate the event
 
 	if (gamestate == GS_INTRO || gamestate == GS_CUTSCENE)
 	{
@@ -1074,8 +1077,6 @@ bool G_Responder (event_t *ev)
 	if (gameaction == ga_nothing &&
 		(demoplayback || gamestate == GS_DEMOSCREEN || gamestate == GS_TITLELEVEL))
 	{
-		if (chatmodeon) chatmodeon = 0;
-
 		const char *cmd = Bindings.GetBind (ev->data1);
 
 		if (ev->type == EV_KeyDown)
@@ -1108,6 +1109,9 @@ bool G_Responder (event_t *ev)
 
 		return false;
 	}
+
+	if (CT_Responder(ev))
+		return true; // chat ate the event
 
 	if (gamestate == GS_LEVEL)
 	{


### PR DESCRIPTION
This bug can happen in two occasions afaik:

1. Open the Console and type 'messagemode' - Done, you won't be able to do anything.
2. In Multiplayer, another player changes the level while you have the chat open - You won't able to interact, have to wait for the time to count down or the host to advance.

What this PR does is
- Give priority to the chat input if its open, letting you finish typing or close. (tho the message will only show up in the console)
- Blocks opening the chat if not on a level or in a demo.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
