### PR TITLE
Added theme preference to the launcher

### DIFF
--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -83,6 +83,7 @@ EXTERN_CVAR(Bool, vid_fullscreen)
 EXTERN_CVAR(Bool, vid_vsync)
 EXTERN_CVAR(Bool, r_dynlights)
 EXTERN_CVAR(Bool, gl_light_shadowmap)
+EXTERN_CVAR(Int, ui_preferred_theme)
 
 #ifdef HAS_UPDATER
 EXTERN_CVAR(Int, updater_update_interval)
@@ -110,6 +111,7 @@ FStartupSelectionInfo::FStartupSelectionInfo(const TArray<WadStuff>& wads, FArgs
 	DefaultVsync = vid_vsync;
 	DefaultDynLights = r_dynlights;
 	DefaultShadowmaps = gl_light_shadowmap;
+	DefaultPreferredTheme = ui_preferred_theme;
 
 	if (defaultiwad[0] != '\0')
 	{
@@ -191,6 +193,7 @@ int FStartupSelectionInfo::SaveInfo()
 	vid_vsync = DefaultVsync;
 	r_dynlights = DefaultDynLights;
 	gl_light_shadowmap = DefaultShadowmaps;
+	ui_preferred_theme = DefaultPreferredTheme;
 	if (DefaultBackend != vid_preferbackend)
 		vid_preferbackend = DefaultBackend;
 

--- a/src/common/engine/i_interface.cpp
+++ b/src/common/engine/i_interface.cpp
@@ -197,33 +197,32 @@ int FStartupSelectionInfo::SaveInfo()
 	if (DefaultBackend != vid_preferbackend)
 		vid_preferbackend = DefaultBackend;
 
+	savenetfile = bSaveNetFile;
+	savenetargs = bSaveNetArgs;
+
+	defaultnetiwad = (*Wads)[DefaultNetIWAD].Name.GetChars();
+	defaultnetpage = DefaultNetPage;
+	defaultnetsavefile = savenetfile ? DefaultNetSaveFile.GetChars() : "";
+	defaultnetargs = savenetargs ? DefaultNetArgs.GetChars() : "";
+
+	defaultnetplayers = DefaultNetPlayers;
+	defaultnethostport = DefaultNetHostPort;
+	defaultnetticdup = DefaultNetTicDup;
+	defaultnetgamemode = DefaultNetGameMode;
+	defaultnetaltdm = DefaultNetAltDM;
+	defaultnethostteam = DefaultNetHostTeam;
+	defaultnetextratic = DefaultNetExtraTic;
+
+	defaultnetaddress = DefaultNetAddress.GetChars();
+	defaultnetjoinport = DefaultNetJoinPort;
+	defaultnetjointeam = DefaultNetJoinTeam;
+
+	defaultiwad = (*Wads)[DefaultIWAD].Name.GetChars();
+	saveargs = bSaveArgs;
+	defaultargs = saveargs ? DefaultArgs.GetChars() : "";
+
 	if (bNetStart)
 	{
-		savenetfile = bSaveNetFile;
-		savenetargs = bSaveNetArgs;
-
-		defaultnetiwad = (*Wads)[DefaultNetIWAD].Name.GetChars();
-		defaultnetpage = DefaultNetPage;
-		defaultnetsavefile = savenetfile ? DefaultNetSaveFile.GetChars() : "";
-		defaultnetargs = savenetargs ? DefaultNetArgs.GetChars() : "";
-
-		if (bHosting)
-		{
-			defaultnetplayers = DefaultNetPlayers;
-			defaultnethostport = DefaultNetHostPort;
-			defaultnetticdup = DefaultNetTicDup;
-			defaultnetgamemode = DefaultNetGameMode;
-			defaultnetaltdm = DefaultNetAltDM;
-			defaultnethostteam = DefaultNetHostTeam;
-			defaultnetextratic = DefaultNetExtraTic;
-		}
-		else
-		{
-			defaultnetaddress = DefaultNetAddress.GetChars();
-			defaultnetjoinport = DefaultNetJoinPort;
-			defaultnetjointeam = DefaultNetJoinTeam;
-		}
-
 		if (!DefaultNetArgs.IsEmpty())
 			Args->AppendRawArgsString(DefaultNetArgs);
 		if (!AdditionalNetArgs.IsEmpty())
@@ -231,10 +230,6 @@ int FStartupSelectionInfo::SaveInfo()
 
 		return DefaultNetIWAD;
 	}
-
-	defaultiwad = (*Wads)[DefaultIWAD].Name.GetChars();
-	saveargs = bSaveArgs;
-	defaultargs = saveargs ? DefaultArgs.GetChars() : "";
 
 	if (!DefaultArgs.IsEmpty())
 		Args->AppendRawArgsString(DefaultArgs);

--- a/src/common/engine/i_interface.h
+++ b/src/common/engine/i_interface.h
@@ -107,6 +107,7 @@ struct FStartupSelectionInfo
 	int DefaultFileLoadBehaviour = 0;
 	bool DefaultDynLights = true;
 	bool DefaultShadowmaps = false;
+	int DefaultPreferredTheme = 0;
 
 	// Net game info
 	int DefaultNetIWAD = 0;

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -859,27 +859,25 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 			info.LauncherHeight = ui_launcher_height;
 		}
 
-		if (I_PickIWad((queryiwad || showlauncher) || HoldingQueryKey(queryiwad_key), info))
+		const bool pickRes = I_PickIWad(queryiwad || showlauncher || HoldingQueryKey(queryiwad_key), info);
+		pick = info.SaveInfo();
+		disableautoload = !!(info.DefaultStartFlags & 1);
+		autoloadlights = !!(info.DefaultStartFlags & 2);
+		autoloadbrightmaps = !!(info.DefaultStartFlags & 4);
+		autoloadwidescreen = !!(info.DefaultStartFlags & 8);
+		i_loadsupportwad = !!(info.DefaultStartFlags & 16);
+		i_exit_on_not_found = info.DefaultFileLoadBehaviour;
+		if (!info.notifyNewRelease)
+			i_display_new_release = 0; // don't change truthy values
+		if (ui_remember_size)
 		{
-			pick = info.SaveInfo();
-			disableautoload = !!(info.DefaultStartFlags & 1);
-			autoloadlights = !!(info.DefaultStartFlags & 2);
-			autoloadbrightmaps = !!(info.DefaultStartFlags & 4);
-			autoloadwidescreen = !!(info.DefaultStartFlags & 8);
-			i_loadsupportwad = !!(info.DefaultStartFlags & 16);
-			i_exit_on_not_found = info.DefaultFileLoadBehaviour;
-			if (!info.notifyNewRelease)
-				i_display_new_release = 0; // don't change truthy values
-			if (ui_remember_size)
-			{
-				ui_launcher_width = info.LauncherWidth;
-				ui_launcher_height = info.LauncherHeight;
-			}
+			ui_launcher_width = info.LauncherWidth;
+			ui_launcher_height = info.LauncherHeight;
 		}
-		else
-		{
+
+		if (!pickRes)
 			return -1;
-		}
+
 		havepicked = true;
 	}
 

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -4116,12 +4116,12 @@ static int D_DoomMain_Internal (void)
 		std::vector<FileSys::ResourceName> allwads;
 
 		const FIWADInfo *iwad_info = iwad_man->FindIWAD(allwads, iwad.GetChars(), basewad.GetChars(), optionalwad.GetChars());
+		if (!iwad_info) return 0;	// user exited the selection popup via cancel button.
 
 		GetCmdLineFiles(pwads, false); // [RL0] Update with files passed on the launcher extra args
 		// For now these need to remain verifiable over the network.
 		GetCmdLineFiles(pwads, true);
 
-		if (!iwad_info) return 0;	// user exited the selection popup via cancel button.
 		if ((iwad_info->flags & GI_SHAREWARE) && pwads.size() > 0)
 		{
 			I_FatalError ("You cannot -file or -optfile with the shareware version. Register!");

--- a/src/widgets/launcherwindow.cpp
+++ b/src/widgets/launcherwindow.cpp
@@ -152,25 +152,27 @@ bool LauncherWindow::IsHosting() const
 	return IsInMultiplayer() && Network->IsInHost();
 }
 
-void LauncherWindow::Start()
+void LauncherWindow::SetValues()
 {
 	Info->bNetStart = IsInMultiplayer();
 
 	Settings->SetValues(*Info);
-	if (Info->bNetStart)
-		Network->SetValues(*Info);
-	else
-		PlayGame->SetValues(*Info);
-
+	Network->SetValues(*Info);
+	PlayGame->SetValues(*Info);
 	if (Release)
 		Release->SetValues(*Info);
+}
 
+void LauncherWindow::Start()
+{
+	SetValues();
 	ExecResult = true;
 	DisplayWindow::ExitLoop();
 }
 
 void LauncherWindow::Exit()
 {
+	SetValues();
 	ExecResult = false;
 	DisplayWindow::ExitLoop();
 }

--- a/src/widgets/launcherwindow.h
+++ b/src/widgets/launcherwindow.h
@@ -54,6 +54,7 @@ public:
 	void ForceCheckUpdate();
 
 private:
+	void SetValues();
 	void OnClose() override;
 	void OnGeometryChanged() override;
 	void OnWindowClose() override;

--- a/src/widgets/networkpage.cpp
+++ b/src/widgets/networkpage.cpp
@@ -123,26 +123,24 @@ void NetworkPage::SetValues(FStartupSelectionInfo& info) const
 	info.DefaultNetArgs = ParametersEdit->GetText();
 
 	info.bHosting = IsInHost();
-	if (info.bHosting)
-	{
-		info.DefaultNetPage = 0;
-		HostPage->SetValues(info);
-	}
-	else
-	{
-		info.DefaultNetPage = 1;
-		JoinPage->SetValues(info);
-	}
+	info.DefaultNetPage = info.bHosting ? 0 : 1;
+
+	HostPage->SetValues(info);
+	JoinPage->SetValues(info);
 
 	info.bSaveNetFile = SaveFileCheckbox->GetChecked();
 	info.bSaveNetArgs = SaveParametersCheckbox->GetChecked();
 	const auto save = SaveFileEdit->GetText();
-	if (!save.empty())
-		info.AdditionalNetArgs.AppendFormat(" -loadgame \"%s\"", save.c_str());
-	const auto pClass = PlayerClassEdit->GetText();
-	if (!pClass.empty())
-		info.AdditionalNetArgs.AppendFormat(" +playerclass \"%s\"", pClass.c_str());
 	info.DefaultNetSaveFile = save;
+
+	if (info.bNetStart)
+	{
+		if (!save.empty())
+			info.AdditionalNetArgs.AppendFormat(" -loadgame \"%s\"", save.c_str());
+		const auto pClass = PlayerClassEdit->GetText();
+		if (!pClass.empty())
+			info.AdditionalNetArgs.AppendFormat(" +playerclass \"%s\"", pClass.c_str());
+	}
 }
 
 void NetworkPage::UpdatePlayButton()
@@ -266,23 +264,23 @@ HostSubPage::HostSubPage(NetworkPage* main, const FStartupSelectionInfo& info) :
 
 void HostSubPage::SetValues(FStartupSelectionInfo& info) const
 {
-	info.AdditionalNetArgs = "";
+	FString tempArgs = {};
 
 	info.DefaultNetExtraTic = ExtraTicCheckbox->GetChecked();
 	if (info.DefaultNetExtraTic)
-		info.AdditionalNetArgs.AppendFormat(" -extratic");
+		tempArgs.AppendFormat(" -extratic");
 
 	const int dup = TicDupDropdown->GetSelectedItem();
 	if (dup > 0)
-		info.AdditionalNetArgs.AppendFormat(" -dup %d", dup + 1);
+		tempArgs.AppendFormat(" -dup %d", dup + 1);
 	info.DefaultNetTicDup = dup;
 
 	info.DefaultNetPlayers = clamp<int>(MaxPlayersEdit->GetTextInt(), 1, MAXPLAYERS);
-	info.AdditionalNetArgs.AppendFormat(" -host %d", info.DefaultNetPlayers);
+	tempArgs.AppendFormat(" -host %d", info.DefaultNetPlayers);
 	const int port = clamp<int>(PortEdit->GetTextInt(), 0, UINT16_MAX);
 	if (port > 0)
 	{
-		info.AdditionalNetArgs.AppendFormat(" -port %d", port);
+		tempArgs.AppendFormat(" -port %d", port);
 		info.DefaultNetHostPort = port;
 	}
 	else
@@ -295,11 +293,11 @@ void HostSubPage::SetValues(FStartupSelectionInfo& info) const
 	switch (info.DefaultNetGameMode)
 	{
 	case 1:
-		info.AdditionalNetArgs.AppendFormat(" -coop");
+		tempArgs.AppendFormat(" -coop");
 		break;
 	case 3:
 		{
-			info.AdditionalNetArgs.AppendFormat(" +teamplay 1");
+			tempArgs.AppendFormat(" +teamplay 1");
 			int team = 255;
 			if (!TeamEdit->GetText().empty())
 			{
@@ -307,16 +305,19 @@ void HostSubPage::SetValues(FStartupSelectionInfo& info) const
 				if (team < 0 || team > 255)
 					team = 255;
 			}
-			info.AdditionalNetArgs.AppendFormat(" +team %d", team);
+			tempArgs.AppendFormat(" +team %d", team);
 			info.DefaultNetHostTeam = team;
 		}
 	case 2:
 		if (AltDeathmatchCheckbox->GetChecked())
-			info.AdditionalNetArgs.AppendFormat(" -altdeath");
+			tempArgs.AppendFormat(" -altdeath");
 		else
-			info.AdditionalNetArgs.AppendFormat(" -deathmatch");
+			tempArgs.AppendFormat(" -deathmatch");
 		break;
 	}
+
+	if (info.bNetStart && info.bHosting)
+		info.AdditionalNetArgs = tempArgs;
 }
 
 void HostSubPage::UpdateLanguage()
@@ -419,6 +420,8 @@ JoinSubPage::JoinSubPage(NetworkPage* main, const FStartupSelectionInfo& info) :
 
 void JoinSubPage::SetValues(FStartupSelectionInfo& info) const
 {
+	FString tempArgs = {};
+
 	FString addr = AddressEdit->GetText();
 	info.DefaultNetAddress = addr;
 	const int port = clamp<int>(AddressPortEdit->GetTextInt(), 0, UINT16_MAX);
@@ -432,8 +435,7 @@ void JoinSubPage::SetValues(FStartupSelectionInfo& info) const
 		info.DefaultNetJoinPort = 0;
 	}
 
-	info.AdditionalNetArgs = "";
-	info.AdditionalNetArgs.AppendFormat(" -join %s", addr.GetChars());
+	tempArgs.AppendFormat(" -join %s", addr.GetChars());
 
 	int team = 255;
 	if (!TeamEdit->GetText().empty())
@@ -442,8 +444,11 @@ void JoinSubPage::SetValues(FStartupSelectionInfo& info) const
 		if (team < 0 || team > 255)
 			team = 255;
 	}
-	info.AdditionalNetArgs.AppendFormat(" +team %d", team);
+	tempArgs.AppendFormat(" +team %d", team);
 	info.DefaultNetJoinTeam = team;
+
+	if (info.bNetStart && !info.bHosting)
+		info.AdditionalNetArgs = tempArgs;
 }
 
 void JoinSubPage::UpdateLanguage()

--- a/src/widgets/settingspage.cpp
+++ b/src/widgets/settingspage.cpp
@@ -57,6 +57,14 @@ SettingsPage::SettingsPage(LauncherWindow* launcher, const FStartupSelectionInfo
 	DynLightsCheckbox = new CheckboxLabel(this);
 	ShadowmapCheckbox = new CheckboxLabel(this);
 
+	ThemeLabel = new TextLabel(this);
+	ThemeDropdown = new Dropdown(this);
+	ThemeDropdown->SetMaxDisplayItems(3);
+	ThemeDropdown->AddItem(GStrings.GetString("OPTVAL_AUTO"));
+	ThemeDropdown->AddItem(GStrings.GetString("OPTVAL_DARK"));
+	ThemeDropdown->AddItem(GStrings.GetString("OPTVAL_LIGHT"));
+	ThemeDropdown->SetSelectedItem(info.DefaultPreferredTheme);
+
 	FullscreenCheckbox->SetChecked(info.DefaultFullscreen);
 	VsyncCheckbox->SetChecked(info.DefaultVsync);
 	DontAskAgainCheckbox->SetChecked(!info.DefaultQueryIWAD);
@@ -189,6 +197,8 @@ void SettingsPage::SetValues(FStartupSelectionInfo& info) const
 	info.DefaultQueryIWAD = !DontAskAgainCheckbox->GetChecked();
 	info.DefaultLanguage = languages[LangList->GetSelectedItem()].first.GetChars();
 
+	info.DefaultPreferredTheme = ThemeDropdown->GetSelectedItem();
+
 	int flags = 0;
 	if (DisableAutoloadCheckbox->GetChecked()) flags |= 1;
 	if (LightsCheckbox->GetChecked()) flags |= 2;
@@ -246,6 +256,11 @@ void SettingsPage::SetValues(FStartupSelectionInfo& info) const
 void SettingsPage::UpdateLanguage()
 {
 	GetCanvas()->setLanguage(GStrings.GetLangName().GetChars());
+
+	ThemeLabel->SetText(GStrings.GetString("PICKER_THEME"));
+	ThemeDropdown->UpdateItem(GStrings.GetString("OPTVAL_AUTO"), 0);
+	ThemeDropdown->UpdateItem(GStrings.GetString("OPTVAL_DARK"), 1);
+	ThemeDropdown->UpdateItem(GStrings.GetString("OPTVAL_LIGHT"), 2);
 
 	LangLabel->SetText(GStrings.GetString("OPTMNU_LANGUAGE"));
 	LoadLabel->SetText(GStrings.GetString("PICKER_FILELOADING"));
@@ -421,7 +436,13 @@ void SettingsPage::OnGeometryChanged()
 	y += LoadLabel->GetPreferredHeight();
 
 	LoadList->SetFrameGeometry(w - panelWidth, y, panelWidth, LoadList->GetPreferredHeight());
-	y += LoadLabel->GetPreferredHeight();
+	y += LoadList->GetPreferredHeight() + 10.0;
+
+	ThemeLabel->SetFrameGeometry(w - panelWidth, y, panelWidth, ThemeLabel->GetPreferredHeight());
+	y += ThemeLabel->GetPreferredHeight();
+
+	ThemeDropdown->SetFrameGeometry(w - panelWidth, y, panelWidth, ThemeDropdown->GetPreferredHeight());
+	y += ThemeDropdown->GetPreferredHeight() + 10.0;
 
 	const double bottomPanelWidth = w - panelWidth - 10.0;
 	y = bottomPanelTop;

--- a/src/widgets/settingspage.h
+++ b/src/widgets/settingspage.h
@@ -46,6 +46,7 @@ private:
 	TextLabel* GeneralLabel = nullptr;
 	TextLabel* ExtrasLabel = nullptr;
 	TextLabel* LoadLabel = nullptr;
+	TextLabel* ThemeLabel = nullptr;
 	CheckboxLabel* FullscreenCheckbox = nullptr;
 	CheckboxLabel* VsyncCheckbox = nullptr;
 	CheckboxLabel* DisableAutoloadCheckbox = nullptr;
@@ -56,6 +57,7 @@ private:
 	CheckboxLabel* SupportWadsCheckbox = nullptr;
 	CheckboxLabel* DynLightsCheckbox = nullptr;
 	CheckboxLabel* ShadowmapCheckbox = nullptr;
+	Dropdown* ThemeDropdown = nullptr;
 #ifdef RENDER_BACKENDS
 	TextLabel* BackendLabel = nullptr;
 	CheckboxLabel* VulkanCheckbox = nullptr;

--- a/src/widgets/widgetresourcedata.cpp
+++ b/src/widgets/widgetresourcedata.cpp
@@ -33,6 +33,15 @@ CUSTOM_CVARD(Int, ui_theme, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "launcher theme
 	if (self > 4) self = 4;
 }
 
+// This is the cvar exposed to the launcher to ensure that high-contrast themes don't break.
+CUSTOM_CVAR(Int, ui_preferred_theme, 0, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+{
+	if (self < 0)
+		self = 0;
+	else if (self > 2)
+		self = 2;
+}
+
 TDeletingArray<FResourceFile*>* WidgetResources = nullptr;
 
 bool IsZWidgetAvailable()
@@ -80,6 +89,13 @@ void InitWidgetResources(const char* filename)
 		break;
 	}		
 	auto use_dark = ui_theme == 1 || ui_theme == 3 || (ui_theme == 0 && (theme & Dark));
+	if (ui_theme == 0 && ui_preferred_theme > 0)
+	{
+		if (ui_preferred_theme == 1)
+			use_dark = true;
+		else if (ui_preferred_theme == 2)
+			use_dark = false;
+	}
 
 	Theme::initilize(use_dark? DARK: LIGHT, theme & HighContrast);
 


### PR DESCRIPTION
Adds the ability to switch between dark and light themes from within the launcher. This is not a direct value set of `ui_theme` but instead influences only the light and dark mode, this way high-contrast values are still respected. Because a restart is needed for this value to take effect (ZWidget doesn't support live updating), the launcher will now save values on close as opposed to only when starting a game. Because of this, a few things in the launcher needed to be refactored to support the idea that multiple either/or pages will always be getting saved.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
