### PR TITLE
use native fullscreen by default on macos

### DIFF
--- a/src/common/platform/posix/cocoa/i_video.mm
+++ b/src/common/platform/posix/cocoa/i_video.mm
@@ -93,7 +93,7 @@ EXTERN_CVAR(Int,  vid_defheight)
 EXTERN_CVAR(Bool, vk_debug)
 
 CVAR(Bool, mvk_debug, false, 0)
-CVAR(Bool, vid_nativefullscreen, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Bool, vid_nativefullscreen, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 CUSTOM_CVAR(Bool, vid_autoswitch, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG | CVAR_NOINITCALL)
 {

--- a/src/gameconfigfile.cpp
+++ b/src/gameconfigfile.cpp
@@ -719,6 +719,16 @@ void FGameConfigFile::DoGlobalSetup ()
 				}
 			}
 		}
+
+		if(EngineLastRunVer < 234)
+		{
+			// Native fullscreen is now enabled by default, this is only used for MacOS.
+			var = FindCVar("vid_nativefullscreen", NULL);
+			if(var != NULL)
+			{
+				var->SetGenericRep(1, CVAR_Bool);
+			}
+		}
 	}
 
 	OkayToWrite = true;

--- a/src/version.h
+++ b/src/version.h
@@ -45,7 +45,7 @@
 // Version stored in the ini's [LastRun] section.
 // Bump it if you made some configuration change that you want to
 // be able to migrate in FGameConfigFile::DoGlobalSetup().
-#define ENGINELASTRUNVERSION "233"
+#define ENGINELASTRUNVERSION "234"
 #define GAMELASTRUNVERSION "1"
 
 // Protocol version used in demos.


### PR DESCRIPTION
This change flips the default behaviour to use real fullscreen on MacOS as it gives a much better and more consistent OS experience. Using a borderless window is pretty rare in macOS games, and breaks several system features like Game mode and Spaces.

This is window code, not rendering, but to be safe I checked with both the OpenGL and Vulkan backends and native fullscreen works as expected on both.

Fixes #1523

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
