### PR TITLE
writeini must now always write in the config directory

### DIFF
--- a/src/m_misc.cpp
+++ b/src/m_misc.cpp
@@ -373,8 +373,22 @@ void M_SaveDefaultsFinal ()
 
 UNSAFE_CCMD (writeini)
 {
-	const char *filename = (argv.argc() == 1) ? NULL : argv[1];
-	if (!M_SaveDefaults (filename))
+	FString fileName = {};
+	if (argv.argc() > 1)
+	{
+		FString file = argv[1];
+		file.ReplaceChars('.', '-');
+		file += ".ini";
+
+		FString path = M_GetConfigPath(true);
+		auto i = path.LastIndexOf("/") + 1;
+		path.Remove(i, path.Len() - i);
+		path.AppendFormat("%s", file.GetChars());
+
+		fileName = path;
+	}
+
+	if (!M_SaveDefaults (fileName.IsEmpty() ? nullptr : fileName.GetChars()))
 	{
 		Printf ("Writing config failed: %s\n", strerror(errno));
 	}


### PR DESCRIPTION
All paths will now be relative to this directory. Also automatically appends a `.ini` to the end of the file now.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
