### PR TITLE
Make line-to-line portals facing a sky display the sky after portal recursion end

### DIFF
--- a/src/common/rendering/gl/gl_renderstate.cpp
+++ b/src/common/rendering/gl/gl_renderstate.cpp
@@ -564,12 +564,12 @@ void FGLRenderState::EnableLineSmooth(bool on)
 //
 //
 //==========================================================================
-void FGLRenderState::ClearScreen()
+void FGLRenderState::ClearScreen(PalEntry color)
 {
 	bool multi = !!glIsEnabled(GL_MULTISAMPLE);
 
 	screen->mViewpoints->Set2D(*this, SCREENWIDTH, SCREENHEIGHT);
-	SetColor(0, 0, 0);
+	SetColor(color);
 	Apply();
 
 	glDisable(GL_MULTISAMPLE);

--- a/src/common/rendering/gl/gl_renderstate.h
+++ b/src/common/rendering/gl/gl_renderstate.h
@@ -115,7 +115,7 @@ public:
 
 	void ToggleState(int state, bool on);
 
-	void ClearScreen() override;
+	void ClearScreen(PalEntry color) override;
 	void Draw(int dt, int index, int count, bool apply = true) override;
 	void DrawIndexed(int dt, int index, int count, bool apply = true) override;
 

--- a/src/common/rendering/gles/gles_renderstate.cpp
+++ b/src/common/rendering/gles/gles_renderstate.cpp
@@ -689,11 +689,11 @@ void FGLRenderState::EnableLineSmooth(bool on)
 //
 //
 //==========================================================================
-void FGLRenderState::ClearScreen()
+void FGLRenderState::ClearScreen(PalEntry color)
 {
 
 	screen->mViewpoints->Set2D(*this, SCREENWIDTH, SCREENHEIGHT);
-	SetColor(0, 0, 0);
+	SetColor(color);
 	Apply();
 
 	glDisable(GL_DEPTH_TEST);

--- a/src/common/rendering/gles/gles_renderstate.h
+++ b/src/common/rendering/gles/gles_renderstate.h
@@ -109,7 +109,7 @@ public:
 
 	void ToggleState(int state, bool on);
 
-	void ClearScreen() override;
+	void ClearScreen(PalEntry color) override;
 	void Draw(int dt, int index, int count, bool apply = true) override;
 	void DrawIndexed(int dt, int index, int count, bool apply = true) override;
 

--- a/src/common/rendering/hwrenderer/data/hw_renderstate.h
+++ b/src/common/rendering/hwrenderer/data/hw_renderstate.h
@@ -738,7 +738,7 @@ public:
 	// API-dependent render interface
 
 	// Draw commands
-	virtual void ClearScreen() = 0;
+	virtual void ClearScreen(PalEntry color = 0xff000000) = 0;
 	virtual void Draw(int dt, int index, int count, bool apply = true) = 0;
 	virtual void DrawIndexed(int dt, int index, int count, bool apply = true) = 0;
 

--- a/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
+++ b/src/common/rendering/vulkan/renderer/vk_renderstate.cpp
@@ -47,10 +47,10 @@ VkRenderState::VkRenderState(VulkanRenderDevice* fb) : fb(fb), mStreamBufferWrit
 	Reset();
 }
 
-void VkRenderState::ClearScreen()
+void VkRenderState::ClearScreen(PalEntry color)
 {
 	screen->mViewpoints->Set2D(*this, SCREENWIDTH, SCREENHEIGHT);
-	SetColor(0, 0, 0);
+	SetColor(color);
 	Apply(DT_TriangleStrip);
 	mCommandBuffer->draw(4, 1, FFlatVertexBuffer::FULLSCREEN_INDEX, 0);
 }

--- a/src/common/rendering/vulkan/renderer/vk_renderstate.h
+++ b/src/common/rendering/vulkan/renderer/vk_renderstate.h
@@ -43,7 +43,7 @@ public:
 	virtual ~VkRenderState() = default;
 
 	// Draw commands
-	void ClearScreen() override;
+	void ClearScreen(PalEntry color) override;
 	void Draw(int dt, int index, int count, bool apply = true) override;
 	void DrawIndexed(int dt, int index, int count, bool apply = true) override;
 

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -627,6 +627,16 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *cl
 	auto &state = mState;
 	if (state->renderdepth>r_portal_recursions)
 	{
+		if (lines[0].seg->linedef->frontsector->GetTexture(sector_t::ceiling) == skyflatnum ||
+			lines[0].seg->linedef->frontsector->GetTexture(sector_t::floor) == skyflatnum)
+		{
+			HWSkyInfo skyinfo;
+			skyinfo.init(di, lines[0].seg->linedef->frontsector, sector_t::ceiling,
+						 lines[0].seg->linedef->frontsector->skytransfer,
+						 lines[0].seg->linedef->frontsector->Colormap.FadeColor);
+			HWSkyPortal sky(screen->mSkyData, mState, &skyinfo, true);
+			sky.DrawContents(di, rstate);
+		}
 		return false;
 	}
 	auto &vp = di->Viewpoint;

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -627,15 +627,35 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *cl
 	auto &state = mState;
 	if (state->renderdepth>r_portal_recursions)
 	{
-		if (lines[0].seg->linedef->frontsector->GetTexture(sector_t::ceiling) == skyflatnum ||
-			lines[0].seg->linedef->frontsector->GetTexture(sector_t::floor) == skyflatnum)
+		sector_t* mysector = lines[0].seg->linedef->frontsector;
+		if (mysector->GetTexture(sector_t::ceiling) == skyflatnum ||
+			mysector->GetTexture(sector_t::floor) == skyflatnum)
 		{
 			HWSkyInfo skyinfo;
-			skyinfo.init(di, lines[0].seg->linedef->frontsector, sector_t::ceiling,
-						 lines[0].seg->linedef->frontsector->skytransfer,
-						 lines[0].seg->linedef->frontsector->Colormap.FadeColor);
+			skyinfo.init(di, mysector, sector_t::ceiling, mysector->skytransfer, mysector->Colormap.FadeColor);
 			HWSkyPortal sky(screen->mSkyData, mState, &skyinfo, true);
 			sky.DrawContents(di, rstate);
+		}
+		else if (!mysector->Colormap.FadeColor.isBlack())
+		{
+			auto &vp = di->Viewpoint;
+			int fogd = GetFogDensity(di->Level, di->lightmode, mysector->lightlevel, mysector->Colormap.FadeColor,
+									 mysector->Colormap.FogDensity,
+									 mysector->Colormap.BlendFactor);
+			float dist = min((lines[0].seg->linedef->v1->fPos() - vp.Pos.XY()).Length(),
+							 (lines[0].seg->linedef->v2->fPos() - vp.Pos.XY()).Length());
+			if (di->VPUniforms.mThickFogDistance > 0.0 && dist > di->VPUniforms.mThickFogDistance)
+			{
+				dist = dist + di->VPUniforms.mThickFogMultiplier * (dist - di->VPUniforms.mThickFogDistance);
+			}
+			float factor = 1.05f - exp(-fogd * dist / 62500.f);
+			uint32_t alpha = uint32_t(255 * factor)<<24;
+			rstate.EnableTexture(false);
+			rstate.ClearScreen(mysector->Colormap.FadeColor | alpha);
+		}
+		else
+		{
+			rstate.ClearScreen();
 		}
 		return false;
 	}

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -30,6 +30,8 @@
 #include "texturemanager.h"
 #include "hw_viewpointbuffer.h"
 
+EXTERN_CVAR(Bool, gl_noskyboxes)
+
 void SetPlaneTextureRotation(FRenderState& state, HWSectorPlane* plane, FGameTexture* texture);
 
 //-----------------------------------------------------------------------------
@@ -631,10 +633,32 @@ bool HWLineToLinePortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *cl
 		if (mysector->GetTexture(sector_t::ceiling) == skyflatnum ||
 			mysector->GetTexture(sector_t::floor) == skyflatnum)
 		{
-			HWSkyInfo skyinfo;
-			skyinfo.init(di, mysector, sector_t::ceiling, mysector->skytransfer, mysector->Colormap.FadeColor);
-			HWSkyPortal sky(screen->mSkyData, mState, &skyinfo, true);
-			sky.DrawContents(di, rstate);
+			FSectorPortal *sportal = mysector->ValidatePortal(mysector->GetTexture(sector_t::ceiling) == skyflatnum ?
+															  sector_t::ceiling : sector_t::floor);
+			if (sportal && !(sportal->mFlags & PORTSF_INSKYBOX) && !gl_noskyboxes)
+			{
+				HWSkyboxPortal myportal(mState, sportal);
+				for (unsigned i = 0; i < lines.Size(); i++)
+				{
+					myportal.AddLine(&lines[i]);
+				}
+				myportal.DrawContents(di, rstate);
+			}
+			else
+			{
+				HWSkyInfo skyinfo;
+				skyinfo.init(di, mysector, mysector->GetTexture(sector_t::ceiling) == skyflatnum ?
+							 sector_t::ceiling : sector_t::floor,
+							 mysector->skytransfer, mysector->Colormap.FadeColor);
+				HWSkyPortal sky(screen->mSkyData, mState, &skyinfo, true);
+				sky.SetupStencil(di, rstate, false);
+				auto new_di = di->StartDrawInfo(di->Level, di, di->Viewpoint, &di->VPUniforms);
+				new_di->mCurrentPortal = di->mCurrentPortal;
+				rstate.SetLightIndex(-1);
+				sky.DrawContents(new_di, rstate);
+				new_di->EndDrawInfo();
+				sky.RemoveStencil(di, rstate, false);
+			}
 		}
 		else if (!mysector->Colormap.FadeColor.isBlack())
 		{

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -268,6 +268,14 @@ public:
 	{
 		glport = ll;
 	}
+	virtual void DrawContents(HWDrawInfo *di, FRenderState &state)
+	{
+		if (Setup(di, state, (di->Viewpoint.bDoOob ? di->rClipper : di->mClipper)))
+		{
+			di->DrawScene(DM_PORTAL);
+			Shutdown(di, state);
+		}
+	} // Just removed redundant screenclear, since it happens inside Setup here
 };
 
 

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -395,6 +395,7 @@ struct HWSkyPortal : public HWPortal
 	HWSkyInfo * origin;
 	FSkyVertexBuffer *vertexBuffer;
 	friend struct HWEEHorizonPortal;
+	friend struct HWLineToLinePortal;
 
 protected:
 	virtual void DrawContents(HWDrawInfo *di, FRenderState &state);


### PR DESCRIPTION
Make line-to-line portals that face a sky floor or ceiling display the sky instead of being cleared to black when over the portal recursion limit.

Tested with 
[serial_portals.wad.zip](https://github.com/user-attachments/files/30626964/serial_portals.wad.zip)

Change value of `r_portal_recursions` higher or lower in the console.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
