### PR TITLE
Update walkplane for every step in P_XYMovement

### DIFF
--- a/src/playsim/p_mobj.cpp
+++ b/src/playsim/p_mobj.cpp
@@ -2571,6 +2571,12 @@ static double P_XYMovement (AActor *mo, DVector2 scroll)
 
 		ptry = start + move * step / steps;
 
+		// Before we only updated walkplane if we were blocked.
+		// This can cause objects to downwarp infinitely far to the
+		// sector's floor if you are moving too fast. So, make sure
+		// that it is up-to-date for every step.
+		walkplane = P_CheckSlopeWalk(mo, onestep);
+
 		DVector2 startvel = mo->Vel.XY();
 
 		// killough 3/15/98: Allow objects to drop off
@@ -5714,7 +5720,7 @@ void AActor::HandleSpawnFlags ()
 		{
 			Level->total_monsters--;
 		}
-		
+
 		flags |= MF_FRIENDLY;
 		flags &= ~MF_COUNTKILL;
 	}
@@ -5743,9 +5749,9 @@ void AActor::HandleSpawnFlags ()
 		{
 			Level->total_monsters--;
 		}
-		
+
 		flags &= ~MF_COUNTKILL;
-		
+
 		if (flags & MF_COUNTITEM)
 		{
 			flags &= ~MF_COUNTITEM;


### PR DESCRIPTION
# whatis?

In `P_XYMovement`: `P_CheckSlopeWalk` sets `walkplane`, which is then passed to `P_TryMove` when on the floor. This handles snapping to the floor.

When moving too fast between sector boundaries, you can downwarp to the next sector's floor. That's cuz walkplane only updates if you get blocked. If you're never blocked by anything, then walkplane is the same one it calculated for the first step. (In my experience slopes make it happen a lil more often.)

Solution is pretty simple, double-check our work every step.

# test?

- Grab [slope_downwarp_test.zip](https://github.com/user-attachments/files/31056912/slope_downwarp_test.zip)
- Launch w/ `-file slope_downwarp_test.zip +map map01`
- Doomguy will be propelled forward at an extreme velocity on map start.
  - If the bug is fixed, then you will fall for a bit, and then land on a platform that says "YAY" on the floor.
  - If the bug isn't fixed, then you will instantly snap to the bottom of the giant pit. A frowny face will greet you there.


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
