### PR TITLE
Debugger fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,10 +267,6 @@ if (CURL_REQUIRED)
 	endif()
 endif()
 
-if (NOT FORCE_INTERNAL_CPPDAP)
-	find_package( cppdap CONFIG )
-endif()
-
 include( TargetArch )
 
 target_architecture(TARGET_ARCHITECTURE)

--- a/src/common/scripting/dap/PexCache.cpp
+++ b/src/common/scripting/dap/PexCache.cpp
@@ -36,7 +36,7 @@ namespace DebugServer
 static void NormalizeArchivePath(std::string &path)
 {
 	auto it = path.find(':');
-	if (it != std::string::npos && (it == 1 && path.size() >= 2 && path[2] == '\\')) // make sure it's not a windows path
+	if (it != std::string::npos && (it == 1 && path.size() >= 2 && (path[2] == '\\' || path[2] == '/'))) // make sure it's not a windows path
 	{
 		it = path.find(':', 3);
 	}


### PR DESCRIPTION
* We shouldn't allow using the non-vendored cppdap, we rely on patches in our version that are still on hanging PRs
* Fixes normalizing windows paths that contain a drive name and forward slashes


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
