### PR TITLE
Undo incorrect BringUpWeapon "fix"

### DIFF
--- a/wadsrc/static/zscript/actors/player/player.zs
+++ b/wadsrc/static/zscript/actors/player/player.zs
@@ -1887,7 +1887,6 @@ class PlayerPawn : Actor
 		}
 
 		let weapon = player.PendingWeapon;
-		bool fromPowerup = false;
 
 		// If the player has a tome of power, use self weapon's powered up
 		// version, if one is available.
@@ -1897,7 +1896,6 @@ class PlayerPawn : Actor
 			player.mo.FindInventory ('PowerWeaponLevel2', true))
 		{
 			weapon = weapon.SisterWeapon;
-			fromPowerup = true;
 		}
 
 		player.PendingWeapon = WP_NOCHANGE;
@@ -1906,7 +1904,7 @@ class PlayerPawn : Actor
 
 		if (weapon != null)
 		{
-			weapon.OnSelect(fromPowerup);
+			weapon.OnSelect();
 			weapon.PlayUpSound(self);
 			player.refire = 0;
 


### PR DESCRIPTION
Undo https://github.com/UZDoom/UZDoom/pull/1743
The "fix" above was incorrect, because I misremembered the original idea behind my own implementation. The `fromPowerup` argument is not supposed to be ever set in BringUpWeapon. Its actual purpose is to signal that OnSelect is being called as a result of PowerWeaponLevel2 dynamically changing the *current* weapon — and it already does that correctly here: https://github.com/UZDoom/UZDoom/blob/ea894e164c6fabc564d656257c00a28c48e1342f/wadsrc/static/zscript/actors/inventory/powerups.zs#L1146-L1166

So, cycling *into* a sisterweapon from another weapon should not set this argument to true. It should only be true when you receive PowerWeaponLevel2 and it immediately changes your *current* weapon to its sisterweapon.

Sorry for the back and forth! This one is on me. I'll make sure the wiki documentation reflects the meaning of the argument accurately.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
