### PR TITLE
Startup video playback input fix

### DIFF
--- a/src/common/engine/d_event.cpp
+++ b/src/common/engine/d_event.cpp
@@ -94,7 +94,7 @@ void D_ProcessEvents (void)
 		// allow the game to intercept Escape before dispatching it.
 		if (ev->type != EV_KeyDown || ev->data1 != KEY_ESCAPE || !sysCallbacks.WantEscape || !sysCallbacks.WantEscape())
 		{
-			if (gamestate != GS_INTRO) // GS_INTRO blocks the UI.
+			if (gamestate != GS_STARTUP && gamestate != GS_INTRO) // GS_INTRO blocks the UI.
 			{
 				if (C_Responder(ev))
 					continue;				// console ate the event


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Fixes #1292.

Supresses key inputs during the startup phase and thus preventing the unresponsive menu showing up.