### PR TITLE
Explicitly set X11 WM_CLASS/Wayland app_id

### DIFF
--- a/src/common/platform/posix/sdl/i_main.cpp
+++ b/src/common/platform/posix/sdl/i_main.cpp
@@ -206,6 +206,8 @@ int main (int argc, char **argv)
 #endif
 */
 
+	// despite the name, this also sets the wayland app_id
+	SDL_SETENV("SDL_VIDEO_X11_WMCLASS", APPID);
 	if (SDL_Init (0) < 0)
 	{
 		fprintf (stderr, "Could not initialize SDL:\n%s\n", SDL_GetError());

--- a/src/posix/freedesktop/org.zdoom.UZDoom.desktop
+++ b/src/posix/freedesktop/org.zdoom.UZDoom.desktop
@@ -11,6 +11,7 @@ Type=Application
 Keywords=Doom;Heretic;Hexen;strife;pwad;iwad;first;person;shooter;
 MimeType=application/x-doom-wad;application/x-doom-pk7;application/x-doom-pk3;
 Actions=launch-safemode;launch-doom-1;launch-doom-2;launch-heretic;launch-hexen;launch-strife;
+StartupWMClass=org.zdoom.UZDoom
 
 [Desktop Action launch-safemode]
 Name=UZDoom Safemode


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

This PR sets the Wayland app_id and X11 WM_CLASS to org.zdoom.UZDoom, and adds the StartupWMClass to the desktop file. The latter fixes issues on GNOME where, under certain circumstances, the desktop file will be unable to be matched to the window. Just setting the StartupWMClass isn't a stable solution, because SDL by default makes the app_id/WM_CLASS be the name of the executable (for example, the executable name changed from uzdoom.bin to uzdoom between 4.14.3 and 5.0-rc1), so it is best to explicitly set it instead. Reverse DNS names, just the same as what is recommended or required by many other Freedesktop and adjacent standards, is the recommended form for this to take.

BTW the CONTRIBUTING.md link doesn't seem quite right, it took me here while editing: https://github.com/UZDoom/UZDoom/compare/blob/trunk/CONTRIBUTING.md
