### PR TITLE
Prevent overdraw in reflective-plane stencils.

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -973,6 +973,7 @@ void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 		for (unsigned int i = 0; i < lines.Size(); i++)
 		{
 			bool edgeline = (i == 0) || !lines[i].seg->backsector || lines[i].seg->backsector->isClosed()
+				|| lines[i].seg->frontsector->isClosed()
 				|| (lines[i].seg->frontsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor] !=
 					lines[i].seg->backsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor]);
 			if (!edgeline && lines[i].seg->backsector)

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -972,24 +972,41 @@ void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 		// Cannot combine these two for loops because of the DrawIndexed() vs Draw() calls interleaving
 		for (unsigned int i = 0; i < lines.Size(); i++)
 		{
-			flat.section = lines[i].sub->section;
-			flat.iboindex = lines[i].sub->sector->iboindex[isceiling ? sector_t::ceiling : sector_t::floor];
-			flat.plane.GetFromSector(lines[i].sub->sector, isceiling ? sector_t::ceiling : sector_t::floor);
-			screen->mVertexData->Map();
-			auto verts = screen->mVertexData->AllocVertices(5);
-			auto ptr = verts.first;
-			ptr[0].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
-					   lines[i].vertexes[0]->p.Y, 0, 0);
-			ptr[1].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p),
-					   lines[i].vertexes[1]->p.Y, 0, 0);
-			ptr[2].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p) + zshift*GetMirrorSide(),
-					   lines[i].vertexes[1]->p.Y, 0, 0);
-			ptr[3].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p) + zshift*GetMirrorSide(),
-					   lines[i].vertexes[0]->p.Y, 0, 0);
-			ptr[4].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
-					   lines[i].vertexes[0]->p.Y, 0, 0);
-			screen->mVertexData->Unmap();
-			state.Draw(DT_TriangleStrip, verts.second, 5, screen->IsVulkan());
+			bool edgeline = (i == 0) || !lines[i].seg->backsector
+				|| (lines[i].seg->frontsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor] !=
+					lines[i].seg->backsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor]);
+			if (!edgeline && lines[i].seg->backsector)
+			{
+				if (isceiling)
+				{
+					edgeline |= lines[i].seg->frontsector->ceilingplane.fD() != lines[i].seg->backsector->ceilingplane.fD();
+				}
+				else
+				{
+					edgeline |= lines[i].seg->frontsector->floorplane.fD() != lines[i].seg->backsector->floorplane.fD();
+				}
+			}
+			if (edgeline)
+			{
+				flat.section = lines[i].sub->section;
+				flat.iboindex = lines[i].sub->sector->iboindex[isceiling ? sector_t::ceiling : sector_t::floor];
+				flat.plane.GetFromSector(lines[i].sub->sector, isceiling ? sector_t::ceiling : sector_t::floor);
+				screen->mVertexData->Map();
+				auto verts = screen->mVertexData->AllocVertices(5);
+				auto ptr = verts.first;
+				ptr[0].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
+						   lines[i].vertexes[0]->p.Y, 0, 0);
+				ptr[1].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p),
+						   lines[i].vertexes[1]->p.Y, 0, 0);
+				ptr[2].Set(lines[i].vertexes[1]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[1]->p) + zshift*GetMirrorSide(),
+						   lines[i].vertexes[1]->p.Y, 0, 0);
+				ptr[3].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p) + zshift*GetMirrorSide(),
+						   lines[i].vertexes[0]->p.Y, 0, 0);
+				ptr[4].Set(lines[i].vertexes[0]->p.X, flat.plane.plane.ZatPoint(lines[i].vertexes[0]->p),
+						   lines[i].vertexes[0]->p.Y, 0, 0);
+				screen->mVertexData->Unmap();
+				state.Draw(DT_TriangleStrip, verts.second, 5, (i == 0));
+			}
 		}
 	}
 	else

--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -972,7 +972,7 @@ void HWPlaneMirrorPortal::DrawPortalStencil(FRenderState &state, int pass)
 		// Cannot combine these two for loops because of the DrawIndexed() vs Draw() calls interleaving
 		for (unsigned int i = 0; i < lines.Size(); i++)
 		{
-			bool edgeline = (i == 0) || !lines[i].seg->backsector
+			bool edgeline = (i == 0) || !lines[i].seg->backsector || lines[i].seg->backsector->isClosed()
 				|| (lines[i].seg->frontsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor] !=
 					lines[i].seg->backsector->reflect[isceiling ? sector_t::ceiling : sector_t::floor]);
 			if (!edgeline && lines[i].seg->backsector)

--- a/src/rendering/hwrenderer/scene/hw_portal.h
+++ b/src/rendering/hwrenderer/scene/hw_portal.h
@@ -92,7 +92,7 @@ public:
 	TArray<HWWall> lines;
 	BoundingRect boundingBox;
 	int planesused = 0;
-	float zshift = 0.1; 	// HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats unless zshift >= 0.1
+	float zshift = 1.0;	// HWPlaneMirrorPortal::DrawPortalStencil() z-fights with flats even at a distance of 32000 map units unless zshift >= 1.0
 	HWFlat flat;
 
 	HWPortal(FPortalSceneState *s, bool local = false) : mState(s), boundingBox(false)


### PR DESCRIPTION
Covering leaky seams does not have to occur for all the lines in the reflective flats portal. The `state.Draw()` call also doesn't have to be re-initialized (last boolean argument) for every line. Just the first one.

This was prompted by someone reporting a significant slowdown in reflective flats rendering.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
