### PR TITLE
Add more banner positioning options

### DIFF
--- a/libraries/ZWidget/include/zwidget/widgets/imagebox/imagebox.h
+++ b/libraries/ZWidget/include/zwidget/widgets/imagebox/imagebox.h
@@ -4,11 +4,36 @@
 #include "../../core/widget.h"
 #include "../../core/image.h"
 
-enum ImageBoxMode
+enum ImageBoxScale
 {
-	Center,
-	Contain,
-	Cover
+	None     = 0,
+	Contain  = 0b0'000'000'01,
+	Cover    = 0b0'000'000'10,
+
+	StretchX = 0b0'000'100'00,
+	GrowX    = 0b0'000'010'00,
+	ShrinkX  = 0b0'000'001'00,
+
+	StretchY = 0b0'100'000'00,
+	GrowY    = 0b0'010'000'00,
+	ShrinkY  = 0b0'001'000'00,
+
+	Stretch = StretchX|StretchY,
+	Grow    = GrowX|GrowY,
+	Shrink  = ShrinkX|ShrinkY,
+};
+
+enum ImageBoxAnchor
+{
+	Center = 0,
+	North  = 0b00010,
+	South  = 0b00011,
+	East   = 0b01000,
+	West   = 0b01100,
+	NorthEast = North|East,
+	NorthWest = North|West,
+	SouthEast = South|East,
+	SouthWest = South|West,
 };
 
 class ImageBox : public Widget
@@ -17,7 +42,8 @@ public:
 	ImageBox(Widget* parent);
 
 	void SetImage(std::shared_ptr<Image> newImage);
-	void SetImageMode(ImageBoxMode mode);
+	void SetImageScale(ImageBoxScale scale);
+	void SetImageAnchor(ImageBoxAnchor anchor);
 
 	double GetPreferredWidth() override;
 	double GetPreferredHeight() override;
@@ -27,5 +53,6 @@ protected:
 
 private:
 	std::shared_ptr<Image> image;
-	ImageBoxMode mode = ImageBoxMode::Center;
+	ImageBoxScale scale = ImageBoxScale::None;
+	ImageBoxAnchor anchor = ImageBoxAnchor::Center;
 };

--- a/libraries/ZWidget/src/widgets/imagebox/imagebox.cpp
+++ b/libraries/ZWidget/src/widgets/imagebox/imagebox.cpp
@@ -1,3 +1,4 @@
+#include <bit>
 
 #include "widgets/imagebox/imagebox.h"
 
@@ -30,44 +31,100 @@ void ImageBox::SetImage(std::shared_ptr<Image> newImage)
 	}
 }
 
-void ImageBox::SetImageMode(ImageBoxMode newMode)
+void ImageBox::SetImageScale(ImageBoxScale newScale)
 {
-	if (mode != newMode)
+	if (scale != newScale)
 	{
-		mode = newMode;
+		scale = newScale;
 		Update();
 	}
 }
 
+void ImageBox::SetImageAnchor(ImageBoxAnchor newAnchor)
+{
+	if (anchor != newAnchor)
+	{
+		anchor = newAnchor;
+		Update();
+	}
+}
+
+template <typename T>
+concept Bits = std::unsigned_integral<T> || std::is_enum_v<T>;
+
+template <Bits T, typename U = T>
+[[nodiscard]] inline constexpr U onebit(T n)
+{
+	return static_cast<U>(std::has_single_bit(n) ? n: static_cast<T>(0));
+}
+
+template <Bits T, typename U = T, typename V = T>
+[[nodiscard]] inline constexpr U only(T a, V b)
+{
+	return static_cast<U>(!(a&~b)? a: static_cast<T>(0));
+}
+
+template <Bits T, typename U = T, typename V = T>
+[[nodiscard]] inline constexpr U all(T a, V b)
+{
+	return static_cast<U>((a&b)==b? a: static_cast<T>(0));
+}
+
 void ImageBox::OnPaint(Canvas* canvas)
 {
-	if (image)
+	if (!image) return;
+
+	double bw = GetWidth(), bh = GetHeight();
+	double iw = image->GetWidth(), ih = image->GetHeight();
+	double rw = bw / iw, rh = bh / ih;
+	double xscale = 1, yscale = 1;
+
+	if (only(scale, ImageBoxScale::Contain|ImageBoxScale::Cover|ImageBoxScale::Grow|ImageBoxScale::Shrink)
+		&& (only(scale, ImageBoxScale::Contain|ImageBoxScale::Cover)
+			|| all(scale, ImageBoxScale::Grow)
+			|| all(scale, ImageBoxScale::Shrink)
+		))
 	{
-		if (mode == ImageBoxMode::Center)
+		auto rc = onebit<unsigned, ImageBoxScale>(scale & (ImageBoxScale::Cover | ImageBoxScale::Contain));
+		double rm = rc == ImageBoxScale::Cover? std::max(rw, rh): std::min(rw, rh);
+		xscale = yscale = (scale & ImageBoxScale::Grow)
+			? std::max(1., rm)
+			: (scale & ImageBoxScale::Shrink)
+				? std::min(1., rm)
+				: rm;
+	}
+	else
+	{
+		switch (onebit<unsigned, ImageBoxScale>(scale & (ImageBoxScale::StretchX | ImageBoxScale::GrowX | ImageBoxScale::ShrinkX)))
 		{
-			canvas->drawImage(image, Point((GetWidth() - (double)image->GetWidth()) * 0.5, (GetHeight() - (double)image->GetHeight()) * 0.5));
+			default: break;
+			case ImageBoxScale::StretchX: xscale = rw;            break;
+			case ImageBoxScale::GrowX:    xscale = rw > 1? rw: 1; break;
+			case ImageBoxScale::ShrinkX:  xscale = rw < 1? rw: 1; break;
 		}
-		else if (mode == ImageBoxMode::Contain)
+		switch (onebit<unsigned, ImageBoxScale>(scale & (ImageBoxScale::StretchY | ImageBoxScale::GrowY | ImageBoxScale::ShrinkY)))
 		{
-			double bw = GetWidth();
-			double bh = GetHeight();
-			double iw = image->GetWidth();
-			double ih = image->GetHeight();
-			double xscale = bw / iw;
-			double yscale = bh / ih;
-			double scale = std::min(xscale, yscale);
-			canvas->drawImage(image, Rect::xywh((bw - iw * scale) * 0.5, (bh - ih * scale) * 0.5, iw * scale, ih * scale));
-		}
-		else if (mode == ImageBoxMode::Cover)
-		{
-			double bw = GetWidth();
-			double bh = GetHeight();
-			double iw = image->GetWidth();
-			double ih = image->GetHeight();
-			double xscale = bw / iw;
-			double yscale = bh / ih;
-			double scale = std::max(xscale, yscale);
-			canvas->drawImage(image, Rect::xywh((bw - iw * scale) * 0.5, (bh - ih * scale) * 0.5, iw * scale, ih * scale));
+			default: break;
+			case ImageBoxScale::StretchY: yscale = rh;            break;
+			case ImageBoxScale::GrowY:    yscale = rh > 1? rh: 1; break;
+			case ImageBoxScale::ShrinkY:  yscale = rh < 1? rh: 1; break;
 		}
 	}
+	iw *= xscale;
+	ih *= yscale;
+
+	constexpr auto Horizontal = ImageBoxAnchor::East & ImageBoxAnchor::West;
+	constexpr auto Vertical = ImageBoxAnchor::North & ImageBoxAnchor::South;
+	double x = (anchor & Horizontal)
+		? (anchor & ~Horizontal & ImageBoxAnchor::West)
+			? 0
+			: bw-iw
+		: (bw-iw)*0.5;
+	double y = (anchor & Vertical)
+		? (anchor & ~Vertical & ImageBoxAnchor::South)
+			? bh-ih
+			: 0
+		: (bh-ih)*0.5;
+
+	canvas->drawImage(image, Rect::xywh(x, y, iw, ih));
 }

--- a/libraries/ZWidget/src/widgets/toolbar/toolbarbutton.cpp
+++ b/libraries/ZWidget/src/widgets/toolbar/toolbarbutton.cpp
@@ -17,7 +17,7 @@ void ToolbarButton::SetIcon(std::string icon)
 		if (!image)
 			image = new ImageBox(this);
 		image->SetImage(Image::LoadResource(icon, GetDpiScale()));
-		image->SetImageMode(ImageBoxMode::Contain);
+		image->SetImageScale(ImageBoxScale::Contain);
 	}
 	else
 	{

--- a/src/widgets/launcherbanner.cpp
+++ b/src/widgets/launcherbanner.cpp
@@ -150,6 +150,8 @@ LauncherBanner::LauncherBanner(Widget* parent, FName colors, float mix) : Widget
 	Logo = new ImageBox(this);
 	auto imgsrc = (useColors || Theme::getMode() == LIGHT) ? "ui/banner-light.png": "ui/banner-dark.png";
 	Logo->SetImage(Image::LoadResource(imgsrc));
+	Logo->SetImageAnchor(Theme::getAnchor());
+	Logo->SetImageScale(Theme::getScale());
 	this->SetStyleColor("background-color", bg);
 }
 
@@ -160,7 +162,7 @@ double LauncherBanner::GetPreferredHeight()
 
 void LauncherBanner::OnGeometryChanged()
 {
-	auto W = GetWidth(), H = Logo->GetPreferredHeight();
+	auto W = GetWidth(), H = GetPreferredHeight();
 	auto w = Logo->GetPreferredWidth();
 	auto h = H/stripes.size();
 	for (unsigned i = 0; i < stripes.size(); i++)

--- a/src/widgets/themedata.cpp
+++ b/src/widgets/themedata.cpp
@@ -20,8 +20,11 @@
 #include "sc_man.h"
 #include "themedata.h"
 #include "utility/colorspace.h"
+#include "zwidget/widgets/imagebox/imagebox.h"
 
 Colorf Theme::accent;
+ImageBoxAnchor Theme::anchor;
+ImageBoxScale Theme::scale;
 ThemeData Theme::dark = {};
 ThemeData Theme::light = {};
 ThemeData* Theme::theme = nullptr;
@@ -38,6 +41,8 @@ enum ThemeCommands
 	THEME_HOVER,
 	THEME_CLICK,
 	THEME_BORDER,
+	THEME_ANCHOR,
+	THEME_SCALE,
 };
 
 static const char *ThemeCommandStrings[] =
@@ -51,7 +56,65 @@ static const char *ThemeCommandStrings[] =
 	"hover",
 	"click",
 	"border",
+	"anchor",
+	"scale",
 	nullptr
+};
+
+static const ImageBoxAnchor BannerAnchor[] = {
+	Center,
+	North,
+	South,
+	East,
+	West,
+	NorthEast,
+	NorthWest,
+	SouthEast,
+	SouthWest,
+};
+
+static const char* BannerAnchorStrings[2*(sizeof(BannerAnchor)/sizeof(BannerAnchor[0]))+1] = {
+	"Center", "C",
+	"North", "N",
+	"South", "S",
+	"East", "E",
+	"West", "W",
+	"NorthEast", "NE",
+	"NorthWest", "NW",
+	"SouthEast", "SE",
+	"SouthWest", "SW",
+	nullptr,
+};
+
+static const ImageBoxScale BannerScale[] = {
+	None,
+	Contain,
+	Cover,
+	StretchX,
+	GrowX,
+	ShrinkX,
+	StretchY,
+	GrowY,
+	ShrinkY,
+	Stretch,
+	Grow,
+	Shrink,
+};
+
+static const char* BannerScaleStrings[(sizeof(BannerScale)/sizeof(BannerScale[0]))+1] = {
+	"None",
+	"Contain",
+	"Cover",
+	"StretchX",
+	"GrowX",
+	"ShrinkX",
+	"StretchY",
+	"GrowY",
+	"ShrinkY",
+	"Stretch",
+	"Grow",
+	"Shrink",
+	nullptr,
 };
 
 void Theme::initilize(Mode mode, bool contrast)
@@ -71,6 +134,8 @@ void Theme::initilize(Mode mode, bool contrast)
 
 	// basic fallback
 	Theme::accent = Colorf::fromRgb(0x7f7f7f);
+	Theme::anchor = Center;
+	Theme::scale = Contain;
 	simple(Theme::light, 0xffffff, 0x000000, 0xffff00, 0x000000);
 	simple(Theme::dark,  0x000000, 0xffffff, 0x0000ff, 0xffffff);
 
@@ -122,6 +187,37 @@ void Theme::initilize(Mode mode, bool contrast)
 			case THEME_ACCENT:
 				Theme::accent = Colorf::fromRgb(hex(sc));
 				continue;
+			case THEME_ANCHOR:
+				{
+					sc.MustGetString();
+					auto anchor = sc.MatchString(BannerAnchorStrings);
+					if (anchor == -1) DPrintf(DMSG_WARNING, "Unknown anchor '%s'\n", sc.String);
+					else Theme::anchor = BannerAnchor[anchor/2];
+					continue;
+				}
+			case THEME_SCALE:
+				{
+					sc.MustGetString();
+					FString s = sc.String;
+					unsigned scale = None;
+					for (auto &ss: s.Split(','))
+					{
+						size_t i;
+						for (i = 0; BannerScaleStrings[i]; i++)
+						{
+							if (ss.CompareNoCase(BannerScaleStrings[i]) == 0) break;
+						}
+						if (!BannerScaleStrings[i])
+						{
+							DPrintf(DMSG_WARNING, "Unknown scale '%s'\n", ss.GetChars());
+							scale = Theme::scale;
+							break;
+						}
+						scale |= BannerScale[i];
+					}
+					Theme::scale = static_cast<ImageBoxScale>(scale);
+					continue;
+				}
 			}
 			if (!t)
 			{
@@ -157,8 +253,6 @@ Colorf Theme::mix(const ColorLayers& color, float mix)
 	auto c = Color::mix(a, b, mix).rgb;
 	return { c.r, c.g, c.b };
 }
-
-Colorf Theme::getAccent() { return { Theme::accent }; }
 
 Colorf Theme::getMain  (float mix) { return Theme::mix(Theme::theme->main,   mix); }
 Colorf Theme::getHeader(float mix) { return Theme::mix(Theme::theme->header, mix); }

--- a/src/widgets/themedata.h
+++ b/src/widgets/themedata.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <zwidget/core/colorf.h>
+#include <zwidget/widgets/imagebox/imagebox.h>
 
 enum Mode { LIGHT, DARK };
 
@@ -42,6 +43,9 @@ class Theme
 private:
 	static Colorf accent; // UZDoom brand color
 
+	static ImageBoxAnchor anchor; // banner
+	static ImageBoxScale scale;
+
 	static ThemeData light;
 	static ThemeData dark;
 	static ThemeData *theme;
@@ -59,7 +63,9 @@ public:
 		theme = mode == LIGHT? &light: &dark;
 	}
 
-	static Colorf getAccent();
+	static Colorf getAccent() { return { Theme::accent }; }
+	static ImageBoxAnchor getAnchor() { return Theme::anchor; }
+	static ImageBoxScale getScale() { return Theme::scale; }
 
 	static Colorf getMain(float mix);
 	static Colorf getHeader(float mix);

--- a/wadsrc/static/ui/theme.txt
+++ b/wadsrc/static/ui/theme.txt
@@ -1,6 +1,8 @@
 // currently I match the fallbacks in themedata.cpp
 
 accent #237887
+anchor Center
+scale Contain
 
 [light]
 


### PR DESCRIPTION
Gives people more options to theme the launcher, as suggested [here](https://github.com/UZDoom/UZDoom/issues/1772).

Makes stuff like this trivially possible:
<img width="726" height="913" alt="image" src="https://github.com/user-attachments/assets/607d197c-f53e-4271-996d-44eeef11ca1c" />


## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
