### PR TITLE
Automap match statusbar (+text padding)

### DIFF
--- a/src/am_map.cpp
+++ b/src/am_map.cpp
@@ -162,6 +162,7 @@ CVAR(Bool, am_showkeys, true, CVAR_ARCHIVE);
 CVAR(Int, am_showtriggerlines, 0, CVAR_ARCHIVE);
 CVAR(Int, am_showthingsprites, 0, CVAR_ARCHIVE);
 CVAR (Bool, am_showkeys_always, false, CVAR_ARCHIVE);
+CVAR(Bool, am_match_statusbar, true, CVAR_ARCHIVE)
 
 CUSTOM_CVAR(Int, am_emptyspacemargin, 0, CVAR_ARCHIVE)
 {
@@ -608,7 +609,7 @@ CCMD(am_restorecolors)
 }
 
 
-namespace AutoMap::Colors 
+namespace AutoMap::Colors
 {
 	static inline const AMColor not_used = AMColor(0x010000);
 
@@ -1935,7 +1936,7 @@ void DAutomap::drawGrid (int color)
 	start = miny - exty;
 	start = ceil((start - bmaporgy) / FBlockmap::MAPBLOCKUNITS) * FBlockmap::MAPBLOCKUNITS + bmaporgy;
 	end = miny + minlen - exty;
-	
+
 	// draw horizontal gridlines
 	uint16_t yLineCount = ceil(abs(end - start) / (double)FBlockmap::MAPBLOCKUNITS);
 	y = start;

--- a/src/d_main.cpp
+++ b/src/d_main.cpp
@@ -942,6 +942,8 @@ CVAR(Bool, vid_activeinbackground, false, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 EXTERN_CVAR(Bool, r_drawvoxels)
 EXTERN_CVAR(Int, gl_tonemap)
+EXTERN_CVAR(Bool, am_match_statusbar)
+
 static uint32_t GetCaps()
 {
 	ActorRenderFeatureFlags FlagSet;
@@ -1241,9 +1243,17 @@ void D_Display ()
 		if (!hud_toggled)
 		{
 			V_DrawBlend(viewsec);
+
 			if (automapactive)
 			{
-				primaryLevel->automap->Drawer ((hud_althud && viewheight == SCREENHEIGHT) ? viewheight : StatusBar->GetTopOfStatusbar());
+				if (viewheight == SCREENHEIGHT && (hud_althud || am_match_statusbar))
+				{
+					primaryLevel->automap->Drawer (viewheight);
+				}
+				else
+				{
+					primaryLevel->automap->Drawer (StatusBar->GetTopOfStatusbar());
+				}
 			}
 
 			// for timing the statusbar code.
@@ -1265,7 +1275,7 @@ void D_Display ()
 				StatusBar->CallDraw (HUD_AltHud, vp.TicFrac);
 				StatusBar->DrawTopStuff (HUD_AltHud);
 			}
-			else if (viewheight == SCREENHEIGHT && viewactive && screenblocks > 10)
+			else if (viewheight == SCREENHEIGHT && (viewactive || (am_match_statusbar && automapactive)) && screenblocks > 10)
 			{
 				EHudState state = DrawFSHUD ? HUD_Fullscreen : HUD_None;
 				StatusBar->DrawBottomStuff (state);

--- a/src/g_statusbar/shared_sbar.cpp
+++ b/src/g_statusbar/shared_sbar.cpp
@@ -71,6 +71,7 @@ EXTERN_CVAR (Bool, am_showtotaltime)
 EXTERN_CVAR (Bool, am_showlevelname)
 EXTERN_CVAR(Bool, inter_subtitles)
 EXTERN_CVAR(Bool, ui_screenborder_classic_scaling)
+EXTERN_CVAR(Bool, am_match_statusbar)
 
 CVAR(Int, hud_scale, -1, CVAR_ARCHIVE);
 CVAR(Bool, log_vgafont, false, CVAR_ARCHIVE);
@@ -529,8 +530,8 @@ void DBaseStatusBar::DoDrawAutomapHUD(int crdefault, int highlight)
 	auto fheight = font->GetHeight();
 	FString textbuffer;
 	int sec;
-	int y = 0;
 	int textdist = 4;
+	int y = textdist;
 	int zerowidth = font->GetCharWidth('0');
 
 	if (!generic_ui)
@@ -562,7 +563,7 @@ void DBaseStatusBar::DoDrawAutomapHUD(int crdefault, int highlight)
 
 	if (!deathmatch)
 	{
-		y = 0;
+		y = textdist;
 		if (am_showmonsters)
 		{
 			textbuffer.Format("%s\34%c %d/%d", GStrings.GetString("AM_MONSTERS"), crdefault + 65, primaryLevel->killed_monsters, primaryLevel->total_monsters);
@@ -616,8 +617,14 @@ void DBaseStatusBar::DoDrawAutomapHUD(int crdefault, int highlight)
 
 	StatusbarToRealCoords(x, yy, w, h);
 
+	int screenBottom = GetTopOfStatusbar();
+	if (am_match_statusbar && viewheight == SCREENHEIGHT)
+	{
+		screenBottom = SCREENHEIGHT;
+	}
+
 	// Get the y coordinate for the first line of the map name text.
-	y = Scale(GetTopOfStatusbar() - int(h), vheight, twod->GetHeight()) - fheight * numlines;
+	y = Scale(screenBottom - int(h), vheight, twod->GetHeight()) - fheight * numlines;
 
 	// Draw the texts centered above the status bar.
 	for (unsigned i = 0; i < numlines; i++)

--- a/wadsrc/static/menudef.txt
+++ b/wadsrc/static/menudef.txt
@@ -1933,6 +1933,7 @@ OptionMenu AutomapOptions protected
 	Option "$AUTOMAPMNU_SHOWTOTALTIME",			"am_showtotaltime", "OnOff"
 	Option "$AUTOMAPMNU_SHOWMAPLABEL",			"am_showmaplabel", "MaplabelTypes"
 	Option "$AUTOMAPMNU_SHOWLEVELNAME",			"am_showlevelname", "OnOff"
+	Option "$AUTOMAPMNU_MATCHSTATUSBAR",		"am_match_statusbar", "OnOff"
 
 	StaticText ""
 	Option "$AUTOMAPMNU_SHOWKEYS",				"am_showkeys", "OnOff"
@@ -3133,7 +3134,7 @@ OptionMenu AccessibilityOptions protected
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_EXTRA"
 	Slider "$ACCMNU_LIGHT_RADIUS", "r_visibility", 0.0, 16.0, 1.0, 1
 	Tooltip "$ACCMNU_TOOLTIP_LIGHT_RADIUS"
-	
+
 	StaticText ""
 	Slider "$ACCMNU_DOUBLECLICK_THRESHOLD", "cl_doubleclickthreshold", 100, 600, 25, 0
 	Tooltip "$ACCMNU_TOOLTIP_DOUBLECLICK_THRESHOLD"


### PR DESCRIPTION
This change introduces a new automap option and cvar: am_matchStatusbar, which when enabled, causes the automap screen to use the same status bar setting as the game screen, so fullscreen hud or no hud can be used on the automap:

<img width="752" height="624" alt="Screenshot 2026-09-12 at 02 31 29" src="https://github.com/user-attachments/assets/271c0836-e9fc-4212-aeea-44aa6a971c2b" />
<img width="752" height="624" alt="Screenshot 2026-09-12 at 02 28 37" src="https://github.com/user-attachments/assets/73738f68-5304-4e47-8f59-b88d79ea87a0" />
<img width="752" height="624" alt="Screenshot 2026-09-12 at 02 30 26" src="https://github.com/user-attachments/assets/3931718f-a24b-46f4-91bc-0703902fe9cb" />

This change does not affect the alternative HUD, that always draws the automap fullscreen and uses its own overlay text.

(also also adjusted the top padding of the upper text while I was in here)

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
