### PR TITLE
Remove leftover src/gitinfo.h during configure/build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,7 +288,16 @@ option(BUILD_FLATPAK "Enable Flatpak-specific build options" OFF)
 
 # Update gitinfo.h
 
+# Older trees wrote gitinfo.h into src/. That path is obsolete (generation
+# now targets the build dir) but a leftover copy still gets picked up by the
+# HEADER_FILES glob below and breaks the build. Delete it if present.
+if( EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/gitinfo.h" )
+	file( REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/gitinfo.h" )
+	message( STATUS "Removed leftover ${CMAKE_CURRENT_SOURCE_DIR}/gitinfo.h" )
+endif()
+
 add_custom_target( revision_check
+	COMMAND "${CMAKE_COMMAND}" -E rm -f "${CMAKE_CURRENT_SOURCE_DIR}/gitinfo.h"
 	COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/UpdateRevision.cmake" "${CMAKE_BINARY_DIR}/gitinfo.h"
 	BYPRODUCTS "${CMAKE_BINARY_DIR}/gitinfo.h"
 	WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"


### PR DESCRIPTION
## Summary
Leftover `src/gitinfo.h` from older builds gets sucked into the `HEADER_FILES` `*.h` glob and conflicts with the build-dir copy generated by `revision_check`.

- Delete it at configure time when present
- Also `cmake -E rm -f` it from `revision_check` so a regenerate mid-tree stays clean

Fixes #1435

## Test plan
- [x] Dropped a dummy `src/gitinfo.h` and confirmed configure-time `file(REMOVE)` deletes it
- [x] Full UZDoom configure/build with a planted stale `src/gitinfo.h` succeeds and uses `${CMAKE_BINARY_DIR}/gitinfo.h`