### PR TITLE
add always skip intermission option

### DIFF
--- a/src/g_level.cpp
+++ b/src/g_level.cpp
@@ -703,6 +703,9 @@ bool FLevelLocals::ShouldDoIntermission(cluster_info_t* nextcluster, cluster_inf
 	if ((sv_alwaystally == 2) || (deathmatch))
 		return true;
 
+	if (sv_alwaystally == 3)
+		return false;
+
 	if ((sv_alwaystally == 0) && (flags & LEVEL_NOINTERMISSION))
 		return false;
 

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1761,6 +1761,7 @@ OptionValue AlwaysTally
 	0,	"$OPTVAL_MODDEFINED"
 	1,	"$OPTVAL_NOTHUBS"
 	2,	"$OPTVAL_WITHHUBS"
+	3,	"$OPTVAL_NEVER"
 }
 
 OptionValue SaveOrder


### PR DESCRIPTION
I'm not sure why 'always' wasn't an option for skipping the intermission screen, I couldn't find any discussion of it here, so I've added it in. please let me know if there was a reason.

This option (sv_alwaystally 3) always skips the intermission score screen (except in deathmatch). it does not affect the cutscenes or text screens in my testing.

https://github.com/user-attachments/assets/664416ef-cbf3-4d04-8cd7-52dc52c5a489

(The level name on load is a mod, and not part of this change)


## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
