### PR TITLE
revert change to bone buffers from 3d2f9e0 (the buffer shouldn't be mapped here)

### DIFF
--- a/src/common/rendering/hwrenderer/data/hw_bonebuffer.cpp
+++ b/src/common/rendering/hwrenderer/data/hw_bonebuffer.cpp
@@ -69,7 +69,6 @@ void BoneBuffer::Clear()
 
 int BoneBuffer::UploadBones(const TArray<VSMatrix>& bones)
 {
-	Map();
 	int totalsize = bones.Size();
 	if (totalsize > (int)mMaxUploadSize)
 	{
@@ -86,12 +85,10 @@ int BoneBuffer::UploadBones(const TArray<VSMatrix>& bones)
 	if (thisindex + totalsize <= mBufferSize)
 	{
 		memcpy(mBufferPointer + thisindex * BONE_SIZE, bones.Data(), totalsize * BONE_SIZE);
-		Unmap();
 		return thisindex;
 	}
 	else
 	{
-		Unmap();
 		return -1;	// Buffer is full. Since it is being used live at the point of the upload we cannot do much here but to abort.
 	}
 }


### PR DESCRIPTION
this only affects older gpus, but is still an important fix

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
