### PR TITLE
Skip remarks column when parsing csv

### DIFF
--- a/src/common/engine/stringtable.cpp
+++ b/src/common/engine/stringtable.cpp
@@ -519,6 +519,10 @@ bool FStringTable::ParseLanguageCSV(int filenum, const char* buffer, size_t size
 			{
 				labelcol = column;
 			}
+			else if (entry.CompareNoCase("remarks") == 0)
+			{
+				continue;
+			}
 			else
 			{
 				auto languages = entry.Split(" ", FString::TOK_SKIPEMPTY);


### PR DESCRIPTION
Having remarks filled in was causing a crash in some instances

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
