### PR TITLE
Replace some hardcoded weapon states with their respective Getters

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/weapons.zs
+++ b/wadsrc/static/zscript/actors/inventory/weapons.zs
@@ -414,7 +414,7 @@ class Weapon : StateProvider
 
 		// Play ready sound, if any.
 		let psp = player.GetPSprite(PSP_WEAPON);
-		if (weapon.ReadySound && psp && psp.curState == weapon.FindState('Ready'))
+		if (weapon.ReadySound && psp && psp.curState == weapon.GetReadyState())
 		{
 			if (!weapon.bReadySndHalf || random[WpnReadySnd]() < 128)
 			{
@@ -556,7 +556,7 @@ class Weapon : StateProvider
 
 	override bool TryPickup (in out Actor toucher)
 	{
-		State ReadyState = FindState('Ready');
+		State ReadyState = GetReadyState();
 		if (ReadyState != NULL && ReadyState.ValidateSpriteFrame())
 		{
 			return Super.TryPickup (toucher);
@@ -1025,7 +1025,7 @@ class Weapon : StateProvider
 		{
 			enoughmask = 1 << altFire;
 		}
-		if (altFire && FindState('AltFire') == null)
+		if (altFire && GetAltAtkState(false) == null)
 		{ // If this weapon has no alternate fire, then there is never enough ammo for it
 			enough &= 1;
 		}

--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -440,7 +440,7 @@ class PlayerPawn : Actor
 	virtual void FireWeaponAlt (State stat)
 	{
 		let weapn = player.ReadyWeapon;
-		if (weapn == null || weapn.FindState('AltFire') == null || !weapn.CheckAmmo (Weapon.AltFire, true))
+		if (weapn == null || weapn.GetAltAtkState(false) == null || !weapn.CheckAmmo (Weapon.AltFire, true))
 		{
 			return;
 		}


### PR DESCRIPTION
Currently, if you replace the ``AltFire`` state with a custom one via ``GetAltAtkState``, the weapon doesn't recognize it, blocking you from firing, a workaround would be having a empty AltFire state and ``A_WeaponReady(WOF_NOSECONDARY)``

``CheckAmmo`` and ``FireWeaponAlt`` should get the ``AltFire`` state from the ``GetAltAtkState`` getter to accomodate for logic that requires it.

A similar issue applies to the Ready state, it doesn't check for ``GetReadyState``
Not tested, going by code: also fixes ``Weapon.ReadySound`` not playing when replacing the state via ``GetReadyState``

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
