### PR TITLE
Fix appstream network issue

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -164,8 +164,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref }}
       - run: |
-          flatpak-builder-lint --gha-format \
-            appstream src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
+          file=src/posix/freedesktop/org.zdoom.UZDoom.metainfo.xml
+          # These are here twice. First is to get nice output, second is to not make ci fail if network access fails
+          flatpak-builder-lint --gha-format appstream $file || true
+          AS_VALIDATE_NONET=1 flatpak-builder-lint appstream $file
 
 # ======================
 # Primary Build Configuration


### PR DESCRIPTION
CI has been failing a lot recently due to network instability. This should fix a big cause of these failures. Keep in mind that some valid network related issues may get lost with this fix applied (but they will get caught during Flatpak creation)

Thank you for finding a fix for this @fpiesche

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
