### PR TITLE
Update line length before ACS HudMessage type-on routine

### DIFF
--- a/src/g_statusbar/hudmessages.cpp
+++ b/src/g_statusbar/hudmessages.cpp
@@ -745,6 +745,7 @@ bool DHUDMessageTypeOnFadeOut::Tick ()
 			int linevis = LineVisible;
 			int linedrawcount = linevis;
 			FString text = Lines[CurrLine].Text;
+			LineLen = (int)text.Len();
 			// Advance LineVisible by 'step' *visible* characters
 			while (step > 0 && State == 3)
 			{


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.

An attempt to fix https://github.com/UZDoom/UZDoom/issues/1676#issue-5045502710

As far as I can tell, when HudMessageBold is handled through p_acs.cpp:
- During the DHUDMessage constructor (called from the DHUDMessageTypeOnFadeOut::DHUDMessageTypeOnFadeOut constructor), DHUDMessage::ResetText is called with a HUD width of the current SetHudSize() width.
- During ResetText, LineLen is set based on the bank of FBrokenLines that was derived from that width.
- Further down in p_acs.cpp, we have a WrapWidth, so we call SetWrapWidth() which calls ResetText again. V_Breaklines is called again and wraps to the new width. **LineLen does not get updated!**
- As the first line of the message is typed, the Tick method will continue to attempt to draw characters from past the end of its string up until it passes the length of the original line. If one of the junk characters happens to be the TEXTCOLOR_ESCAPE, the string will be checked at that index for "[" and will cause an out of bounds exception.

Making sure LineLen is updated before starting to put more characters on the screen fixes the issue, but I'm not sure if this was avoided originally for optimality.