### PR TITLE
Multiplayer tab improvements

### DIFF
--- a/libraries/ZWidget/src/widgets/tabwidget/tabwidget.cpp
+++ b/libraries/ZWidget/src/widgets/tabwidget/tabwidget.cpp
@@ -94,6 +94,7 @@ void TabWidget::OnBarCurrentChanged()
 {
 	int pageIndex = Bar->GetCurrentIndex();
 	PageStack->SetCurrentWidget(Pages[pageIndex]);
+	GetCurrentWidget()->SetFocus();
 	if (OnCurrentChanged)
 		OnCurrentChanged();
 }

--- a/src/widgets/networkpage.cpp
+++ b/src/widgets/networkpage.cpp
@@ -34,6 +34,7 @@ constexpr double EditHeight = 24.0;
 
 NetworkPage::NetworkPage(LauncherWindow* launcher, const FStartupSelectionInfo& info) : Widget(nullptr), Launcher(launcher)
 {
+	SelectLabel = new TextLabel(this);
 	ParametersEdit = new LineEdit(this);
 	ParametersLabel = new TextLabel(this);
 	SaveFileEdit = new LineEdit(this);
@@ -160,8 +161,11 @@ void NetworkPage::OnGeometryChanged()
 	const double h = GetHeight();
 
 	double y = 0.0;
+	SelectLabel->SetFrameGeometry(0.0, y, w, SelectLabel->GetPreferredHeight());
+	y += SelectLabel->GetPreferredHeight();
+
 	IWADsDropdown->SetFrameGeometry(0.0, y, w, IWADsDropdown->GetPreferredHeight());
-	y += IWADsDropdown->GetPreferredHeight() + 7.0;
+	y += IWADsDropdown->GetPreferredHeight() + 12.0;
 	const double pageTop = y;
 
 	y = h - SaveFileCheckbox->GetPreferredHeight();
@@ -193,6 +197,7 @@ void NetworkPage::OnGeometryChanged()
 
 void NetworkPage::UpdateLanguage()
 {
+	SelectLabel->SetText(GStrings.GetString("PICKER_SELECT"));
 	ParametersLabel->SetText(GStrings.GetString("PICKER_ADDPARM"));
 	SaveFileLabel->SetText(GStrings.GetString("PICKER_LOADSAVE"));
 	SaveFileCheckbox->SetText(GStrings.GetString("PICKER_REMSAVE"));

--- a/src/widgets/networkpage.cpp
+++ b/src/widgets/networkpage.cpp
@@ -105,6 +105,17 @@ void NetworkPage::OnSetFocus()
 	IWADsDropdown->SetFocus();
 }
 
+bool NetworkPage::OnFileDrop(std::string path)
+{
+	auto text = ParametersEdit->GetText();
+	if (!text.empty()) text += " ";
+	text += "-file \"";
+	text += path;
+	text += "\"";
+	ParametersEdit->SetText(text);
+	return true;
+}
+
 void NetworkPage::SetValues(FStartupSelectionInfo& info) const
 {
 	info.DefaultNetIWAD = IWADsDropdown->GetSelectedItem();

--- a/src/widgets/networkpage.h
+++ b/src/widgets/networkpage.h
@@ -60,6 +60,7 @@ private:
 	JoinSubPage* JoinPage = nullptr;
 	TabWidget* StartPages = nullptr;
 
+	TextLabel* SelectLabel = nullptr;
 	TextLabel* ParametersLabel = nullptr;
 	LineEdit* ParametersEdit = nullptr;
 	CheckboxLabel* SaveParametersCheckbox = nullptr;

--- a/src/widgets/networkpage.h
+++ b/src/widgets/networkpage.h
@@ -47,6 +47,7 @@ private:
 	void OnGeometryChanged() override;
 	void OnSetFocus() override;
 	void OnIWADsListActivated();
+	bool OnFileDrop(std::string) override;
 
 	LauncherWindow* Launcher = nullptr;
 


### PR DESCRIPTION
This is a small set of changes designed to make the multiplayer tab more functional including adding the drag and drop file support to it (#1643) alongside trying to improve clarity around the IWAD selector. This also fixes tabs not getting focused when being selected which allowed for odd behaviors like dragging and dropping files adding to hidden tabs. Previously an element within the tab had to be interacted with before it would gain focus, making this drag and drop behavior inconsistent.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
