### PR TITLE
Fixed local pickups not working with dehacked items

### DIFF
--- a/wadsrc/static/zscript/actors/inventory/inventory.zs
+++ b/wadsrc/static/zscript/actors/inventory/inventory.zs
@@ -1453,7 +1453,7 @@ class DehackedPickup : Inventory
 	{
 		if (RealPickup != null)
 			return RealPickup.ShouldStay ();
-		else return true;
+		else return false;
 	}
 
 	override bool ShouldRespawn ()


### PR DESCRIPTION
This function gets called before RealPickup is spawned meaning it was never allowed to be locally picked up with true as the default.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
