### PR TITLE
Fixed OOB string access in MODELDEF path parsing

### DIFF
--- a/src/r_data/models.cpp
+++ b/src/r_data/models.cpp
@@ -844,7 +844,7 @@ void ParseModelDefLump(int Lump)
 					sc.MustGetString();
 					FixPathSeperator(sc.String);
 					path = sc.String;
-					if (path[(int)path.Len()-1]!='/') path+='/';
+					if (path.IsNotEmpty() && path[(int)path.Len()-1]!='/') path+='/';
 				}
 				else if (sc.Compare("model"))
 				{


### PR DESCRIPTION
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
