### PR TITLE
Silence annoying warning

### DIFF
--- a/src/widgets/themedata.cpp
+++ b/src/widgets/themedata.cpp
@@ -108,18 +108,20 @@ void Theme::initilize(Mode mode, bool contrast)
 			auto command = sc.MatchString(ThemeCommandStrings);
 			switch (command)
 			{
+			default:
+				break;
 			case -1:
 				DPrintf(DMSG_WARNING, "Unknown theme command");
-				break;
+				continue;
 			case THEME_LIGHT:
 				t = &Theme::light;
-				break;
+				continue;
 			case THEME_DARK:
 				t = &Theme::dark;
-				break;
+				continue;
 			case THEME_ACCENT:
 				Theme::accent = Colorf::fromRgb(hex(sc));
-				break;
+				continue;
 			}
 			if (!t)
 			{


### PR DESCRIPTION
> Theme not selected
> Theme not selected

Is no more!

The warning was showing up when it wasn't supposed to, due to some faulty flow control

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
