### PR TITLE
Removed \ from cmdline arg parsing

### DIFF
--- a/src/common/utility/m_argv.cpp
+++ b/src/common/utility/m_argv.cpp
@@ -619,19 +619,12 @@ void FArgs::AppendRawArgsString(FString argv)
 			lastQuoteType = argv[i];
 			tmp += argv.Mid(lastSection, i - lastSection);
 			has_tmp = true;
-			bool wasSlash = false;
 
-			for(i++; (argv[i] != lastQuoteType || wasSlash) && i < argv.Len(); i++)
+			for(i++; argv[i] != lastQuoteType && i < argv.Len(); i++)
 			{
-				if(i == '\\' && !wasSlash)
-				{
-					wasSlash = true;
-				}
-				else
-				{
-					tmp += argv[i];
-					wasSlash = false;
-				}
+				// Previously this attempted to support \ but did so in such an erroneous
+				// way that fixing it breaks the current parsing.
+				tmp += argv[i];
 			}
 			lastSection = i + 1;
 		}


### PR DESCRIPTION
This was always broken and fixing it breaks too many current systems that expect it now. Fixes #1367.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
