### PR TITLE
Add TexMan.ResetAnimationTimer ZScript Function

### DIFF
--- a/src/common/scripting/interface/vmnatives.cpp
+++ b/src/common/scripting/interface/vmnatives.cpp
@@ -39,6 +39,7 @@
 #include "image.h"
 #include "s_soundinternal.h"
 #include "i_time.h"
+#include "animations.h"
 
 #include "maps.h"
 #include "types.h"
@@ -583,6 +584,15 @@ DEFINE_ACTION_FUNCTION(_TexMan, GetCanvas)
 	PARAM_INT(type);
 	PARAM_INT(flags);
 	ACTION_RETURN_POINTER(GetTextureCanvas(texturename, static_cast<ETextureType>(type), flags));
+}
+
+DEFINE_ACTION_FUNCTION(_TexMan, ResetAnimationTimer)
+{
+	PARAM_PROLOGUE;
+	PARAM_INT(texid);
+	FTextureID textureid;
+	textureid.SetIndex(texid);
+	ACTION_RETURN_BOOL(TexAnim.ResetTimerForTexture(textureid));
 }
 
 //=====================================================================================

--- a/src/gamedata/textures/animations.cpp
+++ b/src/gamedata/textures/animations.cpp
@@ -148,6 +148,27 @@ FAnimDef *FTextureAnimator::AddComplexAnim (FTextureID picnum, const TArray<FAni
 	return AddAnim (anim);
 }
 
+
+
+//==========================================================================
+//
+// Find and return an animation by base texture ID
+//
+//==========================================================================
+
+FAnimDef *FTextureAnimator::FindAnim(FTextureID picnum)
+{
+	unsigned int i;
+
+	for (i = 0; i < mAnimations.Size(); ++i)
+	{
+		if (picnum == mAnimations[i].BasePic)
+			return &mAnimations[i];
+	}
+
+	return NULL;
+}
+
 //==========================================================================
 //
 // FTextureAnimator :: Initanimated
@@ -1185,6 +1206,23 @@ void FTextureAnimator::UpdateAnimations (uint64_t mstime)
 	}
 }
 
+void FTextureAnimator::ResetTimer(FAnimDef &anim)
+{
+	anim.SwitchTime = 0u;
+	anim.CurFrame   = 0u;
+	if (anim.AnimType == FAnimDef::ANIM_OscillateDown)
+		anim.AnimType = FAnimDef::ANIM_OscillateUp;
+	if (anim.bDiscrete)
+	{
+		TexMan.SetTranslation(anim.BasePic, anim.Frames[anim.CurFrame].FramePic);
+	}
+	else
+	{
+		for (size_t i = 0u; i < anim.NumFrames; ++i)
+			TexMan.SetTranslation(anim.BasePic + i, anim.BasePic + (i + anim.CurFrame) % anim.NumFrames);
+	}
+}
+
 void FTextureAnimator::ResetTimers()
 {
 	for (auto& fire : mFireTextures)
@@ -1198,20 +1236,22 @@ void FTextureAnimator::ResetTimers()
 	}
 	for (auto& anim : mAnimations)
 	{
-		anim.SwitchTime = 0u;
-		anim.CurFrame   = 0u;
-		if (anim.AnimType == FAnimDef::ANIM_OscillateDown)
-			anim.AnimType = FAnimDef::ANIM_OscillateUp;
-		if (anim.bDiscrete)
+		ResetTimer(anim);
+	}
+}
+
+bool FTextureAnimator::ResetTimerForTexture(FTextureID texture)
+{
+	if (texture.isValid())
+	{
+		FAnimDef *anim = FindAnim(texture);
+		if (anim != nullptr)
 		{
-			TexMan.SetTranslation(anim.BasePic, anim.Frames[anim.CurFrame].FramePic);
-		}
-		else
-		{
-			for (size_t i = 0u; i < anim.NumFrames; ++i)
-				TexMan.SetTranslation(anim.BasePic + i, anim.BasePic + (i + anim.CurFrame) % anim.NumFrames);
+			ResetTimer(*anim);
+			return true;
 		}
 	}
+	return false;
 }
 
 //==========================================================================

--- a/src/gamedata/textures/animations.h
+++ b/src/gamedata/textures/animations.h
@@ -128,6 +128,7 @@ class FTextureAnimator
 	FSwitchDef* ParseSwitchDef(FScanner& sc, bool ignoreBad);
 	void AddSwitchPair(FSwitchDef* def1, FSwitchDef* def2);
 	void ParseAnimatedDoor(FScanner& sc);
+	void ResetTimer(FAnimDef &anim);
 
 public:
 
@@ -143,6 +144,7 @@ public:
 	FAnimDef* AddSimpleAnim(FTextureID picnum, int animcount, uint32_t speedmin, uint32_t speedrange = 0);
 	FAnimDef* AddComplexAnim(FTextureID picnum, const TArray<FAnimDef::FAnimFrame>& frames);
 
+	FAnimDef* FindAnim(FTextureID texture);
 	FSwitchDef* FindSwitch(FTextureID texture);
 	FDoorAnimation* FindAnimatedDoor(FTextureID picnum);
 	void UpdateAnimations(uint64_t mstime);
@@ -161,6 +163,7 @@ public:
 	bool InitStandaloneAnimation(FStandaloneAnimation &animInfo, FTextureID tex, uint32_t curTic);
 	FTextureID UpdateStandaloneAnimation(FStandaloneAnimation &animInfo, double curTic);
 	void ResetTimers();
+	bool ResetTimerForTexture(FTextureID texture);
 };
 
 extern FTextureAnimator TexAnim;

--- a/wadsrc/static/zscript/engine/base.zs
+++ b/wadsrc/static/zscript/engine/base.zs
@@ -342,6 +342,7 @@ struct TexMan
 	native static bool OkForLocalization(TextureID patch, String textSubstitute);
 	native static bool UseGamePalette(TextureID tex);
 	native static Canvas GetCanvas(String texture, int usetype = Type_Wall, int flags = 0);
+	native static bool ResetAnimationTimer(TextureID tex);
 }
 
 /*


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

## What the is this?
I've been tinkering with using ANIMDEFS for ZScript UI stuff (Supplice terminals, to be specific), and it works pretty damn great, except for one missing piece: the ability to restart an animation from the beginning (e.g. for triggering an animation when the player opens a menu page, or somesuch). This PR adds a quick function to TexMan in ZScript to do just that, which smooths it out rather nicely without having to write an entire second animation system in ZScript to redo what ANIMDEFS already does.

[Side note: I could see this being extended to a general "SetAnimationTime" function, but that requires a bit more housekeeping, i.e. jumping to the middle of the animation sequence based on the specified time; I'm just keeping it simple for now.]

Feedback welcome, since I haven't tinkered with this area of code before and FTextureID is a bit fiddly to work with.