### PR TITLE
Handle long lines getting culled if vertices are far but line is near

### DIFF
--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -1011,6 +1011,11 @@ CCMD(changesky)
 CCMD(skymisttoggle)
 {
 	primaryLevel->flags3 ^= LEVEL3_SKYMIST;
+	if (primaryLevel->flags3 | LEVEL3_SKYMIST)
+	{
+		primaryLevel->skymisttexture.SetNull();
+		InitSkyMap (primaryLevel);
+	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/console/c_cmds.cpp
+++ b/src/console/c_cmds.cpp
@@ -1011,11 +1011,6 @@ CCMD(changesky)
 CCMD(skymisttoggle)
 {
 	primaryLevel->flags3 ^= LEVEL3_SKYMIST;
-	if (primaryLevel->flags3 | LEVEL3_SKYMIST)
-	{
-		primaryLevel->skymisttexture.SetNull();
-		InitSkyMap (primaryLevel);
-	}
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gamedata/g_mapinfo.cpp
+++ b/src/gamedata/g_mapinfo.cpp
@@ -87,7 +87,7 @@ level_info_t *FindLevelInfo (const char *mapname, bool allowdefault)
 		if (TheDefaultLevelInfo.LevelName.IsEmpty())
 		{
 			TheDefaultLevelInfo.SkyPic2 = TheDefaultLevelInfo.SkyPic1 = "SKY1";
-			TheDefaultLevelInfo.SkyMistPic = "SKYMIST1";
+			TheDefaultLevelInfo.SkyMistPic = "SKYMISTA";
 			TheDefaultLevelInfo.LevelName = "Unnamed";
 		}
 		return &TheDefaultLevelInfo;
@@ -247,7 +247,7 @@ void level_info_t::Reset()
 	NextMap = "";
 	NextSecretMap = "";
 	SkyPic1 = SkyPic2 = "-NOFLAT-";
-	SkyMistPic = "SKYMIST1";
+	SkyMistPic = "SKYMISTA";
 	cluster = 0;
 	partime = 0;
 	sucktime = 0;

--- a/src/rendering/hwrenderer/scene/hw_bsp.cpp
+++ b/src/rendering/hwrenderer/scene/hw_bsp.cpp
@@ -264,15 +264,36 @@ bool HWDrawInfo::IsDistanceCulled(seg_t *line)
 	if (Viewpoint.culldistsq <= 0.0)
 		return false;
 
-	double dist1 = (line->v1->fPos() - Viewpoint.Pos).LengthSquared();
-	double dist2 = (line->v2->fPos() - Viewpoint.Pos).LengthSquared();
+	DVector2 VPos = Viewpoint.Pos.XY();
 	if (Viewpoint.bDoOob && r_radarclipper && !(Level->flags3 & LEVEL3_NOFOGOFWAR))
 	{
-		dist1 = (line->v1->fPos() - Viewpoint.OffPos).LengthSquared();
-		dist2 = (line->v2->fPos() - Viewpoint.OffPos).LengthSquared();
+		VPos = Viewpoint.OffPos.XY();
 	}
+	DVector2 vec1 = (line->linedef->v1->fPos() - VPos);
+	DVector2 vec2 = (line->linedef->v2->fPos() - VPos);
+	double dist1 = vec1.LengthSquared();
+	double dist2 = vec2.LengthSquared();
 	if ((dist1 > Viewpoint.culldistsq) && (dist2 > Viewpoint.culldistsq))
-		return true;
+	{
+		if (vec1.dot(vec2) > 0.0) // Angle subtended by the line at the viewpoint less than 90-degrees
+		{
+			return true;
+		}
+		else
+		{
+			DVector2 linevec = line->linedef->Delta();
+			double linelensq = linevec.LengthSquared();
+			if (linelensq > 0.0)
+			{
+				double projlen = -vec1.dot(linevec) / linelensq;
+				DVector2 closest = line->linedef->v1->fPos() + linevec * projlen;
+				if ((VPos- closest).LengthSquared() > Viewpoint.culldistsq)
+				{
+					return true;
+				}
+			}
+		}
+	}
 	return false;
 }
 

--- a/src/rendering/hwrenderer/scene/hw_skyportal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_skyportal.cpp
@@ -99,7 +99,7 @@ void HWSkyPortal::DrawContents(HWDrawInfo *di, FRenderState &state)
 			float misth = origin->texture[2]->GetDisplayHeight();
 			float myscale = di->Level->hw_skymistyscale;
 			float myoffset = (myscale - 1.0)*0.857*misth; // [DVR] Why so many magic numbers when it comes to sky??
-			vertexBuffer->RenderDome(state, origin->texture[2], origin->x_offset[2], myoffset, false, FSkyVertexBuffer::SKYMODE_FOGLAYER, !!(di->Level->flags & LEVEL_FORCETILEDSKY), 0, (myscale == 0.0 ? 0 : 240.0/misth/myscale), FadeColor);
+			vertexBuffer->RenderDome(state, origin->texture[2], origin->x_offset[2], myoffset, false, FSkyVertexBuffer::SKYMODE_FOGLAYER, !!(di->Level->flags & LEVEL_FORCETILEDSKY), 1.0, (myscale == 0.0 ? 0 : 240.0/misth/myscale), FadeColor);
 		}
 		else if (!di->isFullbrightScene() || r_distance_cull_type > 1)
 		{

--- a/src/rendering/r_sky.cpp
+++ b/src/rendering/r_sky.cpp
@@ -74,6 +74,10 @@ void InitSkyMap(FLevelLocals *Level)
 	if (Level->skymisttexture.isNull())
 	{
 		Level->skymisttexture = TexMan.CheckForTexture("skymista", ETextureType::Any);
+		if (TexMan.GetGameTexture(Level->skymisttexture, false) == nullptr)
+		{
+			Level->skymisttexture.SetNull();
+		}
 	}
 
 	skytex1 = TexMan.GetGameTexture(Level->skytexture1, false);

--- a/src/rendering/r_utility.cpp
+++ b/src/rendering/r_utility.cpp
@@ -147,7 +147,10 @@ CUSTOM_CVARD(Bool, r_cull_fps, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "Boolean
 		r_distance_cull_type = 3;
 	}
 }
-CVARD(Color, gl_cullcolor, 0x888888, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "Fog color when r_distance_cull_type > 1. Does not override map fade colors. Hardware renderer only.")
+CUSTOM_CVARD(Color, gl_cullcolor, 0x888888, CVAR_ARCHIVE | CVAR_GLOBALCONFIG, "Fog color when r_distance_cull_type > 1. Does not override map fade colors. Hardware renderer only.")
+{
+	primaryLevel->cullcolor = gl_cullcolor;
+}
 
 int 			viewwindowx;
 int 			viewwindowy;


### PR DESCRIPTION
Distance to segment vertices were being used for culling. This presented a problem when:
- incredibly long linedefs were present close to the viewpoint, but the vertices were far away
- linedefs were split into segments due to bsp, and a segment's vertices were far away resulting in the whole linedef getting rendered as skyflat 

Fixed by using the whole linedefs vertices for culling distance calculations, and computing shortest distance to the entire linedef if angle subtended by linedef at viewpoint is greater than 90-degrees. I could compute that every time but wanted to avoid excessive computation for every segment.
Closes #1809 

Fix cullcolor change applying to current level. 
~~Re-read skymist lump if skymisttoggle console command is run. (This wasn't a problem if skymist lump is specified in `MAPINFO`, but if not the internal one from uzdoom.pk3 was not being read on first `InitSkyMap()` for some reason. Maybe it is being called too early?)~~
Enforce skymist `xscale` to 1.0.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
