### PR TITLE
Fixes for drag and drop file behavior in the launcher

### DIFF
--- a/libraries/ZWidget/include/zwidget/core/widget.h
+++ b/libraries/ZWidget/include/zwidget/core/widget.h
@@ -248,6 +248,7 @@ private:
 	Widget* CaptureWidget = nullptr;
 	Widget* HoverWidget = nullptr;
 	bool HiddenFlag = false;
+	bool Dropping = false;
 
 	StandardCursor CurrentCursor = StandardCursor::arrow;
 

--- a/libraries/ZWidget/src/core/widget.cpp
+++ b/libraries/ZWidget/src/core/widget.cpp
@@ -921,7 +921,14 @@ void Widget::OnWindowDpiScaleChanged()
 
 bool Widget::OnFileDrop(std::string path)
 {
-	return (FocusWidget && FocusWidget->OnFileDrop(path)) || (ParentObj && ParentObj->OnFileDrop(path));
+	bool res = false;
+	if (!Dropping)
+	{
+		Dropping = true;
+		res = (FocusWidget && FocusWidget->OnFileDrop(path)) || (ParentObj && ParentObj->OnFileDrop(path));
+	}
+	Dropping = false;
+	return res;
 }
 
 double Widget::GetDpiScale() const

--- a/src/widgets/playgamepage.cpp
+++ b/src/widgets/playgamepage.cpp
@@ -100,9 +100,9 @@ bool PlayGamePage::OnFileDrop(std::string path)
 {
 	auto text = ParametersEdit->GetText();
 	if (!text.empty()) text += " ";
-	text += "-file '";
+	text += "-file \"";
 	text += path;
-	text += "'";
+	text += "\"";
 	ParametersEdit->SetText(text);
 	return true;
 }


### PR DESCRIPTION
This fixes #1641 which was a stack overflow being caused by a recursive call. Also switches to `"` instead of `'` when appending file paths since I'm not entirely sure that was supported? I've only ever seen `"` used for encapsulating paths.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
