### PR TITLE
Speeding up reflective flats when not rendered through another portal or rendered through another reflective flat

### DIFF
--- a/src/rendering/hwrenderer/scene/hw_portal.cpp
+++ b/src/rendering/hwrenderer/scene/hw_portal.cpp
@@ -946,7 +946,10 @@ bool HWPlaneMirrorPortal::Setup(HWDrawInfo *di, FRenderState &rstate, Clipper *c
 	di->SetClipHeight(planez, state->PlaneMirrorMode < 0 ? -1.f : 1.f);
 	di->SetupView(rstate, vp.Pos.X, vp.Pos.Y, vp.Pos.Z, !!(state->MirrorFlag & 1), !!(state->PlaneMirrorFlag & 1));
 	vp.ViewVector3D.Z = - vp.ViewVector3D.Z;
-	SetupCoverage(di);
+	if (di->outer->mCurrentPortal && (di->outer->mCurrentPortal->GetHWPortalType() != HWP_PLANEMIRROR))
+	{
+		SetupCoverage(di);
+	}
 	ClearClipper(di, clipper);
 
 	di->UpdateCurrentMapSection();


### PR DESCRIPTION
In #619 (the big portals in mirrors and mirrors in portals fix), `SetupCoverage()` was added to `class HWPlaneMirror`. It was necessary to see any reflections in flats when viewed through other portals like line mirrors or line portals. This caused unnecessary slowdown in all other cases.

Now, this PR only calls `SetupCoverage()` for reflective flats when viewed through another portal that is not itself a reflective flat. This speeds up rendering, especially when reflective flat floor and ceiling from the same `PortalGroup` face each other.

For a good test, warp to ( -1736, 2154) in MAP01 of "[Sapphire: Orbital Research](https://www.moddb.com/mods/sapphire-orbital-research)" map pack with `notarget` enabled and `vid_fps` set to `true`. The area has reflective floors facing reflective ceilings.

Further optimization here is possible once the 3D camera frustum gets backported.

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
