### PR TITLE
Reuse bone cache across portals

### DIFF
--- a/src/common/rendering/v_video.h
+++ b/src/common/rendering/v_video.h
@@ -147,6 +147,7 @@ public:
 	HWViewpointBuffer *mViewpoints = nullptr;	// Viewpoint render data.
 	FLightBuffer *mLights = nullptr;			// Dynamic lights
 	BoneBuffer* mBones = nullptr;				// Model bones
+	unsigned int mBoneCacheGeneration = 0;		
 	IShadowMap mShadowMap;
 
 	int mGameScreenWidth = 0;

--- a/src/playsim/actor.h
+++ b/src/playsim/actor.h
@@ -750,6 +750,8 @@ public:
 	int							 flags;
 	int							 overrideFlagsSet;
 	int							 overrideFlagsClear;
+	unsigned int				 cachedBoneFrame;
+	int							 cachedBoneStartPos = -1;
 
 	AnimInfo anims;
 

--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -675,12 +675,24 @@ void RenderFrameModels(FModelRenderer *renderer, FLevelLocals *Level, const FSpr
 	int boneStartingPosition = -1;
 	bool evaluatedSingle = false;
 
+	if (modelData && modelData->cachedBoneFrame == screen->mBoneCacheGeneration && modelData->cachedBoneStartPos >= 0)
+	{
+		boneStartingPosition = modelData->cachedBoneStartPos;
+		evaluatedSingle = true;
+	}
+
 	for (unsigned i = 0; i < frameinfo.modelsamount; i++)
 	{
 		if (CalcModelOverrides(i, smf, modelData, frameinfo, drawinfo, is_decoupled))
 		{
 			RenderModelFrame(renderer, i, smf, modelData, frameinfo, drawinfo, is_decoupled, tic, translation, boneStartingPosition, evaluatedSingle);
 		}
+	}
+
+	if (modelData && boneStartingPosition >= 0)
+	{
+		modelData->cachedBoneFrame = screen->mBoneCacheGeneration;
+		modelData->cachedBoneStartPos = boneStartingPosition;
 	}
 }
 

--- a/src/rendering/hwrenderer/hw_entrypoint.cpp
+++ b/src/rendering/hwrenderer/hw_entrypoint.cpp
@@ -275,6 +275,7 @@ void WriteSavePic(player_t* player, FileWriter* file, int width, int height)
 		screen->mLights->Clear();
 		screen->mBones->Clear();
 		screen->mViewpoints->Clear();
+		screen->mBoneCacheGeneration++;
 
 		// This shouldn't overwrite the global viewpoint even for a short time.
 		FRenderViewpoint savevp;
@@ -346,6 +347,7 @@ sector_t* RenderView(player_t* player)
 		screen->mLights->Clear();
 		screen->mBones->Clear();
 		screen->mViewpoints->Clear();
+		screen->mBoneCacheGeneration++;
 
 		// NoInterpolateView should have no bearing on camera textures, but needs to be preserved for the main view below.
 		bool saved_niv = NoInterpolateView;


### PR DESCRIPTION
I have a map with *many* tiles in an effort to create manipulatable terrain, but there was a lot of lag involving portals because every model would be recalculated per *pass*. 

But with this change, bones are no longer recalculated on each render pass - they're simply copied over, which will boost performance when portals are involved.

If proof is needed, [here's a demo mod.](https://drive.google.com/file/d/1UG7Qh5vHaFfvXkT6AEoAiS8HJHrXYWsS/view?usp=sharing)
It features one massive room with four line portals.
* Load MAP01
* Type the following in console:
  * `r_portal_recursions 2`
  * `tile`

(Recursions set to 2 is recommended because I don't want to accidentally fry anyone's hardware. It's very performance intensive. `tile` will spawn all the tiles.)

The models in question have `DistanceCheck` with a cvar set to 1024, changed their stats to a non-thinker, and have 255 bones in the tiles, but performance is significantly hampered due to portals. With the change to reusing the bone cache instead of recalculating every pass, performance is greatly increased.

I also tried this with smaller tiles (8 x 8 instead of 15 x 15 and it quadrupled the actor count), but that only made a miniscule improvement to performance.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
