### PR TITLE
Print IWAD search paths via `DEBUG_LOG`

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -406,3 +406,4 @@ Corey Agallow
 Jordi Conesa
 Andrei Stepanov
 Gabriel Valderrama
+Whovian9369

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -24,6 +24,7 @@
 
 #include "c_cvars.h"
 #include "cmdlib.h"
+#include "c_console.h"
 #include "d_main.h"
 #include "d_steam.h"
 #include "engineerrors.h"

--- a/src/d_iwad.cpp
+++ b/src/d_iwad.cpp
@@ -633,6 +633,7 @@ int FIWadManager::IdentifyVersion (std::vector<FileSys::ResourceName>&wadfiles, 
 	// Collect all IWADs in the search path
 	for (auto &dir : mSearchPaths)
 	{
+		DEBUG_LOG("Using IWAD search path %s", dir.GetChars());
 		AddIWADCandidates(dir.GetChars());
 	}
 	for (auto& dir : mRecursiveSearchPaths)


### PR DESCRIPTION
Adds printing of search paths that are set in the configuration file's `IWADSearch.Directories` section when `developer=4` is set in the configuration.

Admittedly it's only been tested on Linux test builds of UZDoom (using the 5.0.0-rc.2 and 5.0.0-rc.3 branches as the base) and on a single macOS test build (using the 5.0.0-rc.3 branch as a base), but I don't foresee issues on Windows environments.

An example of the appropriate configuration section and the patch in action is below.

```ini
[IWADSearch.Directories]
Path=.
Path=$DOOMWADDIR
PathList=$DOOMWADPATH
Path=$PROGDIR
Path=$HOME/.local/share/games/uzdoom
```
```
$ build/uzdoom
UZDoom version 5.0.0-rc.3.0-4ca59094-m
Build: SDL2 dated 1979-12-31 19:00:00 -0500
OS: NixOS 26.11 (Zokor), Linux 6.6.87.2-microsoft-standard-WSL2 on x86_64
M_LoadDefaults: Load system defaults.
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/uzdoom.pk3
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/game_support.pk3
d_iwad.cpp:636 : Using IWAD search path .
d_iwad.cpp:636 : Using IWAD search path /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build
d_iwad.cpp:636 : Using IWAD search path /home/whovian/.local/share/games/uzdoom
Identified /home/whovian/.local/share/games/uzdoom/doom2.wad as DOOM 2: Hell on Earth
Identified /home/whovian/.local/share/games/uzdoom/doom1.wad as DOOM Shareware
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/lights.pk3
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/brightmaps.pk3
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/game_widescreen_gfx.pk3
common/utility/findfile.cpp:255 : /home/whovian/Downloads/Games/Windows/DOOM/UZDoom.git/build/uzdoom.pk3
```

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
