### PR TITLE
Fix linebreak issue in `echo`

### DIFF
--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -1234,12 +1234,14 @@ CCMD (clear)
 
 CCMD (echo)
 {
-	int last = argv.argc()-1;
-	for (int i = 1; i <= last; ++i)
+	int count = argv.argc();
+	FString str = (count <= 1)? "": argv[1];
+	for (auto i = 2; i < count; i++)
 	{
-		FString formatted = strbin1 (argv[i]);
-		Printf ("%s%s", formatted.GetChars(), i!=last ? " " : "\n");
+		str.AppendCharacter(' ');
+		str += argv[i];
 	}
+	Printf("%s\n", str.GetChars());
 }
 
 CCMD(toggleconsole)


### PR DESCRIPTION
Fixes #1708, introduced in 4cf08b9

There are some other functions that I suspect will have similar issues, too. I've been meaning to fix the linebreak inconsistencies anyways, so I'll tackle those when I have some time. Just so I don't lose it, this should find most if not all of the candidate issues: `grep -noP 'Printf\s*\(\s*"(?:[^"\x5c]|\x5c.)*"' src -r | grep -vF '\n' | cut -d : -f 1,2`

There is a deeper fix that will need doing, where string repeat buffer needs to only apply once a newline is encountered, but that can come in a future patch.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
