### PR TITLE
fix(cmake): include OpenGL backend headers in VS project sources

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -565,6 +565,7 @@ file( GLOB HEADER_FILES
 	common/thirdparty/utf8proc/*.h
 	common/rendering/*.h
 	common/rendering/gl_load/*.h
+	common/rendering/gl/*.h
 	common/rendering/gles/*.h
 	common/rendering/hwrenderer/data/*.h
 	common/rendering/vulkan/*.h


### PR DESCRIPTION
## Summary

fix(cmake): include OpenGL backend headers in VS project sources

## Changes

- src/CMakeLists.txt: add common/rendering/gl/*.h so gl_*.h appear in the IDE

Fixes #1769
