### PR TITLE
Add temporary workaround for #1624

### DIFF
--- a/src/common/engine/stringtable.cpp
+++ b/src/common/engine/stringtable.cpp
@@ -652,7 +652,14 @@ void FStringTable::LoadLanguage (int lumpnum, const char* buffer, size_t size)
 					errordone = true;
 					return;
 				}
+#if 0
+				// FIXME: the next line (and probably any of the other ScriptError calls) causes a crash right now
 				sc.ScriptError ("Found a string without a language specified.");
+#else
+				if (!errordone) Printf("Found a string without a language specified.\n");
+				errordone = true;
+				return;
+#endif
 			}
 
 			bool skip = false;


### PR DESCRIPTION
The crash happens deep inside of TArray (during a guard check). I do not have the time to properly investigate the problem.

This change makes the engine skip the invalid lump instead of aborting.

If someone has time to actually investigate before 5.0, I would be grateful. If not, an actual fix will be high-priority for me once I have more time

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
