### PR TITLE
Document config env vars

### DIFF
--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -280,7 +280,7 @@ FGameConfigFile::FGameConfigFile ()
 		"# contains a search directory.\n\n"
 
 		"# $DOOMWADPATH references a system environment variable of the same name whose\n"
-		"# value contains a colon (on Windows) or semicolon (on other systems) delimited\n"
+		"# value contains a semicolon (on Windows) or colon (on other systems) delimited\n"
 		"# list of searchable directories.\n"
 		"# It's *similar* to $DOOMWADDIR, except that $DOOMWADPATH is a list of possible\n"
 		"# search directories.\n\n"

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -267,8 +267,37 @@ FGameConfigFile::FGameConfigFile ()
 		}
 	}
 
-	// Add some self-documentation.
 	SetSectionNote("IWADSearch.Directories",
+		// Add env var documentation.
+		"\n#### Environment Variable Information ####\n\n"
+
+		"# . references the current directory that UZDoom is launched from within your\n"
+		"# terminal or console.\n"
+		"# For example if you are in /home/Username/a/b/c/d/ when you start UZDoom, it\n"
+		"# will look in that directory for WADs.\n\n"
+
+		"# $DOOMWADDIR references a system environment variable of the same name that\n"
+		"# contains a search directory.\n\n"
+
+		"# $DOOMWADPATH references a system environment variable of the same name whose\n"
+		"# value contains a colon (on Windows) or semicolon (on other systems) delimited\n"
+		"# list of searchable directories.\n"
+		"# It's *similar* to $DOOMWADDIR, except that $DOOMWADPATH is a list of possible\n"
+		"# search directories.\n\n"
+
+		"# $HOME references your system user directory.\n"
+		"# On Windows, that will likely default to C:\\Users\\Username\\\n"
+		"# On macOS environments, that will likely default to $HOME (/User/Username)\n"
+		"# On most Linux environments, that will likely default to $HOME (/home/Username)\n\n"
+
+		"# $PROGDIR references the directory that the main binary is located.\n"
+		"# On Windows this is likely to be next to \"UZDoom.exe\".\n"
+		"# On Linux this is likely to be next to where the main binary is for the app,\n"
+		"# and may differ from distro to distro.\n"
+		"# On macOS this is likely to be \"/Applications/UZDoom.app/Content/Resources\"\n"
+		"\n" // Add a final newline before going back to the original section header text.
+		// Finish documentation.
+
 		"# These are the directories to automatically search for IWADs.\n"
 		"# Each directory should be on a separate line, preceded by Path=\n");
 	SetSectionNote("FileSearch.Directories",

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -268,13 +268,11 @@ FGameConfigFile::FGameConfigFile ()
 	}
 
 	SetSectionNote("IWADSearch.Directories",
-		// Add env var documentation.
+		// Add environment variable documentation.
 		"\n#### Environment Variable Information ####\n\n"
 
 		"# . references the current directory that UZDoom is launched from within your\n"
-		"# terminal or console.\n"
-		"# For example if you are in /home/Username/a/b/c/d/ when you start UZDoom, it\n"
-		"# will look in that directory for WADs.\n\n"
+		"# terminal or console.\n\n"
 
 		"# $DOOMWADDIR references a system environment variable of the same name that\n"
 		"# contains a search directory.\n\n"
@@ -285,18 +283,16 @@ FGameConfigFile::FGameConfigFile ()
 		"# It's *similar* to $DOOMWADDIR, except that $DOOMWADPATH is a list of possible\n"
 		"# search directories.\n\n"
 
-		"# $HOME references your system user directory.\n"
-		"# On Windows, that will likely default to C:\\Users\\Username\\\n"
-		"# On macOS environments, that will likely default to $HOME (/User/Username)\n"
-		"# On most Linux environments, that will likely default to $HOME (/home/Username)\n\n"
+		"# $HOME references your system user directory.\n\n"
 
-		"# $PROGDIR references the directory that the main binary is located.\n"
-		"# On Windows this is likely to be next to \"UZDoom.exe\".\n"
-		"# On Linux this is likely to be next to where the main binary is for the app,\n"
-		"# and may differ from distro to distro.\n"
-		"# On macOS this is likely to be \"/Applications/UZDoom.app/Content/Resources\"\n"
+		"# $PROGDIR references the directory that the main binary is located.\n\n"
+
+		"For more information and examples of how to use environment variables,\n"
+		"please see the ZDoom Wiki page:\n"
+		"at https://zdoom.org/wiki/Configuration_file#Environment_Variables\n"
+
 		"\n" // Add a final newline before going back to the original section header text.
-		// Finish documentation.
+		// Finish environment variable documentation.
 
 		"# These are the directories to automatically search for IWADs.\n"
 		"# Each directory should be on a separate line, preceded by Path=\n");

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -287,9 +287,9 @@ FGameConfigFile::FGameConfigFile ()
 
 		"# $PROGDIR references the directory that the main binary is located.\n\n"
 
-		"For more information and examples of how to use environment variables,\n"
-		"please see the ZDoom Wiki page:\n"
-		"at https://zdoom.org/wiki/Configuration_file#Environment_Variables\n"
+		"# For more information and examples of how to use environment variables,\n"
+		"# please see the ZDoom Wiki page:\n"
+		"# at https://zdoom.org/wiki/Configuration_file#Environment_Variables\n"
 
 		"\n" // Add a final newline before going back to the original section header text.
 		// Finish environment variable documentation.


### PR DESCRIPTION
Adds some documentation about environment variables to the configuration file generation to assist users.

This was started from a personal want of documentation as [the ZDoom Wiki's "Configuration file" page](https://zdoom.org/w/index.php?title=Configuration_file) is *a bit lacking* around that information. This documentation is somewhat overly verbose, and I anticipate needing to cut it down and likely move a majority of the explanation to the wiki once I am able.

This documentation attempt was made far easier through an earlier variation of PR #1759 enabling the printing of the initial search paths, and trying to work from there with the given information.

Admittedly it's only been tested on Linux test builds of UZDoom (using the 5.0.0-rc.2 and 5.0.0-rc.3 branches as the base), but I don't foresee issues on Windows or macOS environments as I should be replicating the behavior of other text that's already automatically added to the configuration file.

An example of the full Linux configuration file with this in-line documentation is available at https://gist.github.com/Whovian9369/5bdc78dac691d207901126f280e44d88 .

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
