### PR TITLE
Don't ask for 'Accessibility' or 'Device Control' permission on MacOS

### DIFF
--- a/src/common/platform/posix/cocoa/i_input.mm
+++ b/src/common/platform/posix/cocoa/i_input.mm
@@ -42,6 +42,7 @@
 EXTERN_CVAR(Int, m_use_mouse)
 
 CVAR(Bool, use_mouse,    true,  CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
+CVAR(Bool, allow_set_mouse_pos,    false,  CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
 CVAR(Bool, k_allowfullscreentoggle, true, CVAR_ARCHIVE | CVAR_GLOBALCONFIG)
 
@@ -79,6 +80,11 @@ void SetCursorPosition(const NSPoint position)
 {
 	NSWindow* window = [NSApp keyWindow];
 	if (nil == window)
+	{
+		return;
+	}
+
+	if (!allow_set_mouse_pos)
 	{
 		return;
 	}


### PR DESCRIPTION
this is a small change that disables the `SetCursorPosition` function unless the user has changed a cvar `allow_set_mouse_pos` to explicitly enable it.

Setting the cursor position isn't strictly needed afaik since the cursor position is locked during gameplay. This has the side-effect of meaning the mouse cursor re-appears where it was last seen before returning to gameplay, instead of the current behaviour of resetting to centre screen every time. This is the same behaviour observed if the permission is denied.

<img width="507" height="227" alt="Screenshot 2026-09-12 at 18 27 29" src="https://github.com/user-attachments/assets/b20a0a4a-d6d3-4e50-866e-a47ffb861c3c" />

## Checklist
- [X] I have reviewed [CONTRIBUTING.md](../blob/trunk/CONTRIBUTING.md) and agree to its terms.
