### PR TITLE
OG Blood_Flade_Scalar levels implemented

### DIFF
--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -40,7 +40,7 @@
 #include "v_draw.h"
 
 CVAR(Float, underwater_fade_scalar, 1.0f, CVAR_ARCHIVE) // [Nash] user-settable underwater blend intensity
-CVAR( Float, blood_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Pulled from Skulltag - changed default from 0.5 to 1.0
+CVAR( Float, blood_fade_scalar, 0.8f, CVAR_ARCHIVE )	// [SP] Pulled from Skulltag - changed default from 0.5 to 1.0 (changed again from 1.0 to 0.8)
 CVAR( Float, pickup_fade_scalar, 1.0f, CVAR_ARCHIVE )	// [SP] Uses same logic as blood_fade_scalar except for pickups
 CVAR(Float, powerup_fade_scalar, 1.0f, CVAR_ARCHIVE) // [Sal] Adjust screen fades for all inventory items
 
@@ -133,7 +133,7 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 
 	if (painFlash.a != 0)
 	{
-		cnt = DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)];
+		cnt = (DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)]) * 1.20; // "1.20" is here as a "20%" increase (default "blood_fade_scalar" 100% -> 80%, so 100% is now like the old-school red blend)
 
 		// [BC] Allow users to tone down the intensity of the blood on the screen.
 		cnt = (int)( cnt * blood_fade_scalar );
@@ -333,7 +333,7 @@ FVector4 V_CalcBlend(sector_t* viewsector, PalEntry* modulateColor)
 
 	if (player)
 	{
-		V_AddPlayerBlend(player, blend, 0.5, 175);
+		V_AddPlayerBlend(player, blend, 0.8, 225);
 	}
 
 	if (players[consoleplayer].camera != NULL)

--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -143,6 +143,9 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 			if (bloodcnt > maxpainblend)
 				bloodcnt = maxpainblend;
 
+			if (bloodcnt > maxinvalpha)
+				maxinvalpha = bloodcnt;
+
 			V_AddBlend (painFlash.r / 255.f, painFlash.g / 255.f, painFlash.b / 255.f, bloodcnt / 255.f, blend);
 		}
 	}
@@ -203,7 +206,7 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 	}
 
 	// cap opacity if desired
-	if (blend[3] > maxinvalpha && bloodcnt < 160) blend[3] = maxinvalpha; // "bloodcnt < 160" allows an exception to the red pain flash effect
+	if (blend[3] > maxinvalpha) blend[3] = maxinvalpha;
 }
 
 //==========================================================================

--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -88,7 +88,7 @@ void V_AddBlend (float r, float g, float b, float a, float v_blend[4])
 
 void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int maxpainblend)
 {
-	int cnt;
+	int cnt, bloodcnt;
 	auto Level = CPlayer->mo->Level;
 
 	// [RH] All powerups can affect the screen blending now
@@ -133,17 +133,17 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 
 	if (painFlash.a != 0)
 	{
-		cnt = (DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)]) * 1.20; // "1.20" is here as a "20%" increase (default "blood_fade_scalar" 100% -> 80%, so 100% is now like the old-school red blend)
+		bloodcnt = (DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)]) * 1.20; // "1.20" is here as a "20%" increase (default "blood_fade_scalar" 100% -> 80%, so 100% is now like the old-school red blend)
 
 		// [BC] Allow users to tone down the intensity of the blood on the screen.
-		cnt = (int)( cnt * blood_fade_scalar );
+		bloodcnt = (int)( bloodcnt * blood_fade_scalar );
 
-		if (cnt)
+		if (bloodcnt)
 		{
-			if (cnt > maxpainblend)
-				cnt = maxpainblend;
+			if (bloodcnt > maxpainblend)
+				bloodcnt = maxpainblend;
 
-			V_AddBlend (painFlash.r / 255.f, painFlash.g / 255.f, painFlash.b / 255.f, cnt / 255.f, blend);
+			V_AddBlend (painFlash.r / 255.f, painFlash.g / 255.f, painFlash.b / 255.f, bloodcnt / 255.f, blend);
 		}
 	}
 
@@ -203,7 +203,7 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 	}
 
 	// cap opacity if desired
-	if (blend[3] > maxinvalpha) blend[3] = maxinvalpha;
+	if (blend[3] > maxinvalpha && bloodcnt < 160) blend[3] = maxinvalpha; // "bloodcnt < 160" allows an exception to the red pain flash effect
 }
 
 //==========================================================================
@@ -333,7 +333,7 @@ FVector4 V_CalcBlend(sector_t* viewsector, PalEntry* modulateColor)
 
 	if (player)
 	{
-		V_AddPlayerBlend(player, blend, 0.8, 225);
+		V_AddPlayerBlend(player, blend, 0.5, 225);
 	}
 
 	if (players[consoleplayer].camera != NULL)

--- a/src/rendering/2d/v_blend.cpp
+++ b/src/rendering/2d/v_blend.cpp
@@ -133,10 +133,10 @@ void V_AddPlayerBlend (player_t *CPlayer, float blend[4], float maxinvalpha, int
 
 	if (painFlash.a != 0)
 	{
-		bloodcnt = (DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)]) * 1.20; // "1.20" is here as a "20%" increase (default "blood_fade_scalar" 100% -> 80%, so 100% is now like the old-school red blend)
+		bloodcnt = (DamageToAlpha[min (CPlayer->damagecount * painFlash.a / 255, (uint32_t)113)]);
 
 		// [BC] Allow users to tone down the intensity of the blood on the screen.
-		bloodcnt = (int)( bloodcnt * blood_fade_scalar );
+		bloodcnt = (int)( bloodcnt * (blood_fade_scalar  + 0.2)); // "0.2" is here as a "20%" increase (default "blood_fade_scalar" 100% -> 80%, so 100% is now like the old-school red blend)
 
 		if (bloodcnt)
 		{


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

Closes #1576

This one change here I believe we need to rethink: `V_AddPlayerBlend(player, blend, 0.5, 175);` -> `V_AddPlayerBlend(player, blend, 0.8, 225);`

The fourth parameter (175 -> 225) is "maxpainblend", which is fine to change as it only affects the red pain effect. However the third parameter (0.5 -> 0.8) is "maxinvalpha", which affects other effects, by being an opacity cap:

`// cap opacity if desired`
`if (blend[3] > maxinvalpha) blend[3] = maxinvalpha;`

I have tested other effects and everything appears to be unaffected, but I believe it would be a good idea to handle this a different way just to be sure, I just don't quite know how...

If anyone has any feedback/idea I'm very much open :)


EDIT: I preserved the opacity cap as 0.5 by using a new variable "bloodcnt", which creates an exception to the opacity cap only when the pain effect is at its most intense levels (aka when it's blinding the player)
