### PR TITLE
Fix particle flag SPF_NO_XY_BILLBOARD being ignored

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -407,3 +407,4 @@ Jordi Conesa
 Andrei Stepanov
 Gabriel Valderrama
 Whovian9369
+soliddew

--- a/src/rendering/hwrenderer/scene/hw_sprites.cpp
+++ b/src/rendering/hwrenderer/scene/hw_sprites.cpp
@@ -410,9 +410,8 @@ bool HWSprite::CalculateVertices(HWDrawInfo* di, FVector3* v, DVector3* vp)
 	const bool AngledRoll = (actor != nullptr && actor->renderflags2 & RF2_ANGLEDROLL);
 
 	// [BB] Billboard stuff
-	const bool drawWithXYBillboard = ((particle && gl_billboard_particles && !(particle->flags & SPF_NO_XY_BILLBOARD)) || (!(actor && actor->renderflags & RF_FORCEYBILLBOARD)
-		//&& di->mViewActor != nullptr
-		&& (gl_billboard_mode == 1 || (actor && actor->renderflags & RF_FORCEXYBILLBOARD)))) && !AngledRoll;
+	const bool drawWithXYBillboard = ((particle && (gl_billboard_particles || gl_billboard_mode == 1) && !(particle->flags & SPF_NO_XY_BILLBOARD))
+		|| (actor && !(actor->renderflags & RF_FORCEYBILLBOARD) && (gl_billboard_mode == 1 || actor->renderflags & RF_FORCEXYBILLBOARD))) && !AngledRoll;
 
 	bool drawBillboardFacingCamera = gl_billboard_faces_camera;
 	if (!hw_force_cambbpref)


### PR DESCRIPTION
Due to a logic error, the flag SPF_NO_XY_BILLBOARD used in visual thinkers and particles was not overwriting X/Y billboarding being set from gl_billboard_mode 1.  Because actor will be null for a particle, the first OR statement is true and the left side SPF_NO_XY_BILLBOARD check will be ignored. I'm assuming the intent with SPF_NO_XY_BILLBOARD is to take precedence over the CVAR like the other billboarding flags.

I cleaned up the logic to the best of my ability so its a bit easier to understand and works as expected.  I also removed a comment that looks like its been sitting there for 8+ years and references a field that doesn't seem to exist.

Attached is a test map, from left to right are (particles are the same as VTs but I figured I'd include em):

Actor with no flags
Actor with FORCEYBILLBOARD
Actor with FORCEXYBILLBOARD

Particle with no flags (XY)
Particle with SPF_NO_XY_BILLBOARD

VT with no flags (XY)
VT with SPF_NO_XY_BILLBOARD

Thanks to my Supplice team member Kom for helping rubber ducky this out.
## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
[billboardtest.zip](https://github.com/user-attachments/files/31720635/billboardtest.zip)
