### PR TITLE
new menu mode that exclusively takes in gameplay inputs

### DIFF
--- a/src/common/console/c_console.cpp
+++ b/src/common/console/c_console.cpp
@@ -713,7 +713,7 @@ void C_DrawConsole ()
 
 	}
 
-	if (menuactive != MENU_Off)
+	if (menuactive != MENU_Off && menuactive != MENU_GameplayMenu)
 	{
 		return;
 	}
@@ -800,7 +800,7 @@ void C_ToggleConsole ()
 		if (sysCallbacks.ToggleFullConsole) sysCallbacks.ToggleFullConsole();
 		togglestate = c_down;
 	}
-	else if (!chatmodeon && (ConsoleState == c_up || ConsoleState == c_rising) && menuactive == MENU_Off)
+	else if (!chatmodeon && (ConsoleState == c_up || ConsoleState == c_rising) && (menuactive == MENU_Off || menuactive == MENU_GameplayMenu))
 	{
 		ConsoleState = c_falling;
 		HistPos = NULL;
@@ -1214,7 +1214,7 @@ bool C_Responder (event_t *ev)
 	if (ev->type != EV_GUI_Event ||
 		ConsoleState == c_up ||
 		ConsoleState == c_rising ||
-		menuactive != MENU_Off)
+		(menuactive != MENU_Off && menuactive != MENU_GameplayMenu))
 	{
 		return false;
 	}

--- a/src/common/menu/menu.cpp
+++ b/src/common/menu/menu.cpp
@@ -532,6 +532,8 @@ DEFINE_ACTION_FUNCTION(DMenu, ActivateMenu)
 
 void M_SetMenu(FName menu, int param)
 {
+	if(menuactive == MENU_GameplayMenu) menuactive = MENU_Off; // make sure gameplay menu mode gets properly reset when switching menus
+
 	if (sysCallbacks.SetSpecialMenu && !sysCallbacks.SetSpecialMenu(menu, param)) return;
 
 	DMenuDescriptor **desc = MenuDescriptors.CheckKey(menu);
@@ -641,7 +643,6 @@ bool M_Responder (event_t *ev)
 	{
 		return false;
 	}
-
 	if (CurrentMenu != nullptr && menuactive != MENU_Off)
 	{
 		// There are a few input sources we are interested in:
@@ -748,7 +749,7 @@ bool M_Responder (event_t *ev)
 				}
 			}
 		}
-		else if (menuactive != MENU_WaitKey && (ev->type == EV_KeyDown || ev->type == EV_KeyUp))
+		else if (menuactive != MENU_WaitKey && menuactive != MENU_GameplayMenu && (ev->type == EV_KeyDown || ev->type == EV_KeyUp))
 		{
 			// eat blocked controller events without dispatching them.
 			if (ev->data1 >= KEY_FIRSTJOYBUTTON && m_blockcontrollers && ev->type == EV_KeyDown) return true;
@@ -835,9 +836,18 @@ bool M_Responder (event_t *ev)
 				return true;
 			}
 		}
-		return CurrentMenu->CallResponder(ev) || !keyup;
+		if(menuactive != MENU_GameplayMenu || ev->type == EV_GUI_Event)
+		{
+			return CurrentMenu->CallResponder(ev) || !keyup;
+		}
+		else if(CurrentMenu->CallResponder(ev))
+		{
+			return true;
+		}
+		//intentional fallthrough for if MENU_GameplayMenu return false from OnInputEvent
 	}
-	else if (MenuEnabled)
+
+	if (MenuEnabled)
 	{
 		if (ev->type == EV_KeyDown)
 		{

--- a/src/common/menu/menustate.h
+++ b/src/common/menu/menustate.h
@@ -28,5 +28,6 @@ enum EMenuState : int
 	MENU_On,			// Menu is opened
 	MENU_WaitKey,		// Menu is opened and waiting for a key in the controls menu
 	MENU_OnNoPause,		// Menu is opened but does not pause the game
+	MENU_GameplayMenu,	// Menu is opened but does not pause the game, and uses inputevents, and passes through non-consumed events to the playsim
 };
 extern	EMenuState		menuactive; 	// Menu overlayed?

--- a/src/common/menu/messagebox.cpp
+++ b/src/common/menu/messagebox.cpp
@@ -78,7 +78,7 @@ void M_StartMessage(const char *message, int messagemode, FName action)
 	if (CurrentMenu == NULL)
 	{
 		// only play a sound if no menu was active before
-		M_StartControlPanel(menuactive == MENU_Off);
+		M_StartControlPanel(menuactive == MENU_Off || menuactive == MENU_GameplayMenu);
 	}
 	DMenu *newmenu = CreateMessageBoxMenu(CurrentMenu, message, messagemode, false, action);
 	newmenu->mParentMenu = CurrentMenu;

--- a/src/ct_chat.cpp
+++ b/src/ct_chat.cpp
@@ -541,7 +541,7 @@ static bool DoSubstitution (FString &out, const char *in)
 
 bool CanChat()
 {
-	return gamestate == GS_LEVEL && !demoplayback && menuactive == MENU_Off;
+	return gamestate == GS_LEVEL && !demoplayback && (menuactive == MENU_Off || menuactive == MENU_GameplayMenu);
 }
 
 CCMD (messagemode)

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -1083,8 +1083,16 @@ static void DrawRateStuff()
 
 static void DrawOverlays()
 {
-	C_DrawConsole ();
-	M_Drawer ();
+	if(menuactive == MENU_GameplayMenu)
+	{ // draw console above gameplay menus
+		M_Drawer ();
+		C_DrawConsole ();
+	}
+	else
+	{
+		C_DrawConsole ();
+		M_Drawer ();
+	}
 	DrawRateStuff();
 	if (!hud_toggled)
 		FStat::PrintStat (twod);
@@ -2982,7 +2990,7 @@ bool System_WantGuiCapture()
 {
 	bool wantCapt;
 
-	if (menuactive == MENU_Off)
+	if (menuactive == MENU_Off || menuactive == MENU_GameplayMenu)
 	{
 		wantCapt = ConsoleState == c_down || ConsoleState == c_falling || chatmodeon;
 	}
@@ -3007,7 +3015,7 @@ static bool System_DispatchEvent(event_t* ev)
 {
 	shiftState.AddEvent(ev);
 
-	if (ev->type == EV_Mouse && menuactive == MENU_Off && ConsoleState != c_down && ConsoleState != c_falling && !primaryLevel->localEventManager->Responder(ev) && !paused)
+	if (ev->type == EV_Mouse && (menuactive == MENU_Off || (menuactive == MENU_GameplayMenu && CurrentMenu && !CurrentMenu->mMouseCapture))&& ConsoleState != c_down && ConsoleState != c_falling && !primaryLevel->localEventManager->Responder(ev) && !paused)
 	{
 		if (buttonMap.ButtonDown(Button_Mlook) || freelook)
 		{

--- a/src/g_game.cpp
+++ b/src/g_game.cpp
@@ -692,6 +692,17 @@ void G_BuildTiccmd (usercmd_t *cmd)
 	axis_side = buttonMap.ButtonAnalog(Button_MoveLeft) - buttonMap.ButtonAnalog(Button_MoveRight);
 	axis_up = buttonMap.ButtonAnalog(Button_MoveUp) - buttonMap.ButtonAnalog(Button_MoveDown);
 
+	bool ignore_yaw = false;
+	bool ignore_pitch = false;
+
+	if(menuactive == MENU_GameplayMenu && CurrentMenu && CurrentMenu->mMouseCapture)
+	{ // blank out "look" inputs if GameplayMenu wants mouse
+		ignore_yaw = true;
+		ignore_pitch = true;
+		mousex = 0.0f;
+		mousey = 0.0f;
+	}
+
 	if (cl_analog_straferun)
 	{
 		// Rescale diagonal analog input from roughly [0.77, 0.77] to [1.0, 1.0],
@@ -719,14 +730,18 @@ void G_BuildTiccmd (usercmd_t *cmd)
 
 	if (HELD(BT_STRAFE) || (lookstrafe && buttonMap.ButtonDown(Button_Mlook)))
 	{
-		axis_side = axis_yaw;
-		axis_yaw = 0.0f;
+		if(!ignore_yaw)
+		{
+			axis_side = axis_yaw;
+			axis_yaw = 0.0f;
+		}
 	}
 
 	if (buttonMap.ButtonDown(Button_Mlook))
 	{
 		axis_pitch = axis_forward;
 		axis_forward = 0.0f;
+		ignore_pitch = false;
 	}
 
 	auto i_axis_side    = joyint(axis_side * sidemove[cl_analog_run | speed]);
@@ -740,7 +755,10 @@ void G_BuildTiccmd (usercmd_t *cmd)
 	//		the analog device it is. (turnheld)
 	if (i_axis_yaw)
 	{
-		G_AddViewAngle(i_axis_yaw);
+		if(!ignore_yaw)
+		{
+			G_AddViewAngle(i_axis_yaw);
+		}
 		turnheld = 0;
 	}
 	else if (!HELD(BT_RIGHT|BT_LEFT))
@@ -766,7 +784,10 @@ void G_BuildTiccmd (usercmd_t *cmd)
 
 	if (i_axis_pitch)
 	{
-		G_AddViewPitch(i_axis_pitch);
+		if(!ignore_pitch)
+		{
+			G_AddViewPitch(i_axis_pitch);
+		}
 	}
 	else
 	{

--- a/src/p_tick.cpp
+++ b/src/p_tick.cpp
@@ -113,7 +113,7 @@ bool P_CheckTickerPaused ()
 	// pause if in menu or console and at least one tic has been run
 	if ( !netgame
 		 && gamestate != GS_TITLELEVEL
-		 && ((menuactive != MENU_Off && menuactive != MENU_OnNoPause) ||
+		 && ((menuactive != MENU_Off && menuactive != MENU_OnNoPause && menuactive != MENU_GameplayMenu) ||
 			 ConsoleState == c_down || ConsoleState == c_falling)
 		 && !demoplayback
 		 && !demorecording

--- a/wadsrc/static/zscript/engine/ui/menu/menu.zs
+++ b/wadsrc/static/zscript/engine/ui/menu/menu.zs
@@ -165,6 +165,7 @@ class Menu : Object native ui version("2.4")
 		On,				// Menu is opened
 		WaitKey,		// Menu is opened and waiting for a key in the controls menu
 		OnNoPause,		// Menu is opened but does not pause the game
+		GameplayMenu,	// Menu is opened but does not pause the game, and uses inputevents, and passes through non-consumed events to the playsim
 	};
 
 	native Menu mParentMenu;


### PR DESCRIPTION
(and passes them through to the playsim if not consumed)
examples:
[GameplayMenu_BlockMouse.zip](https://github.com/user-attachments/files/32069182/GameplayMenu_BlockMouse.zip)
[GameplayMenu_AllowMouse.zip](https://github.com/user-attachments/files/32069184/GameplayMenu_AllowMouse.zip)

## Checklist
- [x] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
