### PR TITLE
Switched to name-appending system for log files

### DIFF
--- a/src/common/console/c_enginecmds.cpp
+++ b/src/common/console/c_enginecmds.cpp
@@ -101,7 +101,15 @@ UNSAFE_CCMD (exec)
 
 void execLogfile(const char *fn, bool append)
 {
-	if ((Logfile = fopen(fn, append? "a" : "w")))
+	FString file = "log";
+	if (fn != nullptr && strlen(fn) > 0)
+	{
+		file.AppendFormat("-%s", fn);
+		file.ReplaceChars('.', '-');
+	}
+	file.AppendFormat(".txt");
+
+	if ((Logfile = fopen(file.GetChars(), append ? "a" : "w")))
 	{
 		const char *timestr = myasctime();
 		Printf("Log started: %s\n", timestr);


### PR DESCRIPTION
Ensure these are always created where the game is being executed from. Instead, use the name as a quick way to differentiate log files e.g. `+logfile abcd` will be created as `log-abcd.txt`.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
