### PR TITLE
Pbr for all sprites

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_drawstructs.h
+++ b/src/rendering/hwrenderer/scene/hw_drawstructs.h
@@ -380,6 +380,7 @@ public:
 	int modelframeflags;
 	FRenderStyle RenderStyle;
 	int OverrideShader;
+	bool normspec;			// Whether or not the texture is PBR/normal+specular
 
 	FTranslationID translation;
 	int index;

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -272,7 +272,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 
 		if (!modelframe)
 		{
-			if ((texture && texture->GetNormalmap()))
+			if (normspec)
 			{
 				state.SetNormal(-di->Viewpoint.ViewVector3D.X, -di->Viewpoint.ViewVector3D.Z, -di->Viewpoint.ViewVector3D.Y);
 			}
@@ -290,7 +290,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			{
 				state.SetDepthBias(-1, -128);
 			}
-			state.SetLightIndex((texture && texture->GetNormalmap()) ? dynlightindex : -1);
+			state.SetLightIndex(normspec ? dynlightindex : -1);
 			state.Draw(DT_TriangleStrip, vertexindex, 4);
 
 			if (foglayer)
@@ -604,7 +604,7 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 inline void HWSprite::PutSprite(HWDrawInfo *di, bool translucent)
 {
 	// That's a lot of checks...
-	if (((modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING)) || (texture && texture->GetNormalmap()))
+	if (((modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING)) || normspec)
 		&& RenderStyle.BlendOp != STYLEOP_Shadow
 		&& gl_light_sprites && di->Level->HasDynamicLights && !di->isFullbrightScene() && !fullbright
 		&& actor && !(actor->renderflags2 & RF2_NODYNAMICLIGHTING))
@@ -1079,6 +1079,9 @@ void HWSprite::Process(HWDrawInfo *di, AActor* thing, sector_t * sector, area_t 
 		if (!texture || !texture->isValid())
 			return;
 
+		normspec = texture->GetNormalmap() && (texture->GetSpecularmap() ||
+											   (texture->GetMetallic() && texture->GetRoughness()
+												&& texture->GetAmbientOcclusion()));
 		// Canvas textures are stored upside down
 		if (!isPicnumOverride && texture && texture->isHardwareCanvas()) std::swap(vt, vb);
 

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -170,7 +170,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			{
 				float out[3] = {};
 				di->GetDynSpriteLight(gl_light_sprites ? actor : nullptr, gl_light_particles ? particle : nullptr, out);
-				state.SetDynLight(out[0], out[1], out[2]); // [DVR] PBR sprites will reach here.
+				state.SetDynLight(out[0], out[1], out[2]); // [DVR] PBR sprites will not reach here.
 			}
 		}
 		sector_t *cursec = actor ? actor->Sector : particle ? particle->subsector->sector : nullptr;

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -170,7 +170,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			{
 				float out[3] = {};
 				di->GetDynSpriteLight(gl_light_sprites ? actor : nullptr, gl_light_particles ? particle : nullptr, out);
-				state.SetDynLight(out[0], out[1], out[2]);
+				state.SetDynLight(out[0], out[1], out[2]); // [DVR] PBR sprites will reach here.
 			}
 		}
 		sector_t *cursec = actor ? actor->Sector : particle ? particle->subsector->sector : nullptr;
@@ -272,7 +272,14 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 
 		if (!modelframe)
 		{
-			state.SetNormal(0, 0, 0);
+			if ((texture && texture->GetNormalmap()))
+			{
+				state.SetNormal(-di->Viewpoint.ViewVector3D.X, -di->Viewpoint.ViewVector3D.Z, -di->Viewpoint.ViewVector3D.Y);
+			}
+			else
+			{
+				state.SetNormal(0, 0, 0);
+			}
 
 
 			if (screen->BuffersArePersistent())
@@ -283,7 +290,7 @@ void HWSprite::DrawSprite(HWDrawInfo *di, FRenderState &state, bool translucent)
 			{
 				state.SetDepthBias(-1, -128);
 			}
-			state.SetLightIndex(-1);
+			state.SetLightIndex((texture && texture->GetNormalmap()) ? dynlightindex : -1);
 			state.Draw(DT_TriangleStrip, vertexindex, 4);
 
 			if (foglayer)
@@ -597,7 +604,8 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 inline void HWSprite::PutSprite(HWDrawInfo *di, bool translucent)
 {
 	// That's a lot of checks...
-	if (modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING) && RenderStyle.BlendOp != STYLEOP_Shadow
+	if (((modelframe && !modelframe->isVoxel && !(modelframeflags & MDL_NOPERPIXELLIGHTING)) || (texture && texture->GetNormalmap()))
+		&& RenderStyle.BlendOp != STYLEOP_Shadow
 		&& gl_light_sprites && di->Level->HasDynamicLights && !di->isFullbrightScene() && !fullbright
 		&& actor && !(actor->renderflags2 & RF2_NODYNAMICLIGHTING))
 	{


### PR DESCRIPTION
Presence of a normal map texture triggers the mode. No new flags. Every sprite (frame and rotation) is independent. Neutral normal always points to camera viewpoint in first commit.
This was asked for for testing purposes.

Tiny test map: 
[PBR_all_sprites.zip](https://github.com/user-attachments/files/30642289/PBR_all_sprites.zip)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
