### PR TITLE
Added deh/bex support to file dropping in launcher

### DIFF
--- a/src/widgets/networkpage.cpp
+++ b/src/widgets/networkpage.cpp
@@ -110,7 +110,18 @@ bool NetworkPage::OnFileDrop(std::string path)
 {
 	auto text = ParametersEdit->GetText();
 	if (!text.empty()) text += " ";
-	text += "-file \"";
+
+	std::string arg;
+	auto ext = path.substr(path.length() - 4u);
+	if (!stricmp(ext.c_str(), ".deh"))
+		arg = "-deh";
+	else if (!stricmp(ext.c_str(), ".bex"))
+		arg = "-bex";
+	else
+		arg = "-file";
+
+	text += arg;
+	text += " \"";
 	text += path;
 	text += "\"";
 	ParametersEdit->SetText(text);

--- a/src/widgets/playgamepage.cpp
+++ b/src/widgets/playgamepage.cpp
@@ -100,7 +100,18 @@ bool PlayGamePage::OnFileDrop(std::string path)
 {
 	auto text = ParametersEdit->GetText();
 	if (!text.empty()) text += " ";
-	text += "-file \"";
+
+	std::string arg;
+	auto ext = path.substr(path.length() - 4u);
+	if (!stricmp(ext.c_str(), ".deh"))
+		arg = "-deh";
+	else if (!stricmp(ext.c_str(), ".bex"))
+		arg = "-bex";
+	else
+		arg = "-file";
+
+	text += arg;
+	text += " \"";
 	text += path;
 	text += "\"";
 	ParametersEdit->SetText(text);


### PR DESCRIPTION
These need to use the `-deh`/`-bex` commands in order to be processed correctly. Config and demo support can be added at a later time since that will ideally replace the existing argument instead of appending it.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
