### PR TITLE
fix padding of notify messages

### DIFF
--- a/src/console/c_notifybuffer.cpp
+++ b/src/console/c_notifybuffer.cpp
@@ -117,7 +117,7 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 	}
 
 	source.StripRight();
-    // insert the suffix directly as part ofthe message string 
+    // insert the suffix directly as part ofthe message string
     if (countedIdentical > 1)
     {
 		source += " (";
@@ -147,12 +147,13 @@ void FNotifyBuffer::AddString(int printlevel, FString source)
 void FNotifyBuffer::Draw()
 {
 	bool center = (con_centernotify != 0.f);
-	int line, lineadv, color, j;
+	int line, lineadv, color, j, left;
 	bool canskip;
 
 	FFont* font = FFont::GetSmallTextFont(generic_ui ? NewSmallFont : AlternativeSmallFont);
 
 	line = Top + font->GetDisplacement();
+	left = font->GetDisplacement();
 	canskip = true;
 
 	lineadv = font->GetHeight ();
@@ -180,7 +181,7 @@ void FNotifyBuffer::Draw()
 
 			int scale = active_con_scaletext(twod, generic_ui);
 			int textWidth = font->StringWidth(notify.Text);
-			int xPos = 0;
+			int xPos = left;
 
             if (center)
             {


### PR DESCRIPTION
This is a super minor fix that makes the let-aligned edge of the notify text match the top-aligned edge.

Before:
<img width="657" height="121" alt="before" src="https://github.com/user-attachments/assets/d0d02d8d-bd53-4d06-ad45-1d9c8b4ba869" />

After:
<img width="657" height="121" alt="after" src="https://github.com/user-attachments/assets/dd79362e-2b2a-4022-ba3e-8a8b185ed9d2" />


## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
