### PR TITLE
Use correct command name in `numeval` usage

### DIFF
--- a/src/common/console/c_expr.cpp
+++ b/src/common/console/c_expr.cpp
@@ -902,5 +902,5 @@ CCMD (numeval)
 		}
 	}
 
-	Printf ("Usage: eval <expression> [variable]\n");
+	Printf ("Usage: numeval <expression> [variable]\n");
 }


### PR DESCRIPTION
## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
